### PR TITLE
ShapeManager & TextManager. Правим баги при копировании и вставке объектов в режиме редактирования текста + тесты

### DIFF
--- a/e2e/fixtures/editor.fixture.ts
+++ b/e2e/fixtures/editor.fixture.ts
@@ -12,6 +12,7 @@ import { SnappingModel } from '../models/snapping.model'
 import { BackgroundModel } from '../models/background.model'
 import { InteractionBlockerModel } from '../models/interaction-blocker.model'
 import { ImageModel } from '../models/image.model'
+import { ToolbarModel } from '../models/toolbar.model'
 import { bypassCertificateWarning } from '../helpers/certificate.helper'
 import { injectEditorBrowserHelpers } from '../helpers/editor-browser-helpers.helper'
 import { resolveHeadedBrowserHoldMs } from '../helpers/headed-browser-hold.helper'
@@ -32,6 +33,7 @@ interface EditorFixtures {
   background: BackgroundModel
   interactionBlocker: InteractionBlockerModel
   images: ImageModel
+  toolbar: ToolbarModel
 }
 
 interface EditorInternalFixtures {
@@ -52,7 +54,10 @@ export const test = base.extend<EditorFixtures & EditorInternalFixtures>({
     const model = new EditorModel(page)
 
     await page.addInitScript(({ fonts }) => {
-      window.__EDITOR_DEMO_INIT_OPTIONS = { fonts }
+      window.__EDITOR_DEMO_INIT_OPTIONS = {
+        fonts,
+        showToolbar: true
+      }
     }, {
       fonts: E2E_EDITOR_FONTS
     })
@@ -129,6 +134,10 @@ export const test = base.extend<EditorFixtures & EditorInternalFixtures>({
 
   images: async({ editorModel }, use) => {
     await use(editorModel.images)
+  },
+
+  toolbar: async({ editorModel }, use) => {
+    await use(editorModel.toolbar)
   }
 })
 

--- a/e2e/models/editor.model.ts
+++ b/e2e/models/editor.model.ts
@@ -6,6 +6,7 @@ import type {
   MontageAreaInfo,
   MontageAreaBoundsInfo,
   MontageAreaViewportBoundsInfo,
+  ViewportBoundsInfo,
   ObjectTargetParams,
   SnappingObjectSnapshot
 } from '../types'
@@ -20,6 +21,7 @@ import { SnappingModel } from './snapping.model'
 import { BackgroundModel } from './background.model'
 import { InteractionBlockerModel } from './interaction-blocker.model'
 import { ImageModel } from './image.model'
+import { ToolbarModel } from './toolbar.model'
 
 export class EditorModel {
   readonly shapes: ShapeModel
@@ -42,6 +44,8 @@ export class EditorModel {
 
   readonly images: ImageModel
 
+  readonly toolbar: ToolbarModel
+
   constructor(readonly page: Page) {
     this.shapes = new ShapeModel(page)
     this.canvas = new CanvasModel(page)
@@ -53,6 +57,7 @@ export class EditorModel {
     this.background = new BackgroundModel(page)
     this.interactionBlocker = new InteractionBlockerModel(page)
     this.images = new ImageModel(page)
+    this.toolbar = new ToolbarModel(page)
   }
 
   /** Ожидает финальное состояние редактора после завершения init(), а не раннее появление window.editor. */
@@ -128,6 +133,49 @@ export class EditorModel {
     expect(snapshot, 'должен существовать snapshot объекта').not.toBeNull()
 
     return snapshot as SnappingObjectSnapshot
+  }
+
+  /** Возвращает viewport-границы объекта canvas в системе координат canvas. */
+  async getObjectViewportBounds(params: ObjectTargetParams = {}): Promise<ViewportBoundsInfo> {
+    const bounds = await this.page.evaluate(({ objectIndex, id }) => {
+      const {
+        __editorHelpers: helpers
+      } = window as any
+
+      const target = helpers.resolveCanvasObject(objectIndex, id)
+      if (!target) return null
+
+      target.setCoords()
+
+      const tl = target.oCoords?.tl
+      const tr = target.oCoords?.tr
+      const br = target.oCoords?.br
+      const bl = target.oCoords?.bl
+
+      if (!tl || !tr || !br || !bl) return null
+
+      const left = Math.min(tl.x, tr.x, br.x, bl.x)
+      const top = Math.min(tl.y, tr.y, br.y, bl.y)
+      const right = Math.max(tl.x, tr.x, br.x, bl.x)
+      const bottom = Math.max(tl.y, tr.y, br.y, bl.y)
+      const width = right - left
+      const height = bottom - top
+
+      return {
+        left,
+        top,
+        width,
+        height,
+        right,
+        bottom,
+        centerX: left + (width / 2),
+        centerY: top + (height / 2)
+      }
+    }, params)
+
+    expect(bounds, 'для объекта должны существовать viewport-границы').not.toBeNull()
+
+    return bounds as ViewportBoundsInfo
   }
 
   /** Проверяет что количество пользовательских объектов на canvas равно ожидаемому */

--- a/e2e/models/shape.model.ts
+++ b/e2e/models/shape.model.ts
@@ -1490,8 +1490,43 @@ export class ShapeModel {
   }
 
   /** Кликает по фигуре на canvas через реальные координаты viewport. */
-  async clickOnCanvas(params: ObjectTargetParams = {}): Promise<void> {
-    const point = await this._resolveTargetCenterPoint(params)
+  async clickOnCanvas(
+    params: ({
+      point?: 'center' | 'bottom-right'
+    } & ObjectTargetParams) = {}
+  ): Promise<void> {
+    const {
+      point: pointType = 'center',
+      ...targetParams
+    } = params
+
+    const point = pointType === 'bottom-right'
+      ? await this.page.evaluate(({ objectIndex, id }) => {
+        const {
+          editor,
+          __editorHelpers: helpers
+        } = window as any
+
+        const target = helpers.resolveCanvasObject(objectIndex, id)
+        if (!target) return null
+
+        target.setCoords()
+
+        const corner = target.oCoords?.br
+        if (!corner || typeof corner.x !== 'number' || typeof corner.y !== 'number') {
+          return null
+        }
+
+        const canvasRect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+
+        return {
+          x: canvasRect.left + corner.x - 12,
+          y: canvasRect.top + corner.y - 12
+        }
+      }, targetParams)
+      : await this._resolveTargetCenterPoint(targetParams)
+
+    expect(point, 'для клика по фигуре должны существовать координаты на canvas').not.toBeNull()
 
     await this.page.mouse.click(point.x, point.y)
     await waitForCanvasRender({ page: this.page })

--- a/e2e/models/text.model.ts
+++ b/e2e/models/text.model.ts
@@ -57,6 +57,47 @@ export class TextModel {
     this.activeScaleInteraction = null
   }
 
+  /** Возвращает viewport-координаты центра текста для реальных mouse-событий. */
+  private async _resolveTargetCenterPoint(params: ObjectTargetParams = {}): Promise<{ x: number, y: number }> {
+    const point = await this.page.evaluate(({ objectIndex, id }) => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+
+      const target = helpers.resolveCanvasObject(objectIndex, id)
+      if (!target) return null
+
+      target.setCoords()
+
+      const centerPoint = target.getCenterPoint()
+      const sceneCenterX = typeof centerPoint.x === 'number' ? centerPoint.x : 0
+      const sceneCenterY = typeof centerPoint.y === 'number' ? centerPoint.y : 0
+      const viewportTransform = Array.isArray(editor.canvas.viewportTransform)
+        ? editor.canvas.viewportTransform
+        : [1, 0, 0, 1, 0, 0]
+      const viewportX = (viewportTransform[0] * sceneCenterX)
+        + (viewportTransform[2] * sceneCenterY)
+        + viewportTransform[4]
+      const viewportY = (viewportTransform[1] * sceneCenterX)
+        + (viewportTransform[3] * sceneCenterY)
+        + viewportTransform[5]
+      const canvasRect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+
+      return {
+        x: canvasRect.left + viewportX,
+        y: canvasRect.top + viewportY
+      }
+    }, params)
+
+    expect(point, 'для взаимодействия с текстом должны существовать координаты на canvas').not.toBeNull()
+
+    return point as {
+      x: number
+      y: number
+    }
+  }
+
   /** Добавляет текстовый объект на canvas. */
   async add(params: TextAddParams = {}): Promise<TextObjectInfo | null> {
     const textObject = await this.page.evaluate((payload) => {
@@ -205,6 +246,59 @@ export class TextModel {
       : params
 
     return this.getObject(settledParams)
+  }
+
+  /** Кликает по текстовому объекту на canvas через реальные координаты viewport. */
+  async clickOnCanvas(
+    params: ({
+      point?: 'center' | 'bottom-right'
+    } & ObjectTargetParams) = {}
+  ): Promise<void> {
+    const {
+      point: pointType = 'center',
+      ...targetParams
+    } = params
+
+    const point = pointType === 'bottom-right'
+      ? await this.page.evaluate(({ objectIndex, id }) => {
+        const {
+          editor,
+          __editorHelpers: helpers
+        } = window as any
+
+        const target = helpers.resolveCanvasObject(objectIndex, id)
+        if (!target) return null
+
+        target.setCoords()
+
+        const corner = target.oCoords?.br
+        if (!corner || typeof corner.x !== 'number' || typeof corner.y !== 'number') {
+          return null
+        }
+
+        const canvasRect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+
+        return {
+          x: canvasRect.left + corner.x - 12,
+          y: canvasRect.top + corner.y - 12
+        }
+      }, targetParams)
+      : await this._resolveTargetCenterPoint(targetParams)
+
+    expect(point, 'для клика по тексту должны существовать координаты на canvas').not.toBeNull()
+
+    await this.page.mouse.click(point.x, point.y)
+    await waitForCanvasRender({ page: this.page })
+  }
+
+  /** Открывает редактирование текста через реальный двойной клик по canvas. */
+  async openTextEditingFromCanvas(params: ObjectTargetParams = {}): Promise<TextObjectInfo | null> {
+    const point = await this._resolveTargetCenterPoint(params)
+
+    await this.page.mouse.dblclick(point.x, point.y)
+    await waitForCanvasRender({ page: this.page })
+
+    return this.getObject(params)
   }
 
   /** Обновляет стиль текстового объекта через публичный API TextManager. */

--- a/e2e/models/toolbar.model.ts
+++ b/e2e/models/toolbar.model.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { type Page, expect } from '@playwright/test'
+import type { ViewportBoundsInfo } from '../types'
+import { waitForCanvasRender } from '../helpers/canvas-render.helper'
+
+export class ToolbarModel {
+  private readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /** Ожидает пока тулбар редактора станет видимым. */
+  async waitUntilVisible(): Promise<void> {
+    await this.page.waitForFunction(() => {
+      const copyPasteIcon = document.querySelector('img[title="Создать копию"]')
+      if (!(copyPasteIcon instanceof HTMLImageElement)) return false
+
+      const toolbar = copyPasteIcon.closest('div')
+      if (!(toolbar instanceof HTMLDivElement)) return false
+
+      const toolbarStyle = window.getComputedStyle(toolbar)
+      const bounds = toolbar.getBoundingClientRect()
+
+      return toolbarStyle.display !== 'none'
+        && toolbarStyle.visibility !== 'hidden'
+        && bounds.width > 0
+        && bounds.height > 0
+    })
+  }
+
+  /** Возвращает границы тулбара в viewport-координатах canvas. */
+  async getBounds(): Promise<ViewportBoundsInfo> {
+    await this.waitUntilVisible()
+
+    const bounds = await this.page.evaluate(() => {
+      const { editor } = window as any
+      const copyPasteIcon = document.querySelector('img[title="Создать копию"]')
+      if (!(copyPasteIcon instanceof HTMLImageElement)) return null
+
+      const toolbar = copyPasteIcon.closest('div')
+      if (!(toolbar instanceof HTMLDivElement)) return null
+
+      const toolbarRect = toolbar.getBoundingClientRect()
+      const canvasRect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+      const {
+        width,
+        height
+      } = toolbarRect
+      const left = toolbarRect.left - canvasRect.left
+      const top = toolbarRect.top - canvasRect.top
+
+      return {
+        left,
+        top,
+        width,
+        height,
+        right: left + width,
+        bottom: top + height,
+        centerX: left + (width / 2),
+        centerY: top + (height / 2)
+      }
+    })
+
+    expect(bounds, 'для видимого тулбара должны существовать viewport-границы').not.toBeNull()
+
+    return bounds as ViewportBoundsInfo
+  }
+
+  /** Нажимает кнопку тулбара по пользовательскому названию действия. */
+  async clickAction(params: { name: string }): Promise<void> {
+    const { name } = params
+    const actionIcon = this.page.getByTitle(name)
+
+    await expect(actionIcon, `кнопка "${name}" должна существовать в тулбаре`).toBeVisible()
+
+    await actionIcon.click()
+    await waitForCanvasRender({ page: this.page })
+  }
+}

--- a/e2e/tests/shape-manager/shape-editing.spec.ts
+++ b/e2e/tests/shape-manager/shape-editing.spec.ts
@@ -515,6 +515,176 @@ test.describe('Текст внутри фигуры', () => {
   })
 })
 
+test.describe('Тулбар во время редактирования текста внутри фигуры', () => {
+  test('в режиме редактирования текста внутри фигуры при смене вертикального выравнивания тулбар остаётся под всей фигурой', async({
+    editorModel,
+    shapes,
+    toolbar
+  }) => {
+    const shape = await test.step('Добавить фигуру с запасом места по высоте для вертикального выравнивания', async() => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          width: 220,
+          height: 260,
+          text: 'TEST'
+        }
+      })
+    })
+
+    expect(shape).not.toBeNull()
+    expect(typeof shape?.id).toBe('string')
+
+    const shapeId = shape!.id as string
+    const toolbarGapTolerance = 4
+
+    await test.step('Открыть редактирование текста через реальный двойной клик', async() => {
+      const textNode = await shapes.openTextEditingFromCanvas({ id: shapeId })
+
+      expect(textNode?.isEditing).toBe(true)
+      await toolbar.waitUntilVisible()
+    })
+
+    const topState = await test.step('Переключить выравнивание к верхнему краю и зафиксировать состояние', async() => {
+      await shapes.setTextAlign({
+        id: shapeId,
+        vertical: 'top'
+      })
+
+      return {
+        snapshot: await shapes.getScaleSnapshot({ id: shapeId }),
+        shapeBounds: await editorModel.getObjectViewportBounds({ id: shapeId }),
+        toolbarBounds: await toolbar.getBounds()
+      }
+    })
+
+    const middleState = await test.step('Переключить выравнивание к середине и зафиксировать состояние', async() => {
+      await shapes.setTextAlign({
+        id: shapeId,
+        vertical: 'middle'
+      })
+
+      return {
+        snapshot: await shapes.getScaleSnapshot({ id: shapeId }),
+        shapeBounds: await editorModel.getObjectViewportBounds({ id: shapeId }),
+        toolbarBounds: await toolbar.getBounds()
+      }
+    })
+
+    const bottomState = await test.step('Переключить выравнивание к нижнему краю и зафиксировать состояние', async() => {
+      await shapes.setTextAlign({
+        id: shapeId,
+        vertical: 'bottom'
+      })
+
+      return {
+        snapshot: await shapes.getScaleSnapshot({ id: shapeId }),
+        shapeBounds: await editorModel.getObjectViewportBounds({ id: shapeId }),
+        toolbarBounds: await toolbar.getBounds()
+      }
+    })
+
+    await test.step('Проверить что текст сместился внутри фигуры, а тулбар остался под всей фигурой', () => {
+      expect(
+        topState.snapshot.textBoundsTop,
+        'верхняя граница текста должна существовать при выравнивании по верхнему краю'
+      ).not.toBeNull()
+      expect(
+        middleState.snapshot.textBoundsTop,
+        'верхняя граница текста должна существовать при выравнивании по середине'
+      ).not.toBeNull()
+      expect(
+        bottomState.snapshot.textBoundsTop,
+        'верхняя граница текста должна существовать при выравнивании по нижнему краю'
+      ).not.toBeNull()
+
+      const topTextTop = topState.snapshot.textBoundsTop as number
+      const middleTextTop = middleState.snapshot.textBoundsTop as number
+      const bottomTextTop = bottomState.snapshot.textBoundsTop as number
+      const topToolbarGap = topState.toolbarBounds.top - topState.shapeBounds.bottom
+      const middleToolbarGap = middleState.toolbarBounds.top - middleState.shapeBounds.bottom
+      const bottomToolbarGap = bottomState.toolbarBounds.top - bottomState.shapeBounds.bottom
+
+      expect(Math.abs(bottomTextTop - topTextTop)).toBeGreaterThan(20)
+      expect(Math.abs(middleTextTop - topTextTop)).toBeGreaterThan(8)
+      expect(topToolbarGap).toBeGreaterThan(10)
+      expect(middleToolbarGap).toBeGreaterThan(10)
+      expect(bottomToolbarGap).toBeGreaterThan(10)
+      expect(Math.abs(middleToolbarGap - topToolbarGap)).toBeLessThanOrEqual(toolbarGapTolerance)
+      expect(Math.abs(bottomToolbarGap - topToolbarGap)).toBeLessThanOrEqual(toolbarGapTolerance)
+    })
+  })
+
+  test('в режиме редактирования текста внутри фигуры кнопка "Создать копию" создаёт рабочую копию фигуры', async({
+    canvas,
+    editorModel,
+    shapes,
+    toolbar
+  }) => {
+    const shape = await test.step('Добавить фигуру с текстом', async() => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          text: 'TEST'
+        }
+      })
+    })
+
+    expect(shape).not.toBeNull()
+    expect(typeof shape?.id).toBe('string')
+
+    const sourceShapeId = shape!.id as string
+
+    await test.step('Открыть редактирование текста через реальный двойной клик', async() => {
+      const textNode = await shapes.openTextEditingFromCanvas({ id: sourceShapeId })
+
+      expect(textNode?.isEditing).toBe(true)
+      await toolbar.waitUntilVisible()
+    })
+
+    await test.step('Нажать кнопку "Создать копию" в тулбаре', async() => {
+      await toolbar.clickAction({
+        name: 'Создать копию'
+      })
+
+      await editorModel.checkObjectCount({ count: 2 })
+    })
+
+    const copiedShapeId = await test.step('Найти id созданной копии', async() => {
+      const shapeObjects = await shapes.getShapeObjects()
+      const copiedShape = shapeObjects.find((item) => item.id !== sourceShapeId)
+
+      expect(copiedShape).toBeDefined()
+      expect(typeof copiedShape?.id).toBe('string')
+
+      return copiedShape!.id as string
+    })
+
+    await test.step('Сбросить текущее выделение реальным кликом по монтажной области', async() => {
+      await canvas.clickTopLeftInsideMontageArea()
+
+      const activeObject = await editorModel.getActiveObject()
+
+      expect(activeObject).toBeNull()
+    })
+
+    await test.step('Реальным кликом выбрать копию и удалить её как рабочую фигуру', async() => {
+      await shapes.clickOnCanvas({
+        id: copiedShapeId,
+        point: 'bottom-right'
+      })
+
+      const activeObject = await editorModel.getActiveObject()
+
+      expect(activeObject?.id).toBe(copiedShapeId)
+      expect(activeObject?.type).toBe('shape-group')
+
+      await editorModel.deleteSelectedObject()
+      await editorModel.checkObjectCount({ count: 1 })
+    })
+  })
+})
+
 test.describe('Клики мышью в режиме редактирования текста внутри фигуры', () => {
   test.beforeEach(async({ shapes }) => {
     const primaryShape = await shapes.add({

--- a/e2e/tests/text-manager/text-editing.spec.ts
+++ b/e2e/tests/text-manager/text-editing.spec.ts
@@ -619,3 +619,73 @@ test.describe('Позиционирование текста после скей
     })
   })
 })
+
+test.describe('Тулбар во время редактирования текста', () => {
+  test('в режиме редактирования текста кнопка "Создать копию" создаёт рабочую копию текстового объекта', async({
+    canvas,
+    editorModel,
+    text,
+    toolbar
+  }) => {
+    const textObject = await test.step('Добавить отдельный текстовый объект', async() => {
+      return text.add({
+        text: 'Новый текст'
+      })
+    })
+
+    expect(textObject).not.toBeNull()
+    expect(typeof textObject?.id).toBe('string')
+
+    const sourceTextId = textObject!.id as string
+
+    await test.step('Открыть редактирование текста через реальный двойной клик', async() => {
+      const editingText = await text.openTextEditingFromCanvas({ id: sourceTextId })
+
+      expect(editingText?.isEditing).toBe(true)
+      await toolbar.waitUntilVisible()
+    })
+
+    await test.step('Нажать кнопку "Создать копию" в тулбаре', async() => {
+      await toolbar.clickAction({
+        name: 'Создать копию'
+      })
+
+      await editorModel.checkObjectCount({ count: 2 })
+    })
+
+    const copiedTextId = await test.step('Найти id созданной копии', async() => {
+      const objects = await editorModel.getObjects()
+      const copiedText = objects.find((item) => {
+        return item.type === 'background-textbox' && item.id !== sourceTextId
+      })
+
+      expect(copiedText).toBeDefined()
+      expect(typeof copiedText?.id).toBe('string')
+
+      return copiedText!.id as string
+    })
+
+    await test.step('Сбросить текущее выделение реальным кликом по монтажной области', async() => {
+      await canvas.clickTopLeftInsideMontageArea()
+
+      const activeObject = await editorModel.getActiveObject()
+
+      expect(activeObject).toBeNull()
+    })
+
+    await test.step('Реальным кликом выбрать копию и удалить её как рабочий текстовый объект', async() => {
+      await text.clickOnCanvas({
+        id: copiedTextId,
+        point: 'bottom-right'
+      })
+
+      const activeObject = await editorModel.getActiveObject()
+
+      expect(activeObject?.id).toBe(copiedTextId)
+      expect(activeObject?.type).toBe('background-textbox')
+
+      await editorModel.deleteSelectedObject()
+      await editorModel.checkObjectCount({ count: 1 })
+    })
+  })
+})

--- a/e2e/types/editor.types.ts
+++ b/e2e/types/editor.types.ts
@@ -36,6 +36,18 @@ export interface MontageAreaInfo {
   top: number
 }
 
+/** Базовые границы элемента в viewport-координатах canvas. */
+export interface ViewportBoundsInfo {
+  left: number
+  top: number
+  width: number
+  height: number
+  right: number
+  bottom: number
+  centerX: number
+  centerY: number
+}
+
 /** Границы montage area в координатах canvas-сцены. */
 export interface MontageAreaBoundsInfo {
   left: number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.7.15",
+      "version": "0.7.16",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/shape-manager/shape-runtime.spec.ts
+++ b/specs/src/editor/shape-manager/shape-runtime.spec.ts
@@ -30,6 +30,59 @@ describe('shape-runtime', () => {
     expect(group.subTargetCheck).toBe(true)
   })
 
+  it('после materialization возвращает обычную фигуру в базовый интерактивный режим', () => {
+    const shape = createMockShapeNode()
+    const text = createMockShapeTextbox()
+    const group = createMockShapeGroup({ shape, text }) as Group & {
+      interactive?: boolean
+      hoverCursor?: string
+      moveCursor?: string
+    }
+
+    group.selectable = false
+    group.evented = false
+    group.lockMovementX = true
+    group.lockMovementY = true
+    group.hoverCursor = 'text'
+    group.moveCursor = 'text'
+
+    applyShapeGroupInteractivity({ group })
+
+    expect(group.selectable).toBe(true)
+    expect(group.evented).toBe(true)
+    expect(group.lockMovementX).toBe(false)
+    expect(group.lockMovementY).toBe(false)
+    expect(group.hoverCursor).toBeUndefined()
+    expect(group.moveCursor).toBeUndefined()
+  })
+
+  it('после materialization возвращает заблокированную фигуру в базовый заблокированный режим', () => {
+    const shape = createMockShapeNode()
+    const text = createMockShapeTextbox()
+    const group = createMockShapeGroup({ shape, text }) as Group & {
+      interactive?: boolean
+      hoverCursor?: string
+      moveCursor?: string
+    }
+
+    group.locked = true
+    group.selectable = false
+    group.evented = false
+    group.lockMovementX = false
+    group.lockMovementY = false
+    group.hoverCursor = 'text'
+    group.moveCursor = 'text'
+
+    applyShapeGroupInteractivity({ group })
+
+    expect(group.selectable).toBe(true)
+    expect(group.evented).toBe(true)
+    expect(group.lockMovementX).toBe(true)
+    expect(group.lockMovementY).toBe(true)
+    expect(group.hoverCursor).toBeUndefined()
+    expect(group.moveCursor).toBeUndefined()
+  })
+
   it('prepareShapeTextNode для незаблокированного textbox переводит его в базовый неинтерактивный режим', () => {
     const text = createMockShapeTextbox({ text: 'hello' })
 

--- a/specs/src/editor/text-manager/index.spec.ts
+++ b/specs/src/editor/text-manager/index.spec.ts
@@ -1568,6 +1568,61 @@ describe('TextManager', () => {
         expect(textbox.styles?.[1]?.[0]?.fontSize).toBe(initialStyleFontSize)
       })
 
+      it('если размер уже итоговый, возвращает обычный текст в базовый интерактивный режим', () => {
+        const { textManager } = createTextManagerTestSetup()
+        const textbox = createRestoredTemplateLikeTextbox({
+          left: 281,
+          top: 352,
+          scaleX: 1,
+          scaleY: 1
+        })
+
+        textbox.selectable = false
+        textbox.evented = false
+        textbox.editable = false
+        textbox.lockMovementX = true
+        textbox.lockMovementY = true
+
+        const result = textManager.commitStandaloneTextScale({
+          target: textbox
+        })
+
+        expect(result).toBe(false)
+        expect(textbox.selectable).toBe(true)
+        expect(textbox.evented).toBe(true)
+        expect(textbox.editable).toBe(true)
+        expect(textbox.lockMovementX).toBe(false)
+        expect(textbox.lockMovementY).toBe(false)
+      })
+
+      it('если размер уже итоговый, возвращает заблокированный текст в базовый заблокированный режим', () => {
+        const { textManager } = createTextManagerTestSetup()
+        const textbox = createRestoredTemplateLikeTextbox({
+          left: 281,
+          top: 352,
+          scaleX: 1,
+          scaleY: 1
+        })
+
+        textbox.locked = true
+        textbox.selectable = false
+        textbox.evented = false
+        textbox.editable = true
+        textbox.lockMovementX = false
+        textbox.lockMovementY = false
+
+        const result = textManager.commitStandaloneTextScale({
+          target: textbox
+        })
+
+        expect(result).toBe(false)
+        expect(textbox.selectable).toBe(true)
+        expect(textbox.evented).toBe(true)
+        expect(textbox.editable).toBe(false)
+        expect(textbox.lockMovementX).toBe(true)
+        expect(textbox.lockMovementY).toBe(true)
+      })
+
       it('текст внутри фигуры не пересчитывается отдельно от фигуры', () => {
         const { textManager } = createTextManagerTestSetup()
         const textbox = createMockShapeTextbox({
@@ -1590,6 +1645,32 @@ describe('TextManager', () => {
         expect(result).toBe(false)
         expect(textbox.scaleX).toBe(1.4)
         expect(textbox.scaleY).toBe(0.8)
+      })
+
+      it('текст внутри фигуры не получает standalone-интерактивность после materialization', () => {
+        const { textManager } = createTextManagerTestSetup()
+        const textbox = createMockShapeTextbox({
+          text: 'Text inside shape',
+          width: 180
+        })
+
+        textbox.group = {
+          shapeComposite: true
+        } as never
+        textbox.selectable = false
+        textbox.evented = false
+        textbox.lockMovementX = true
+        textbox.lockMovementY = true
+
+        const result = textManager.commitStandaloneTextScale({
+          target: textbox
+        })
+
+        expect(result).toBe(false)
+        expect(textbox.selectable).toBe(false)
+        expect(textbox.evented).toBe(false)
+        expect(textbox.lockMovementX).toBe(true)
+        expect(textbox.lockMovementY).toBe(true)
       })
 
       it('вертикальный scale не выключает autoExpand', () => {

--- a/specs/src/editor/ui/toolbar-manager/index.spec.ts
+++ b/specs/src/editor/ui/toolbar-manager/index.spec.ts
@@ -1,0 +1,78 @@
+import ToolbarManager from '../../../../../src/editor/ui/toolbar-manager'
+import { resolveShapeGroupFromTarget } from '../../../../../src/editor/shape-manager/shape-utils'
+import { createManagerTestMocks } from '../../../../test-utils/editor-helpers'
+import {
+  createMockShapeGroup,
+  createMockShapeNode,
+  createMockShapeTextbox
+} from '../../../../test-utils/shape-helpers'
+
+jest.mock('../../../../../src/editor/shape-manager/shape-utils', () => ({
+  resolveShapeGroupFromTarget: jest.fn()
+}))
+
+const resolveShapeGroupFromTargetMock = resolveShapeGroupFromTarget as jest.Mock
+
+describe('ToolbarManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('во время редактирования текста внутри фигуры позиционирует тулбар и выполняет действия по всей фигуре', () => {
+    const {
+      mockCanvas,
+      mockEditor
+    } = createManagerTestMocks()
+    const actionHandler = jest.fn()
+    const shape = createMockShapeNode()
+    const text = createMockShapeTextbox({
+      text: 'Текст внутри фигуры'
+    })
+    const group = createMockShapeGroup({
+      shape,
+      text
+    })
+
+    mockEditor.options.showToolbar = true
+    mockEditor.options.toolbar = {
+      actions: [{
+        name: 'Проверить target',
+        handle: 'inspectTarget'
+      }],
+      handlers: {
+        inspectTarget: actionHandler
+      }
+    }
+
+    group.getBoundingRect = jest.fn(() => ({
+      left: 40,
+      top: 20,
+      width: 180,
+      height: 180
+    })) as never
+    group.getCenterPoint = jest.fn(() => ({
+      x: 130,
+      y: 110
+    })) as never
+
+    mockCanvas.getActiveObject.mockReturnValue(text)
+    resolveShapeGroupFromTargetMock.mockReturnValue(group)
+
+    const toolbarManager = new ToolbarManager({
+      editor: mockEditor
+    })
+    const toolbarManagerWithUpdate = toolbarManager as ToolbarManager & {
+      _updateToolbar: () => void
+    }
+
+    toolbarManagerWithUpdate._updateToolbar()
+
+    const button = toolbarManager.el.querySelector('button') as HTMLButtonElement
+    button.click()
+
+    expect(toolbarManager.currentTarget).toBe(group)
+    expect(group.setCoords).toHaveBeenCalled()
+    expect(text.setCoords).not.toHaveBeenCalled()
+    expect(actionHandler).toHaveBeenCalledWith(mockEditor, group)
+  })
+})

--- a/src/editor/clipboard-manager/index.ts
+++ b/src/editor/clipboard-manager/index.ts
@@ -57,6 +57,9 @@ export default class ClipboardManager {
 
     try {
       const clonedObject = await activeObject.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
+      this._rehydrateStandaloneTextOnClone({
+        clonedObject
+      })
       this.clipboard = clonedObject
       canvas.fire('editor:object-copied', { object: clonedObject })
     } catch (error) {
@@ -199,9 +202,9 @@ export default class ClipboardManager {
   }
 
   /**
-   * Нормализует текстовые объекты внутри clone перед добавлением на canvas.
+   * Материализует standalone-text в clone до добавления на canvas и в internal clipboard.
    */
-  private _commitStandaloneTextScaleOnClone({ clonedObject }: { clonedObject: FabricObject }): void {
+  private _rehydrateStandaloneTextOnClone({ clonedObject }: { clonedObject: FabricObject }): void {
     const { textManager } = this.editor
     if (!textManager) return
 
@@ -346,7 +349,7 @@ export default class ClipboardManager {
         evented: true
       })
 
-      this._commitStandaloneTextScaleOnClone({
+      this._rehydrateStandaloneTextOnClone({
         clonedObject
       })
 
@@ -476,7 +479,7 @@ export default class ClipboardManager {
         evented: true
       })
 
-      this._commitStandaloneTextScaleOnClone({
+      this._rehydrateStandaloneTextOnClone({
         clonedObject: clonedObj
       })
 

--- a/src/editor/shape-manager/shape-runtime.ts
+++ b/src/editor/shape-manager/shape-runtime.ts
@@ -9,9 +9,11 @@ import type {
 } from './types'
 
 /**
- * Включает интерактивность группы и поддержку sub-target кликов.
+ * Возвращает shape-группу в базовый интерактивный режим и включает sub-target клики.
+ * Временное editing-состояние не должно переживать clone/deserialize/materialization.
  */
 export const applyShapeGroupInteractivity = ({ group }: { group: ShapeGroupLike }): void => {
+  const isLocked = Boolean(group.locked)
   const groupWithInteractive = group as Group & {
     interactive?: boolean
     setInteractive?: (value: boolean) => void
@@ -22,8 +24,14 @@ export const applyShapeGroupInteractivity = ({ group }: { group: ShapeGroupLike 
   }
 
   groupWithInteractive.set({
+    evented: true,
     interactive: true,
-    subTargetCheck: true
+    lockMovementX: isLocked,
+    lockMovementY: isLocked,
+    moveCursor: undefined,
+    selectable: true,
+    subTargetCheck: true,
+    hoverCursor: undefined
   })
 }
 

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -849,6 +849,7 @@ export default class TextManager {
 
   /**
    * Запекает текущий transient scale standalone-textbox в каноническую геометрию.
+   * После materialization также возвращает standalone-textbox в базовое runtime-состояние.
    * Используется для live-scaling, history/template rehydration и групповых трансформаций.
    */
   public commitStandaloneTextScale(
@@ -860,10 +861,30 @@ export default class TextManager {
       shouldDisableAutoExpandOnHorizontalChange?: boolean
     }
   ): boolean {
-    return this.scalingController.commitStandaloneTextScale({
+    const scaleCommitted = this.scalingController.commitStandaloneTextScale({
       target,
       shouldDisableAutoExpandOnHorizontalChange
     })
+
+    if (!TextManager._isTextbox(target)) return scaleCommitted
+    const textbox = target as EditorTextbox
+    const group = textbox.group as (FabricObject & {
+      shapeComposite?: boolean
+    }) | undefined
+    if (group?.shapeComposite === true) return scaleCommitted
+
+    const isLocked = Boolean(textbox.locked)
+
+    textbox.set({
+      editable: !isLocked,
+      evented: true,
+      lockMovementX: isLocked,
+      lockMovementY: isLocked,
+      selectable: true
+    })
+    textbox.setCoords()
+
+    return scaleCommitted
   }
 
   /**

--- a/src/editor/ui/toolbar-manager/default-config.ts
+++ b/src/editor/ui/toolbar-manager/default-config.ts
@@ -1,3 +1,4 @@
+import { FabricObject } from 'fabric'
 import { ImageEditor } from '../..'
 import {
   copyPasteIcon,
@@ -95,36 +96,42 @@ export default {
   },
 
   handlers: {
-    copyPaste: async(editor: ImageEditor) => {
-      editor.clipboardManager.copyPaste()
+    copyPaste: async(editor: ImageEditor, target?: FabricObject | null) => {
+      editor.clipboardManager.copyPaste(target ?? undefined)
     },
 
-    delete: (editor: ImageEditor) => {
-      editor.deletionManager.deleteSelectedObjects()
+    delete: (editor: ImageEditor, target?: FabricObject | null) => {
+      editor.deletionManager.deleteSelectedObjects({
+        objects: target ? [target] : undefined
+      })
     },
 
-    lock: (editor: ImageEditor) => {
-      editor.objectLockManager.lockObject()
+    lock: (editor: ImageEditor, target?: FabricObject | null) => {
+      editor.objectLockManager.lockObject({
+        object: target ?? undefined
+      })
     },
 
-    unlock: (editor: ImageEditor) => {
-      editor.objectLockManager.unlockObject()
+    unlock: (editor: ImageEditor, target?: FabricObject | null) => {
+      editor.objectLockManager.unlockObject({
+        object: target ?? undefined
+      })
     },
 
-    bringForward: (editor: ImageEditor) => {
-      editor.layerManager.bringForward()
+    bringForward: (editor: ImageEditor, target?: FabricObject | null) => {
+      editor.layerManager.bringForward(target ?? undefined)
     },
 
-    bringToFront: (editor: ImageEditor) => {
-      editor.layerManager.bringToFront()
+    bringToFront: (editor: ImageEditor, target?: FabricObject | null) => {
+      editor.layerManager.bringToFront(target ?? undefined)
     },
 
-    sendToBack: (editor: ImageEditor) => {
-      editor.layerManager.sendToBack()
+    sendToBack: (editor: ImageEditor, target?: FabricObject | null) => {
+      editor.layerManager.sendToBack(target ?? undefined)
     },
 
-    sendBackwards: (editor: ImageEditor) => {
-      editor.layerManager.sendBackwards()
+    sendBackwards: (editor: ImageEditor, target?: FabricObject | null) => {
+      editor.layerManager.sendBackwards(target ?? undefined)
     }
   }
 }

--- a/src/editor/ui/toolbar-manager/index.ts
+++ b/src/editor/ui/toolbar-manager/index.ts
@@ -8,14 +8,20 @@ import {
   TPointerEventInfo
 } from 'fabric'
 import { ImageEditor } from '../..'
+import { resolveShapeGroupFromTarget } from '../../shape-manager/shape-utils'
 import defaultConfig from './default-config'
+
+type ToolbarActionHandler = (
+  editor: ImageEditor,
+  target?: FabricObject | null
+) => void
 
 export type ToolbarConfig = {
   style?: Record<string, string | number>,
   btnStyle?: Record<string, string | number>,
   btnHover?: Record<string, string | number>,
   icons?: Record<string, Base64URLString>,
-  handlers?: Record<string, (editor: ImageEditor) => void>,
+  handlers?: Record<string, ToolbarActionHandler>,
   lockedActions?: Array<{ name: string, handle: string }>,
   actions?: Array<{ name: string, handle: string }>,
   offsetTop?: number
@@ -227,7 +233,7 @@ export default class ToolbarManager {
 
       Object.assign(btn.style, btnStyle)
 
-      btn.onclick = () => handlers[handle]?.(this.editor)
+      btn.onclick = () => handlers[handle]?.(this.editor, this.currentTarget)
 
       // Предотвращаем всплытие событий мыши на кнопках тулбара
       // чтобы избежать конфликта с drag'n'drop объектов на канвасе
@@ -315,18 +321,18 @@ export default class ToolbarManager {
   private _updateToolbar(): void {
     if (this.isTransforming || this.isTemporarilyHidden) return
 
-    const obj = this.canvas.getActiveObject()
-    if (!obj) {
+    const target = this._resolveCurrentTarget()
+    if (!target) {
       this.el.style.display = 'none'
       this.currentTarget = null
       return
     }
 
-    const locked = Boolean(obj.locked)
+    const locked = Boolean(target.locked)
 
     // Если объект или его флаг locked изменились — перерисовываем кнопки
-    if (obj !== this.currentTarget || locked !== this.currentLocked) {
-      this.currentTarget = obj
+    if (target !== this.currentTarget || locked !== this.currentLocked) {
+      this.currentTarget = target
       this.currentLocked = locked
       const actions = locked
         ? this.config.lockedActions
@@ -344,9 +350,9 @@ export default class ToolbarManager {
   private _updatePos(): void {
     if (this.isTransforming || this.isTemporarilyHidden) return
 
-    const obj = this.canvas.getActiveObject()
+    const target = this._resolveCurrentTarget()
 
-    if (!obj) {
+    if (!target) {
       this.el.style.display = 'none'
       return
     }
@@ -354,7 +360,7 @@ export default class ToolbarManager {
     const { el, config, canvas } = this
 
     // Пересчитываем внутренние координаты объекта (для корректного getBoundingRect)
-    obj.setCoords()
+    target.setCoords()
 
     // Читаем текущий зум (масштаб) и сдвиг (панорамирование) холста
     const zoom = canvas.getZoom()
@@ -363,12 +369,12 @@ export default class ToolbarManager {
     const [, , , , panX, panY] = canvas.viewportTransform
 
     // Находим центр объекта в исходных canvas-координатах
-    const { x: centerX } = obj.getCenterPoint()
+    const { x: centerX } = target.getCenterPoint()
 
     // Получаем axis-aligned bounding-box объекта (с учётом поворота)
     //    первый аргумент false — не включаем масштаб в результат,
     //    второй true — учитываем текущий трансформ (rotate/scale)
-    const { top: objectTop, height: objectHeight } = obj.getBoundingRect()
+    const { top: objectTop, height: objectHeight } = target.getBoundingRect()
 
     // Вычисляем экранную X-координату центра объекта
     const screenCenterX = centerX * zoom + panX
@@ -385,6 +391,18 @@ export default class ToolbarManager {
       top: `${top}px`,
       display: 'flex'
     })
+  }
+
+  /**
+   * Возвращает объект, относительно которого тулбар должен и позиционироваться, и выполнять действия.
+   * Для текста внутри shape-группы это сама группа, а не внутренний editing-textbox.
+   */
+  private _resolveCurrentTarget(): FabricObject | null {
+    const activeObject = this.canvas.getActiveObject()
+
+    return resolveShapeGroupFromTarget({
+      target: activeObject
+    }) ?? activeObject ?? null
   }
 
   /**


### PR DESCRIPTION
1. ShapeManager. Правим баг когда при редактировании текста тулбар прикреплялся к textbox, а не к shape-group, из-за чего при изменении вертикального выравнивания текста тулбар прыгал вместе с текстом.
2. ShapeManager. Правим баг когда ломается выделение объекта после copyPaste, если он был выполнен в режиме редактирования текста.
3. TextManager. Поправил баг когда ломалось выделение объекта после copyPaste, если он был выполнен в режиме редактирования текста.