### PR TITLE
Делаем динамический импорт только для библиотеки jsPDF, потому что он…

### DIFF
--- a/src/editor/history-manager/index.js
+++ b/src/editor/history-manager/index.js
@@ -1,7 +1,5 @@
 // TODO: Почистить консоль логи когда всё будет готово.
-// TODO: Сделать динамческий импорт jsondiffpatch, чтобы не грузить его в основной бандл
 import { create as diffPatchCreate } from 'jsondiffpatch'
-
 export default class HistoryManager {
   /**
    * @param {object} options
@@ -16,6 +14,15 @@ export default class HistoryManager {
     this.currentIndex = 0
     this.maxHistoryLength = editor.options.maxHistoryLength
 
+    this._createDiffPatcher()
+  }
+
+  /** Проверка, нужно ли пропускать сохранение истории */
+  get skipHistory() {
+    return this._historySuspendCount > 0
+  }
+
+  _createDiffPatcher() {
     this.diffPatcher = diffPatchCreate({
       objectHash(obj) {
         return [
@@ -44,11 +51,6 @@ export default class HistoryManager {
         minLength: 60
       }
     })
-  }
-
-  /** Проверка, нужно ли пропускать сохранение истории */
-  get skipHistory() {
-    return this._historySuspendCount > 0
   }
 
   /** Увеличить счётчик приостановки истории */

--- a/src/editor/image-manager/index.js
+++ b/src/editor/image-manager/index.js
@@ -1,6 +1,5 @@
 import { loadSVGFromURL, FabricImage, util } from 'fabric'
 import { nanoid } from 'nanoid'
-import { jsPDF as JsPDF } from 'jspdf'
 import { calculateScaleFactor } from '../helpers'
 import {
   CANVAS_MAX_WIDTH,
@@ -262,6 +261,8 @@ export default class ImageManager {
       const pxToMm = 0.264583 // коэффициент перевода пикселей в миллиметры (при 96 DPI)
       const pdfWidth = width * pxToMm
       const pdfHeight = height * pxToMm
+
+      const JsPDF = (await this.editor.moduleLoader.loadModule('jspdf')).jsPDF
 
       const pdf = new JsPDF({
         orientation: pdfWidth > pdfHeight ? 'landscape' : 'portrait',

--- a/src/editor/module-loader/index.js
+++ b/src/editor/module-loader/index.js
@@ -1,10 +1,11 @@
 export default class ModuleLoader {
+  /**
+   * @description Класс для динамической загрузки внешних модулей.
+   */
   constructor() {
     this.cache = new Map()
     this.loaders = {
-      fabric: () => import('fabric'),
-      jspdf: () => import('jspdf'),
-      nanoid: () => import('nanoid')
+      jspdf: () => import('jspdf')
     }
   }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,8 +21,8 @@ export default defineConfig({
       // внешние зависимости – не бандлить их
       external: [
         'fabric',
-        'nanoid',
-        'jspdf'
+        'jspdf',
+        'jsondiffpatch'
       ],
 
       output: {


### PR DESCRIPTION
…а дофига весит и не всегда будет нужна. fabricjs, jsondiffpatcher, nanoid используются сразу при инициализации редактора, поэтому нет смысла импортировать их динамически.