### PR TITLE
ShapeManager. Поправил баг когда при обновлении скругления шейпа через update с переданным тем же preset происходила замена пресета с последующим перерасчётом пропорций

### DIFF
--- a/e2e/fixtures/data/shape-rounding.data.ts
+++ b/e2e/fixtures/data/shape-rounding.data.ts
@@ -1,0 +1,19 @@
+import type { ShapeAddParams } from '../../types'
+
+/** Непропорциональный прямоугольник с ручными размерами для regression-сценариев скругления. */
+export const SHAPE_ROUNDING_MANUAL_SIZE_OPTIONS: NonNullable<ShapeAddParams['options']> = {
+  width: 260,
+  height: 140,
+  text: '5.4\nBluetooth',
+  shapeTextAutoExpand: false,
+  rounding: 25,
+  textStyle: {
+    fontSize: 32
+  }
+}
+
+/** Новое значение скругления для проверки что изменение не схлопывает фигуру. */
+export const SHAPE_ROUNDING_UPDATED_VALUE = 28
+
+/** Допуск для сравнения геометрии фигуры до и после изменения скругления. */
+export const SHAPE_ROUNDING_SIZE_TOLERANCE = 2

--- a/e2e/tests/shape-manager/shape-group.spec.ts
+++ b/e2e/tests/shape-manager/shape-group.spec.ts
@@ -5,6 +5,11 @@ import {
   SHAPE_OPACITY_VALUE,
   SHAPE_SHAPE_ONLY_OPACITY_VALUE
 } from '../../fixtures/data/shape-opacity.data'
+import {
+  SHAPE_ROUNDING_MANUAL_SIZE_OPTIONS,
+  SHAPE_ROUNDING_SIZE_TOLERANCE,
+  SHAPE_ROUNDING_UPDATED_VALUE
+} from '../../fixtures/data/shape-rounding.data'
 
 test.describe('Свойства фигур', () => {
   test('при создании прямоугольника слишком большое скругление ограничивается 100', async({ shapes }) => {
@@ -107,6 +112,56 @@ test.describe('Свойства фигур', () => {
     await test.step('Проверить значение rounding', async() => {
       const shape = await shapes.getFirstShape()
       expect(shape.shapeRounding).toBe(20)
+    })
+  })
+
+  test('при изменении скругления шейп с вручную заданными размерами не сжимается', async({ shapes }) => {
+    const createdShape = await test.step('Добавить прямоугольник с вручную заданной шириной и высотой', () => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          ...SHAPE_ROUNDING_MANUAL_SIZE_OPTIONS,
+          id: 'shape-rounding-manual-size'
+        }
+      })
+    })
+
+    await test.step('Проверить что фигура создана в исходном непропорциональном размере', () => {
+      shapes.checkCreation({
+        shape: createdShape,
+        presetKey: 'square'
+      })
+      expect(createdShape?.shapeTextAutoExpand).toBe(false)
+      expect(createdShape?.shapeRounding).toBe(SHAPE_ROUNDING_MANUAL_SIZE_OPTIONS.rounding)
+    })
+
+    const initialSnapshot = await test.step('Получить исходную геометрию фигуры', () => {
+      return shapes.getScaleSnapshot({ id: 'shape-rounding-manual-size' })
+    })
+
+    await test.step('Изменить скругление без смены пресета', () => {
+      return shapes.setRounding({
+        id: 'shape-rounding-manual-size',
+        rounding: SHAPE_ROUNDING_UPDATED_VALUE
+      })
+    })
+
+    const updatedShape = await test.step('Получить состояние фигуры после изменения скругления', () => {
+      return shapes.getObject({ id: 'shape-rounding-manual-size' })
+    })
+    const updatedSnapshot = await test.step('Получить геометрию после изменения скругления', () => {
+      return shapes.getScaleSnapshot({ id: 'shape-rounding-manual-size' })
+    })
+
+    await test.step('Проверить что фигура сохранила ширину и высоту, а текст остался внутри', () => {
+      expect(updatedShape?.shapePresetKey).toBe('square')
+      expect(updatedShape?.shapeRounding).toBe(SHAPE_ROUNDING_UPDATED_VALUE)
+      expect(Math.abs(updatedSnapshot.groupBoundsWidth - initialSnapshot.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_ROUNDING_SIZE_TOLERANCE)
+      expect(Math.abs(updatedSnapshot.groupBoundsHeight - initialSnapshot.groupBoundsHeight))
+        .toBeLessThanOrEqual(SHAPE_ROUNDING_SIZE_TOLERANCE)
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'shape' })
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'text' })
     })
   })
 

--- a/e2e/tests/shape-manager/shape-replace-roundtrip.spec.ts
+++ b/e2e/tests/shape-manager/shape-replace-roundtrip.spec.ts
@@ -4,6 +4,11 @@ import {
   SHAPE_REPLACE_EXPANDING_TEXT,
   SHAPE_REPLACE_TOLERANCE
 } from '../../fixtures/data/shape-replace.data'
+import {
+  SHAPE_ROUNDING_MANUAL_SIZE_OPTIONS,
+  SHAPE_ROUNDING_SIZE_TOLERANCE,
+  SHAPE_ROUNDING_UPDATED_VALUE
+} from '../../fixtures/data/shape-rounding.data'
 
 test.describe('Смена фигуры после roundtrip через разные менеджеры', () => {
   test('после сохранения фигуры в шаблон следующая замена сохраняет её увеличенный размер', async({
@@ -288,6 +293,87 @@ test.describe('Скругление после roundtrip через разные
 
       expect(restoredShape?.shapePresetKey).toBe('square')
       expect(restoredShape?.shapeRounding).toBe(80)
+    })
+  })
+
+  test('после применения шаблона изменение скругления не сжимает шейп с вручную заданными размерами', async({
+    canvas,
+    editorModel,
+    shapes,
+    template
+  }) => {
+    const sourceSnapshot = await test.step('Добавить прямоугольник с вручную заданными размерами', async() => {
+      const createdShape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          ...SHAPE_ROUNDING_MANUAL_SIZE_OPTIONS,
+          id: 'shape-rounding-template-manual-size'
+        }
+      })
+
+      shapes.checkCreation({
+        shape: createdShape,
+        presetKey: 'square'
+      })
+
+      return shapes.getScaleSnapshot({ id: 'shape-rounding-template-manual-size' })
+    })
+
+    const serializedTemplate = await test.step('Сохранить фигуру в шаблон', async() => {
+      await shapes.select({ id: 'shape-rounding-template-manual-size' })
+
+      return template.serializeSelection()
+    })
+
+    await test.step('Очистить canvas и применить шаблон обратно', async() => {
+      expect(serializedTemplate).not.toBeNull()
+      await canvas.clearCanvas()
+
+      const insertedCount = await template.applyTemplate({
+        template: serializedTemplate!
+      })
+
+      expect(insertedCount).toBe(1)
+      await editorModel.checkObjectCount({ count: 1 })
+    })
+
+    const restoredShape = await test.step('Получить восстановленную фигуру из шаблона', () => {
+      return shapes.getObject({ objectIndex: 0 })
+    })
+    const restoredSnapshot = await test.step('Получить геометрию восстановленной фигуры', () => {
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+
+    await test.step('Изменить скругление у восстановленной фигуры', async() => {
+      await shapes.setRounding({
+        objectIndex: 0,
+        rounding: SHAPE_ROUNDING_UPDATED_VALUE
+      })
+    })
+
+    const updatedShape = await test.step('Получить состояние фигуры после изменения скругления', () => {
+      return shapes.getObject({ objectIndex: 0 })
+    })
+    const updatedSnapshot = await test.step('Получить геометрию после изменения скругления', () => {
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+
+    await test.step('Проверить что после шаблона изменение скругления не схлопнуло фигуру', () => {
+      expect(restoredShape?.shapePresetKey).toBe('square')
+      expect(restoredShape?.shapeTextAutoExpand).toBe(false)
+      expect(restoredShape?.shapeRounding).toBe(SHAPE_ROUNDING_MANUAL_SIZE_OPTIONS.rounding)
+      expect(Math.abs(restoredSnapshot.groupBoundsWidth - sourceSnapshot.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_ROUNDING_SIZE_TOLERANCE)
+      expect(Math.abs(restoredSnapshot.groupBoundsHeight - sourceSnapshot.groupBoundsHeight))
+        .toBeLessThanOrEqual(SHAPE_ROUNDING_SIZE_TOLERANCE)
+      expect(updatedShape?.shapePresetKey).toBe('square')
+      expect(updatedShape?.shapeRounding).toBe(SHAPE_ROUNDING_UPDATED_VALUE)
+      expect(Math.abs(updatedSnapshot.groupBoundsWidth - restoredSnapshot.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_ROUNDING_SIZE_TOLERANCE)
+      expect(Math.abs(updatedSnapshot.groupBoundsHeight - restoredSnapshot.groupBoundsHeight))
+        .toBeLessThanOrEqual(SHAPE_ROUNDING_SIZE_TOLERANCE)
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'shape' })
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'text' })
     })
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/shape-manager/shape-manager-mutation.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-mutation.spec.ts
@@ -739,6 +739,41 @@ describe('shape-manager mutation', () => {
     expect(updateSpy).not.toHaveBeenCalled()
   })
 
+  it('setRounding меняет скругление и сохраняет текущий размер фигуры', async() => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const group = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'shape text',
+        width: 260,
+        height: 140,
+        shapeTextAutoExpand: false
+      }
+    })
+
+    if (!group) {
+      throw new Error('shape group should be created')
+    }
+
+    const result = await manager.setRounding({
+      target: group,
+      rounding: 28
+    })
+
+    expect(result).toBe(group)
+    expect(group.shapePresetKey).toBe('square')
+    expect(group.shapeRounding).toBe(28)
+    expect(group.shapeBaseWidth).toBe(260)
+    expect(group.shapeBaseHeight).toBe(140)
+    expect(group.shapeManualBaseWidth).toBe(260)
+    expect(group.shapeManualBaseHeight).toBe(140)
+    expect(group.shapeReplaceBoxWidth).toBe(260)
+    expect(group.shapeReplaceBoxHeight).toBe(140)
+  })
+
   it('при изменении обводки пересчитывает layout в текущих размерах шейпа', async() => {
     const editor = createShapeManagerEditorStub({
       montageAreaWidth: 400

--- a/specs/src/editor/shape-manager/shape-manager-update.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-update.spec.ts
@@ -221,6 +221,51 @@ describe('shape-manager update', () => {
     }))
   })
 
+  it('при обновлении скругления с тем же пресетом сохраняет текущий размер фигуры', async() => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const group = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'shape text',
+        width: 260,
+        height: 140,
+        shapeTextAutoExpand: false
+      }
+    })
+
+    if (!group) {
+      throw new Error('shape group should be created')
+    }
+
+    createShapeNodeMock.mockClear()
+
+    const updatedGroup = await manager.update({
+      target: group,
+      presetKey: 'square',
+      options: {
+        rounding: 28
+      }
+    })
+
+    expect(updatedGroup).not.toBeNull()
+    expect(updatedGroup?.shapePresetKey).toBe('square')
+    expect(updatedGroup?.shapeRounding).toBe(28)
+    expect(updatedGroup?.shapeBaseWidth).toBe(260)
+    expect(updatedGroup?.shapeBaseHeight).toBe(140)
+    expect(updatedGroup?.shapeManualBaseWidth).toBe(260)
+    expect(updatedGroup?.shapeManualBaseHeight).toBe(140)
+    expect(updatedGroup?.shapeReplaceBoxWidth).toBe(260)
+    expect(updatedGroup?.shapeReplaceBoxHeight).toBe(140)
+    expect(createShapeNodeMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      width: 260,
+      height: 140,
+      rounding: 28
+    }))
+  })
+
   it('при смене на non-roundable пресет сбрасывает скругление в 0', async() => {
     const editor = createShapeManagerEditorStub()
     const manager = new ShapeManager({

--- a/src/editor/shape-manager/index.ts
+++ b/src/editor/shape-manager/index.ts
@@ -435,8 +435,9 @@ export default class ShapeManager {
     const currentGroup = this._resolveShapeGroup({ target })
     if (!currentGroup) return null
 
-    const currentPresetKey = presetKey ?? currentGroup.shapePresetKey ?? DEFAULT_SHAPE_PRESET_KEY
-    const basePreset = getShapePreset({ presetKey: currentPresetKey })
+    const currentPresetKey = currentGroup.shapePresetKey ?? DEFAULT_SHAPE_PRESET_KEY
+    const requestedPresetKey = presetKey ?? currentPresetKey
+    const basePreset = getShapePreset({ presetKey: requestedPresetKey })
     if (!basePreset) return null
 
     const {
@@ -502,6 +503,7 @@ export default class ShapeManager {
     const { width: presetWidth, height: presetHeight } = effectivePreset
     const shouldPreserveCurrentAspectRatio = Boolean(preserveCurrentAspectRatio)
     const isPresetReplace = presetKey !== undefined
+      && requestedPresetKey !== currentPresetKey
     const shouldFitReplacementToPreset = isPresetReplace
       && !shouldPreserveCurrentAspectRatio
     const nextReplaceBoxDimensions = shouldFitReplacementToPreset
@@ -646,7 +648,7 @@ export default class ShapeManager {
 
     const shouldPreserveCurrentWidth = rawWidth === undefined
       && rawHeight === undefined
-      && presetKey === undefined
+      && !isPresetReplace
       && shapeTextAutoExpand === undefined
       && rounding === undefined
       && text === undefined


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавили шейп square с текстом "TEST" и изменили его размер путём скейлинга, например, увеличив ширину в 2 раза
2. Применили скругление углов через `editor.shapeManager.update({ preset: 'square', rounding: 28 })`

Как было.

При применении скругления происходила замена текущего пресета square на новый переданный square с последующим перерасчётом пропорций так чтобы текст помещался внутри шейпа, из-за чего происходило сжатие шейпа обратно.

Как сейчас.

Скругление применяется, перерасчёт пропорций и сжатие не происходит.