### PR TITLE
В LayerManger правим баг, когда при поднятии на один уровень вверх ай…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "JavaScript image editor built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/src/editor/defaults.js
+++ b/src/editor/defaults.js
@@ -31,6 +31,9 @@ export default {
   editorContainerWidth: 'fit-content',
   editorContainerHeight: '100%',
 
+  // Максимальная длина истории действий
+  maxHistoryLength: 50,
+
   // Дефолтный тип скейлинга для объектов (cotain/cover)
   scaleType: 'contain',
 

--- a/src/editor/layer-manager/index.js
+++ b/src/editor/layer-manager/index.js
@@ -171,22 +171,39 @@ export default class LayerManager {
     const canvasObjects = canvas.getObjects()
     const selectedObjects = activeSelection.getObjects()
 
-    for (let i = selectedObjects.length - 1; i >= 0; i -= 1) {
-      const obj = selectedObjects[i]
-      const currentIndex = canvasObjects.indexOf(obj)
-      let nextIndex = currentIndex + 1
+    // Получаем индексы всех выделенных объектов
+    const selectedIndices = selectedObjects.map((obj) => canvasObjects.indexOf(obj))
 
-      // Ищем ближайший индекс сверху, не входящий в выделение
-      while (
-        nextIndex < canvasObjects.length
-      && selectedObjects.includes(canvasObjects[nextIndex])
-      ) {
-        nextIndex += 1
-      }
+    // Ищем ближайший объект выше ЛЮБОГО из выделенных (не только самого верхнего)
+    let targetObjectIndex = -1
 
-      if (nextIndex < canvasObjects.length) {
-        canvas.moveObjectTo(obj, nextIndex)
+    for (let i = 0; i < canvasObjects.length; i++) {
+      const obj = canvasObjects[i]
+
+      // Если объект не входит в выделение И находится выше хотя бы одного выделенного
+      if (!selectedObjects.includes(obj) && selectedIndices.some((selectedIdx) => i > selectedIdx)) {
+        targetObjectIndex = i
+        break
       }
+    }
+
+    // Если нашли объект для обмена местами
+    if (targetObjectIndex !== -1) {
+    // Сортируем выделенные объекты по их текущим индексам (сверху вниз)
+      const sortedSelected = selectedObjects
+        .map((obj) => ({ obj, index: canvasObjects.indexOf(obj) }))
+        .sort((a, b) => b.index - a.index)
+
+      // Перемещаем каждый выделенный объект на одну позицию выше найденного объекта
+      // Начинаем с самого верхнего, чтобы не нарушить порядок
+      sortedSelected.forEach((item) => {
+        const currentIndex = canvasObjects.indexOf(item.obj)
+        if (currentIndex < targetObjectIndex) {
+          canvas.moveObjectTo(item.obj, targetObjectIndex)
+          // Обновляем targetObjectIndex, так как объект сдвинулся
+          targetObjectIndex = currentIndex
+        }
+      })
     }
   }
 

--- a/src/editor/listeners.js
+++ b/src/editor/listeners.js
@@ -214,9 +214,6 @@ class Listeners {
 
     // Центрируем монтажную область
     this.editor.canvasManager.centerMontageArea()
-
-    // Сбрасываем все трансформации объектов
-    this.editor.transformManager.resetObjects()
   }
 
   /**

--- a/src/editor/object-lock-manager/index.js
+++ b/src/editor/object-lock-manager/index.js
@@ -15,7 +15,7 @@ export default class ObjectLockManager {
    * @returns
    * @fires editor:object-locked
    */
-  lockObject({ object, withoutSave } = {}) {
+  lockObject({ object, skipInnerObjects, withoutSave } = {}) {
     const { canvas, historyManager } = this.editor
 
     const activeObject = object || canvas.getActiveObject()
@@ -34,7 +34,9 @@ export default class ObjectLockManager {
 
     activeObject.set(lockOptions)
 
-    if (['activeselection', 'group'].includes(activeObject.type)) {
+    const shouldLockInnerObjects = !skipInnerObjects && ['activeselection', 'group'].includes(activeObject.type)
+
+    if (shouldLockInnerObjects) {
       activeObject.getObjects().forEach((obj) => {
         obj.set(lockOptions)
       })

--- a/src/editor/selection-manager/index.js
+++ b/src/editor/selection-manager/index.js
@@ -27,7 +27,7 @@ export default class SelectionManager {
 
     // Если есть заблокированные объекты, то блокируем выделенный объект
     if (hasLockedObjects) {
-      objectLockManager.lockObject({ object, withoutSave: true })
+      objectLockManager.lockObject({ object, skipInnerObjects: true, withoutSave: true })
     }
 
     canvas.setActiveObject(object)


### PR DESCRIPTION
…темы массового выделения перемешивались, и в некоторых случаях поднимались на уровень выше не так как ожидалось. В ObjectLockManager добавлена возможность при блокировке указать флаг skipInnerObjects на тот случай, когда передано массовое выделение объектов и не нужно блокировать все те объекты которые находятся внутри. В defaults не забываем передавать дефолтное значение максимального количества хранимых в истории изменений. Обновляем версию.