### PR TITLE
Listeners. Добавляем метод shouldIgnoreKeyboardEvent который проверяе…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "JavaScript image editor built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/src/editor/defaults.ts
+++ b/src/editor/defaults.ts
@@ -88,5 +88,6 @@ export const defaults: Partial<CanvasOptions> = {
   undoRedoByHotKeys: true,
   selectAllByHotkey: true,
   deleteObjectsByHotkey: true,
-  resetObjectFitByDoubleClick: true
+  resetObjectFitByDoubleClick: true,
+  keyboardIgnoreSelectors: []
 }

--- a/src/editor/types/fabric-extensions.d.ts
+++ b/src/editor/types/fabric-extensions.d.ts
@@ -214,6 +214,11 @@ declare module 'fabric' {
      * Используется для стилизации контейнера редактора.
      */
     containerClass?: string
+
+    /**
+     * Селекторы элементов, для которых нужно игнорировать события клавиатуры
+     */
+    keyboardIgnoreSelectors: string[]
   }
 
   interface FabricObject {


### PR DESCRIPTION
Listeners. Добавляем метод shouldIgnoreKeyboardEvent который проверяет должен ли отработать обработчик события клавиатуры основываясь на event.target. Нужно для того чтобы игнорировать события полей ввода. Также, в настройки редактора добавлена возможность передачи keyboardIgnoreSelectors который содержит массив строк с селекторами для которых должны игнорироваться события клавиатуры из редактора. Может пригодиться, так как все слушатели используют capture: true и они срабатывают на стадии захвата.