### PR TITLE
ShapeManager. При ресайзе шейпа отключаем авторасширение, чтобы не конфликтовать с решением юзера изменить размеры шейпа.

### DIFF
--- a/src/editor/shape-manager/scaling/shape-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling.ts
@@ -901,6 +901,11 @@ export default class ShapeScalingController {
     group.shapeManualBaseWidth = nextManualBaseDimensions.width
     group.shapeManualBaseHeight = nextManualBaseDimensions.height
 
+    if (canScaleWidth && hasWidthChange) {
+      // Ручной resize по ширине фиксирует новую ширину как пользовательский контракт.
+      group.shapeTextAutoExpand = false
+    }
+
     const baseRounding = state?.baseRounding ?? Math.max(0, group.shapeRounding ?? 0)
     const roundingScale = Math.min(allowedScaleX, allowedScaleY)
     const scaledRounding = Math.max(0, baseRounding * roundingScale)


### PR DESCRIPTION
Если юзер задаёт размеры для шейпа путём скейлинга (ресайза), то отключаем авторасширение объекта.

Например, раньше если юзер уменьшил объект до минимума, а потом начал вводить текст, то срабатывало авторасширение и текст прыгал в одну строку:

<img width="476" height="497" alt="image" src="https://github.com/user-attachments/assets/12ad602b-54ea-4ea0-bf13-6e2adf953dbb" />

<img width="458" height="461" alt="image" src="https://github.com/user-attachments/assets/ea144bf2-a86d-4b05-854b-148a8030ee51" />

Теперь, если юзер изменил размер шейпа, а затем обновил текст, или его стили, то авторасширение не сработает:

<img width="476" height="497" alt="image" src="https://github.com/user-attachments/assets/12ad602b-54ea-4ea0-bf13-6e2adf953dbb" />

<img width="458" height="442" alt="image" src="https://github.com/user-attachments/assets/94411277-a509-4180-9383-1c299e3d5114" />
