### PR TITLE
HistoryManager. Даём возможность пробрасывать customData в объекты ре…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "description": "JavaScript image editor built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -6,7 +6,7 @@ import ModuleLoader from './module-loader'
 import WorkerManager from './worker-manager'
 import CustomizedControls from './customized-controls'
 import ToolbarManager from './ui/toolbar-manager'
-import HistoryManager from './history-manager'
+import HistoryManager, { CanvasFullState } from './history-manager'
 import ImageManager from './image-manager'
 import CanvasManager from './canvas-manager'
 import TransformManager from './transform-manager'
@@ -234,7 +234,7 @@ export class ImageEditor {
     }
 
     if (initialStateJSON) {
-      this.historyManager.loadStateFromFullState(initialStateJSON)
+      this.historyManager.loadStateFromFullState(initialStateJSON as CanvasFullState)
     }
 
     this.historyManager.saveState()

--- a/src/editor/types/fabric-extensions.d.ts
+++ b/src/editor/types/fabric-extensions.d.ts
@@ -240,6 +240,16 @@ declare module 'fabric' {
      * Идентификатор фона
      */
     backgroundId?: string | null;
+
+    /**
+     * Произвольные пользовательские данные, связанные с объектом.
+     */
+    customData?: object;
+
+    /**
+     * Сериализованные пользовательские данные в виде строки JSON.
+     */
+    _serializedCustomData?: string;
   }
 
   interface RectProps {


### PR DESCRIPTION
…дактора и храним эти данные при работе с историей изменений. Добавляем сохранение customData для BackgroundManager. При сохранении дифов в историю изменений сериализуем customData в строку, чтобы эти даныне не афектили состояние редактора, если названия свойств совпадают с зарезервированными для fabricjs.