### PR TITLE
Разбираемся с минимальными и максимальными размерами изображений при …

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 // Минимальный и максимальный зум
-export const MIN_ZOOM = 0.05
-export const MAX_ZOOM = 4
-export const MAX_ZOOM_FACTOR = 4
+export const MIN_ZOOM = 0.1
+export const MAX_ZOOM = 2
+export const MAX_ZOOM_FACTOR = 2
 
 // Шаг для зума
 export const DEFAULT_ZOOM_RATIO = 0.1
@@ -10,7 +10,7 @@ export const DEFAULT_ZOOM_RATIO = 0.1
 export const ROTATE_RATIO = 90
 
 // Минимальные и максимальные размеры канваса
-export const CANVAS_MIN_WIDTH = 256
-export const CANVAS_MIN_HEIGHT = 256
+export const CANVAS_MIN_WIDTH = 16
+export const CANVAS_MIN_HEIGHT = 16
 export const CANVAS_MAX_WIDTH = 4096
 export const CANVAS_MAX_HEIGHT = 4096


### PR DESCRIPTION
…включенном скейлинге монтажной области при импорте картинок (scale-montage). Принято решение сделать минимальный размер 16х16px, и скейлить монтажную область для всех картинок которые больше 16х16px. Если картинка меньше 16х16px, то мы вписываем (растягиваем) её в монтажную область с минимальными размерами. Если картинка больше максимальных размеров, то мы уменьшаеми её до максимальных размеров используя отдельный канвас, и потом импортируем. Сделано так, потому что большие картинки могут серьёзно навредить производительности.