### PR TITLE
Shapes, Texts, Templates, Clipboard. Исправляем пересчёт размеров шейпов и материализацию текстовых объектов из шаблонов, а также генерацию id объектов.

### DIFF
--- a/e2e/fixtures/data/template-manager.data.ts
+++ b/e2e/fixtures/data/template-manager.data.ts
@@ -68,6 +68,69 @@ export const PRODUCT_CARD_TEMPLATE_UPDATED_TITLE = 'НАУШНИКИ SONY'
 /** Цвет фона, который должен быть применён как background-object, а не как обычный canvas-объект. */
 export const PRODUCT_CARD_TEMPLATE_BACKGROUND_COLOR = '#fcf4ff'
 
+/** Базовое разрешение для шаблона с текстом внутри фигуры. */
+export const TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION = {
+  width: 810,
+  height: 1080
+} as const
+
+/** Увеличенное разрешение для проверки масштаба текста внутри фигуры из шаблона. */
+export const TEMPLATE_SHAPE_TEXT_LARGE_RESOLUTION = {
+  width: 4096,
+  height: 4096
+} as const
+
+/** Коэффициент масштабирования шаблона с текстом внутри фигуры на большом разрешении. */
+export const TEMPLATE_SHAPE_TEXT_LARGE_SCALE = Math.min(
+  TEMPLATE_SHAPE_TEXT_LARGE_RESOLUTION.width / TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION.width,
+  TEMPLATE_SHAPE_TEXT_LARGE_RESOLUTION.height / TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION.height
+)
+
+/** Допуск для проверок масштаба текста внутри фигуры после применения шаблона. */
+export const TEMPLATE_SHAPE_TEXT_SCALE_TOLERANCE = 1.5
+
+/** Фигура с длинным текстом для проверки сохранения и повторного применения шаблона. */
+export const TEMPLATE_SHAPE_LONG_TEXT_OPTIONS = {
+  id: 'template-shape-long-text',
+  left: 292,
+  top: 814,
+  width: 230,
+  height: 124,
+  shapeTextAutoExpand: false,
+  text: 'Премиальное качество\nПремиальное качество',
+  textStyle: {
+    fontFamily: 'Exo 2',
+    fontSize: 48,
+    bold: true,
+    color: '#333333'
+  },
+  fill: '#EBE4ED',
+  rounding: 25,
+  alignH: 'center',
+  alignV: 'middle'
+} as const
+
+/** Фигура для проверки масштабирования текста внутри шаблона на другом разрешении. */
+export const TEMPLATE_SHAPE_TEXT_SCALE_OPTIONS = {
+  id: 'template-shape-text-scale',
+  left: 292,
+  top: 814,
+  width: 230,
+  height: 124,
+  shapeTextAutoExpand: false,
+  text: 'Премиум',
+  textStyle: {
+    fontFamily: 'Exo 2',
+    fontSize: 24,
+    bold: true,
+    color: '#333333'
+  },
+  fill: '#EBE4ED',
+  rounding: 25,
+  alignH: 'center',
+  alignV: 'middle'
+} as const
+
 /** Полный шаблон product card для e2e-проверок применения готового шаблона. */
 export const PRODUCT_CARD_TEMPLATE: TemplateDefinition = {
   id: 'template-2',

--- a/e2e/models/shape.model.ts
+++ b/e2e/models/shape.model.ts
@@ -2,6 +2,7 @@
 import { type Page, expect } from '@playwright/test'
 import type {
   ShapeObjectInfo,
+  ShapeObjectTreeIds,
   ShapeTextInfo,
   ShapeAddParams,
   ShapeAddAtBoundsParams,
@@ -1459,6 +1460,32 @@ export class ShapeModel {
 
       return helpers.serializeShapeTextObject(textNode)
     }, params)
+  }
+
+  /** Возвращает ID shape-группы и её внутренних объектов. */
+  async getObjectTreeIds(params: ObjectTargetParams = {}): Promise<ShapeObjectTreeIds> {
+    const ids = await this.page.evaluate(({ objectIndex, id }) => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+
+      const target = helpers.resolveCanvasObject(objectIndex, id)
+      if (!target) return null
+
+      const shapeNode = helpers.resolveShapeNode(target)
+      const textNode = editor.shapeManager.getTextNode({ target })
+
+      return {
+        groupId: typeof target.id === 'string' ? target.id : null,
+        shapeId: shapeNode && typeof shapeNode.id === 'string' ? shapeNode.id : null,
+        textId: textNode && typeof textNode.id === 'string' ? textNode.id : null
+      }
+    }, params)
+
+    expect(ids, 'для shape-группы должны существовать id объектов').not.toBeNull()
+
+    return ids as ShapeObjectTreeIds
   }
 
   /** Делает shape активным объектом canvas */

--- a/e2e/tests/shape-manager/shape-group.spec.ts
+++ b/e2e/tests/shape-manager/shape-group.spec.ts
@@ -204,3 +204,86 @@ test.describe('Свойства фигур', () => {
     })
   })
 })
+
+test.describe('ID объектов фигуры', () => {
+  test('при добавлении фигуры внутренние объекты сразу получают id', async({ shapes }) => {
+    await test.step('Добавить фигуру с текстом', async() => {
+      shapes.checkCreation({
+        shape: await shapes.add({
+          presetKey: 'square',
+          options: {
+            id: 'shape-object-ids-source',
+            text: 'Текст внутри фигуры'
+          }
+        }),
+        presetKey: 'square'
+      })
+    })
+
+    await test.step('Проверить id группы и внутренних объектов', async() => {
+      const ids = await shapes.getObjectTreeIds({ id: 'shape-object-ids-source' })
+
+      expect(ids.groupId).toBe('shape-object-ids-source')
+      expect(ids.shapeId).toEqual(expect.any(String))
+      expect(ids.textId).toEqual(expect.any(String))
+      expect(ids.shapeId).not.toBe(ids.textId)
+    })
+  })
+
+  test('после копирования и вставки фигуры внутренние объекты получают новые id', async({
+    clipboard,
+    editorModel,
+    shapes
+  }) => {
+    await test.step('Добавить исходную фигуру', async() => {
+      shapes.checkCreation({
+        shape: await shapes.add({
+          presetKey: 'square',
+          options: {
+            id: 'shape-copy-object-ids-source',
+            text: 'Текст для копии'
+          }
+        }),
+        presetKey: 'square'
+      })
+    })
+
+    const sourceIds = await test.step('Получить id исходной фигуры и внутренних объектов', () => {
+      return shapes.getObjectTreeIds({ id: 'shape-copy-object-ids-source' })
+    })
+
+    await test.step('Скопировать и вставить фигуру', async() => {
+      await shapes.select({ id: 'shape-copy-object-ids-source' })
+      await clipboard.copy()
+      await clipboard.waitForClipboardReady()
+
+      const pasted = await clipboard.paste()
+
+      expect(pasted).toBe(true)
+      await editorModel.checkObjectCount({ count: 2 })
+    })
+
+    const pastedShapeId = await test.step('Найти вставленную фигуру', async() => {
+      const shapeObjects = await shapes.getShapeObjects()
+      const pastedShape = shapeObjects.find((shape) => shape.id !== sourceIds.groupId)
+
+      if (!pastedShape?.id) {
+        throw new Error('после вставки должна существовать новая фигура с id')
+      }
+
+      return pastedShape.id
+    })
+
+    await test.step('Проверить что у вставленной фигуры и внутренних объектов новые id', async() => {
+      const pastedIds = await shapes.getObjectTreeIds({ id: pastedShapeId })
+
+      expect(pastedIds.groupId).toEqual(expect.any(String))
+      expect(pastedIds.shapeId).toEqual(expect.any(String))
+      expect(pastedIds.textId).toEqual(expect.any(String))
+      expect(pastedIds.groupId).not.toBe(sourceIds.groupId)
+      expect(pastedIds.shapeId).not.toBe(sourceIds.shapeId)
+      expect(pastedIds.textId).not.toBe(sourceIds.textId)
+      expect(pastedIds.shapeId).not.toBe(pastedIds.textId)
+    })
+  })
+})

--- a/e2e/tests/template-manager/index.spec.ts
+++ b/e2e/tests/template-manager/index.spec.ts
@@ -14,6 +14,12 @@ import {
   PRODUCT_CARD_TEMPLATE_UPDATED_TITLE,
   TEMPLATE_ALIGNMENT_TOLERANCE,
   TEMPLATE_BOUNDS_TOLERANCE,
+  TEMPLATE_SHAPE_LONG_TEXT_OPTIONS,
+  TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION,
+  TEMPLATE_SHAPE_TEXT_LARGE_SCALE,
+  TEMPLATE_SHAPE_TEXT_LARGE_RESOLUTION,
+  TEMPLATE_SHAPE_TEXT_SCALE_OPTIONS,
+  TEMPLATE_SHAPE_TEXT_SCALE_TOLERANCE,
   TEMPLATE_ROUNDTRIP_BASE_RESOLUTION,
   TEMPLATE_ROUNDTRIP_EXPANDED_RESOLUTION,
   TEMPLATE_ROUNDTRIP_LEFT_SHAPE,
@@ -226,6 +232,111 @@ test.describe('Готовый шаблон', () => {
 
       expect(titleObject.text).toBe(PRODUCT_CARD_TEMPLATE_UPDATED_TITLE)
       expect(subtitleObject.text).toBe('Новый подзаголовок товара')
+    })
+  })
+})
+
+test.describe('Текст внутри фигуры из шаблона', () => {
+  test('длинный текст внутри фигуры из сохранённого шаблона остаётся внутри выделения', async({
+    canvas,
+    shapes,
+    template
+  }) => {
+    const serializedTemplate = await test.step('Создать фигуру с длинным текстом и сохранить её как шаблон', async() => {
+      await canvas.setMontageResolution(TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION)
+      shapes.checkCreation({
+        shape: await shapes.addAtBounds({
+          presetKey: 'square',
+          options: TEMPLATE_SHAPE_LONG_TEXT_OPTIONS
+        }),
+        presetKey: 'square'
+      })
+      await shapes.select({ id: TEMPLATE_SHAPE_LONG_TEXT_OPTIONS.id })
+
+      return template.serializeSelection()
+    })
+
+    await test.step('Очистить canvas и применить сохранённый шаблон', async() => {
+      expect(serializedTemplate).not.toBeNull()
+      await canvas.clearCanvas()
+
+      const insertedCount = await template.applyTemplate({
+        template: serializedTemplate!
+      })
+
+      expect(insertedCount).toBe(1)
+    })
+
+    await test.step('Проверить что текст остался внутри фигуры', async() => {
+      const textNode = await shapes.getTextNode({ objectIndex: 0 })
+      const snapshot = await shapes.getScaleSnapshot({ objectIndex: 0 })
+
+      if (!textNode) {
+        throw new Error('текст внутри фигуры из шаблона должен существовать')
+      }
+
+      expect(textNode.text).toBe(TEMPLATE_SHAPE_LONG_TEXT_OPTIONS.text)
+      expect(textNode.lineCount).toBeGreaterThan(1)
+      shapes.checkNodeInsideGroup({ snapshot, kind: 'text' })
+    })
+  })
+
+  test('текст внутри фигуры из сохранённого шаблона увеличивается вместе с монтажной областью', async({
+    canvas,
+    shapes,
+    template
+  }) => {
+    await test.step('Создать фигуру на исходном размере монтажной области', async() => {
+      await canvas.setMontageResolution(TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION)
+      shapes.checkCreation({
+        shape: await shapes.addAtBounds({
+          presetKey: 'square',
+          options: TEMPLATE_SHAPE_TEXT_SCALE_OPTIONS
+        }),
+        presetKey: 'square'
+      })
+      await shapes.select({ id: TEMPLATE_SHAPE_TEXT_SCALE_OPTIONS.id })
+    })
+
+    const sourceText = await test.step('Получить исходный размер текста внутри фигуры', async() => {
+      return shapes.getTextNode({ id: TEMPLATE_SHAPE_TEXT_SCALE_OPTIONS.id })
+    })
+    const sourceSnapshot = await test.step('Получить исходную геометрию фигуры', async() => {
+      return shapes.getScaleSnapshot({ id: TEMPLATE_SHAPE_TEXT_SCALE_OPTIONS.id })
+    })
+    const serializedTemplate = await test.step('Сохранить фигуру как шаблон', () => {
+      return template.serializeSelection()
+    })
+
+    await test.step('Применить сохранённый шаблон на большом размере монтажной области', async() => {
+      expect(serializedTemplate).not.toBeNull()
+      await canvas.clearCanvas()
+      await canvas.setMontageResolution(TEMPLATE_SHAPE_TEXT_LARGE_RESOLUTION)
+
+      const insertedCount = await template.applyTemplate({
+        template: serializedTemplate!
+      })
+
+      expect(insertedCount).toBe(1)
+    })
+
+    await test.step('Проверить что текст и фигура увеличились в том же масштабе', async() => {
+      const appliedText = await shapes.getTextNode({ objectIndex: 0 })
+      const appliedSnapshot = await shapes.getScaleSnapshot({ objectIndex: 0 })
+
+      if (!sourceText || !appliedText) {
+        throw new Error('текст внутри фигуры должен существовать до и после применения шаблона')
+      }
+
+      const expectedFontSize = sourceText.fontSize * TEMPLATE_SHAPE_TEXT_LARGE_SCALE
+      const expectedWidth = sourceSnapshot.groupBoundsWidth * TEMPLATE_SHAPE_TEXT_LARGE_SCALE
+
+      expect(appliedText.fontSize).toBeGreaterThan(sourceText.fontSize + 1)
+      expect(Math.abs(appliedText.fontSize - expectedFontSize))
+        .toBeLessThanOrEqual(TEMPLATE_SHAPE_TEXT_SCALE_TOLERANCE)
+      expect(Math.abs(appliedSnapshot.groupBoundsWidth - expectedWidth))
+        .toBeLessThanOrEqual(TEMPLATE_SHAPE_TEXT_SCALE_TOLERANCE)
+      shapes.checkNodeInsideGroup({ snapshot: appliedSnapshot, kind: 'text' })
     })
   })
 })

--- a/e2e/types/shape.types.ts
+++ b/e2e/types/shape.types.ts
@@ -191,6 +191,13 @@ export interface ShapeTextInfo extends EditorObjectInfo {
   splitByGrapheme: boolean
 }
 
+/** ID shape-группы и её внутренних объектов. */
+export interface ShapeObjectTreeIds {
+  groupId: string | null
+  shapeId: string | null
+  textId: string | null
+}
+
 /** Параметры одного шага интерактивного масштабирования */
 export interface ShapeScaleStepParams extends ObjectTargetParams {
   scaleX: number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/clipboard-manager/index.spec.ts
+++ b/specs/src/editor/clipboard-manager/index.spec.ts
@@ -28,6 +28,7 @@ describe('ClipboardManager', () => {
   let clipboardManager: ClipboardManager
   let mockCanvas: any
   let commitStandaloneTextScaleMock: jest.Mock
+  let commitRehydratedShapeLayoutMock: jest.Mock
 
   beforeEach(() => {
     // Устанавливаем глобальные моки браузерных API
@@ -37,6 +38,7 @@ describe('ClipboardManager', () => {
     mockEditor = mocks.mockEditor
     mockCanvas = mocks.mockCanvas
     commitStandaloneTextScaleMock = mockEditor.textManager.commitStandaloneTextScale as jest.Mock
+    commitRehydratedShapeLayoutMock = mockEditor.shapeManager.commitRehydratedShapeLayout as jest.Mock
 
     clipboardManager = new ClipboardManager({ editor: mockEditor })
 
@@ -57,6 +59,10 @@ describe('ClipboardManager', () => {
     it('список свойств для clipboard cloning включает replacement box фигуры', () => {
       expect(CLIPBOARD_CLONE_OBJECT_KEYS).toContain('shapeReplaceBoxWidth')
       expect(CLIPBOARD_CLONE_OBJECT_KEYS).toContain('shapeReplaceBoxHeight')
+    })
+
+    it('список свойств для clipboard cloning включает id объектов', () => {
+      expect(CLIPBOARD_CLONE_OBJECT_KEYS).toContain('id')
     })
   })
 
@@ -382,19 +388,27 @@ describe('ClipboardManager', () => {
       })
     })
 
-    it('должен вставить shape-group из внутреннего буфера без потери runtime-свойств', async() => {
+    it('вставляет шейп из внутреннего буфера без потери runtime-свойств', async() => {
+      const sourceShape = createMockShapeNode({ id: 'source-shape' })
+      const sourceText = createMockShapeTextbox({ text: 'source text' })
+      sourceText.set({ id: 'source-text' })
+      const pastedShape = createMockShapeNode({ id: 'pasted-shape' })
+      const pastedText = createMockShapeTextbox({ text: 'pasted text' })
+      pastedText.set({ id: 'pasted-text' })
       const sourceGroup = new ShapeGroupObject([
-        createMockShapeNode() as never,
-        createMockShapeTextbox({ text: 'source text' })
+        sourceShape as never,
+        sourceText
       ], {
+        id: 'source-group',
         left: 10,
         top: 20,
         shapePresetKey: 'square'
       })
       const pastedGroup = new ShapeGroupObject([
-        createMockShapeNode() as never,
-        createMockShapeTextbox({ text: 'pasted text' })
+        pastedShape as never,
+        pastedText
       ], {
+        id: 'pasted-group',
         left: 10,
         top: 20,
         shapePresetKey: 'square'
@@ -405,11 +419,24 @@ describe('ClipboardManager', () => {
 
       const result = await clipboardManager.paste()
 
+      expect(mockEditor.errorManager.emitError).not.toHaveBeenCalled()
       expect(result).toBe(true)
       expect(mockCanvas.add).toHaveBeenCalledWith(pastedGroup)
       expect(pastedGroup.shapeComposite).toBe(true)
       expect(pastedGroup.interactive).toBe(true)
       expect(pastedGroup.subTargetCheck).toBe(true)
+      expect(pastedGroup.id).toEqual(expect.any(String))
+      expect(pastedGroup.id).not.toBe('pasted-group')
+      expect(pastedShape.id).toEqual(expect.any(String))
+      expect(pastedShape.id).not.toBe('pasted-shape')
+      expect(pastedText.id).toEqual(expect.any(String))
+      expect(pastedText.id).not.toBe('pasted-text')
+      expect(commitRehydratedShapeLayoutMock).toHaveBeenCalledWith({
+        target: pastedGroup
+      })
+      expect(commitRehydratedShapeLayoutMock.mock.invocationCallOrder[0]).toBeLessThan(
+        mockCanvas.add.mock.invocationCallOrder[0]
+      )
       expect(mockCanvas.fire).toHaveBeenCalledWith('editor:object-pasted', {
         fromInternalClipboard: true,
         clipboardObject: sourceGroup,

--- a/specs/src/editor/clipboard-manager/index.spec.ts
+++ b/specs/src/editor/clipboard-manager/index.spec.ts
@@ -359,7 +359,7 @@ describe('ClipboardManager', () => {
       })
     })
 
-    it('должен обработать вставку ActiveSelection и установить уникальные id', async() => {
+    it('вставляет выделение с новыми id у всех объектов', async() => {
       const mockObjects = [
         createMockFabricObject({ type: 'rect', id: 'original-rect', left: 50, top: 50 }),
         createMockFabricObject({ type: 'circle', id: 'original-circle', left: 100, top: 100 }),
@@ -371,16 +371,22 @@ describe('ClipboardManager', () => {
       const result = await clipboardManager.paste()
 
       expect(result).toBe(true)
-
-      // Проверяем, что объекты были добавлены на canvas через специальную логику для ActiveSelection
       expect(mockCanvas.discardActiveObject).toHaveBeenCalled()
       expect(mockEditor.historyManager.suspendHistory).toHaveBeenCalled()
       expect(mockEditor.historyManager.resumeHistory).toHaveBeenCalled()
-
-      // Проверяем, что добавлено нужное количество объектов
       expect(mockCanvas.add).toHaveBeenCalledTimes(mockObjects.length)
 
-      // Проверяем вызов события
+      const addedObjects = mockCanvas.add.mock.calls.map(([object]) => object)
+      const addedIds = addedObjects.map((object) => object.id)
+
+      expect(addedIds).toHaveLength(mockObjects.length)
+      expect(new Set(addedIds).size).toBe(mockObjects.length)
+      expect(addedIds).not.toContain('original-rect')
+      expect(addedIds).not.toContain('original-circle')
+      expect(addedIds).not.toContain('original-text')
+      addedObjects.forEach((object) => {
+        expect(object.evented).toBe(true)
+      })
       expect(mockCanvas.fire).toHaveBeenCalledWith('editor:object-pasted', {
         fromInternalClipboard: true,
         clipboardObject: mockGroup,
@@ -388,7 +394,7 @@ describe('ClipboardManager', () => {
       })
     })
 
-    it('вставляет шейп из внутреннего буфера без потери runtime-свойств', async() => {
+    it('вставляет шейп из внутреннего буфера без потери свойств группы', async() => {
       const sourceShape = createMockShapeNode({ id: 'source-shape' })
       const sourceText = createMockShapeTextbox({ text: 'source text' })
       sourceText.set({ id: 'source-text' })
@@ -444,7 +450,7 @@ describe('ClipboardManager', () => {
       })
     })
 
-    it('должен обработать copyPaste для ActiveSelection и установить уникальные id', async() => {
+    it('дублирует выделение с новыми id у всех объектов', async() => {
       const mockObjects = [
         createMockFabricObject({ type: 'rect', id: 'original-rect', left: 75, top: 75 }),
         createMockFabricObject({ type: 'circle', id: 'original-circle', left: 125, top: 125 })
@@ -455,16 +461,21 @@ describe('ClipboardManager', () => {
       const result = await clipboardManager.copyPaste()
 
       expect(result).toBe(true)
-
-      // Проверяем, что были вызваны нужные методы для ActiveSelection
       expect(mockCanvas.discardActiveObject).toHaveBeenCalled()
       expect(mockEditor.historyManager.suspendHistory).toHaveBeenCalled()
       expect(mockEditor.historyManager.resumeHistory).toHaveBeenCalled()
-
-      // Проверяем, что добавлено нужное количество объектов
       expect(mockCanvas.add).toHaveBeenCalledTimes(mockObjects.length)
 
-      // Проверяем вызов события
+      const addedObjects = mockCanvas.add.mock.calls.map(([object]) => object)
+      const addedIds = addedObjects.map((object) => object.id)
+
+      expect(addedIds).toHaveLength(mockObjects.length)
+      expect(new Set(addedIds).size).toBe(mockObjects.length)
+      expect(addedIds).not.toContain('original-rect')
+      expect(addedIds).not.toContain('original-circle')
+      addedObjects.forEach((object) => {
+        expect(object.evented).toBe(true)
+      })
       expect(mockCanvas.fire).toHaveBeenCalledWith('editor:object-duplicated', {
         targetObject: mockGroup,
         clonedObject: expect.any(ActiveSelection)

--- a/specs/src/editor/history-manager/index.spec.ts
+++ b/specs/src/editor/history-manager/index.spec.ts
@@ -1009,6 +1009,34 @@ describe('HistoryManager', () => {
       )
     })
 
+    it('фигура из истории пересчитывает layout до отрисовки', async() => {
+      const { historyManager, mockEditor } = createHistoryManagerTestSetup()
+      const commitRehydratedShapeLayoutMock = mockEditor.shapeManager.commitRehydratedShapeLayout as jest.Mock
+      const state = createState({
+        objects: [
+          { id: 'montage-area', type: 'rect' },
+          {
+            id: 'shape-1',
+            type: 'shape-group',
+            shapeComposite: true,
+            shapePresetKey: 'square'
+          }
+        ] as any[]
+      })
+
+      await historyManager.loadStateFromFullState(state)
+
+      expect(commitRehydratedShapeLayoutMock).toHaveBeenCalledWith({
+        target: expect.objectContaining({
+          id: 'shape-1',
+          type: 'shape-group'
+        })
+      })
+      expect(commitRehydratedShapeLayoutMock.mock.invocationCallOrder[0]).toBeLessThan(
+        mockEditor.canvas.renderAll.mock.invocationCallOrder[0]
+      )
+    })
+
     it('обновляет canvas если размеры изменились', async() => {
       const { historyManager, mockEditor } = createHistoryManagerTestSetup({
         initialCanvasWidth: 800,

--- a/specs/src/editor/shape-manager/index.spec.ts
+++ b/specs/src/editor/shape-manager/index.spec.ts
@@ -1,3 +1,4 @@
+import '../../../test-utils/shape-manager-module-mocks'
 import { Group } from 'fabric'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import {
@@ -5,94 +6,6 @@ import {
   getShapeManagerUnitMocks,
   resetShapeManagerUnitMocks
 } from '../../../test-utils/shape-manager-spec-helpers'
-
-jest.mock('../../../../src/editor/shape-manager/shape-factory', () => ({
-  createShapeNode: jest.fn(),
-  applyShapeStyle: jest.fn(),
-  resizeShapeNode: jest.fn()
-}))
-
-jest.mock('../../../../src/editor/shape-manager/layout/shape-layout', () => ({
-  applyShapeTextLayout: jest.fn(),
-  resolveMinimumShapeWidthForText: jest.fn(() => 1),
-  resolveRequiredShapeHeightForText: jest.fn(({
-    height
-  }: {
-    height: number
-  }) => Math.max(1, height)),
-  resolveShapeTextFrameLayout: jest.fn(({
-    width,
-    padding
-  }: {
-    width: number
-    padding?: {
-      left?: number
-      right?: number
-    }
-  }) => ({
-    frame: {
-      left: padding?.left ?? 0,
-      width: Math.max(1, width - (padding?.left ?? 0) - (padding?.right ?? 0))
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextFixedWidthLayout: jest.fn(({
-    width,
-    height
-  }: {
-    width: number
-    height: number
-  }) => ({
-    width,
-    height,
-    appliedPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    appliedUserPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    frame: {
-      left: 0,
-      top: 0,
-      width: Math.max(1, width),
-      height: Math.max(1, height)
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextAutoExpandWidthForText: jest.fn(({
-    currentWidth,
-    minimumWidth
-  }: {
-    currentWidth: number
-    minimumWidth: number
-  }) => Math.max(currentWidth, minimumWidth)),
-  resolveGroupCenterPoint: jest.fn(({
-    left,
-    top,
-    canvasCenter
-  }: {
-    left?: number
-    top?: number
-    canvasCenter: { x: number; y: number }
-  }) => {
-    if (typeof left === 'number' && typeof top === 'number') {
-      return {
-        x: left,
-        y: top
-      }
-    }
-
-    return canvasCenter
-  })
-}))
 
 describe('shape-manager', () => {
   const mocks = getShapeManagerUnitMocks()

--- a/specs/src/editor/shape-manager/shape-factory.spec.ts
+++ b/specs/src/editor/shape-manager/shape-factory.spec.ts
@@ -1,7 +1,41 @@
 import { Rect } from 'fabric'
-import { resizeShapeNode } from '../../../../src/editor/shape-manager/shape-factory'
+import { nanoid } from 'nanoid'
+import {
+  createShapeNode,
+  resizeShapeNode
+} from '../../../../src/editor/shape-manager/shape-factory'
+
+jest.mock('nanoid')
 
 describe('shape-factory', () => {
+  const mockNanoid = nanoid as jest.MockedFunction<typeof nanoid>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockNanoid.mockImplementation(() => 'shape-node-id')
+  })
+
+  it('при создании фигуры задаёт id внутреннему объекту фигуры', async() => {
+    const shape = await createShapeNode({
+      preset: {
+        key: 'square',
+        type: 'rect',
+        width: 100,
+        height: 100
+      },
+      width: 120,
+      height: 80,
+      style: {
+        fill: '#ffffff',
+        stroke: null,
+        strokeWidth: 0
+      }
+    })
+
+    expect(shape.id).toEqual(expect.stringContaining('shape-node-id'))
+    expect(shape.shapeNodeType).toBe('shape')
+  })
+
   it('для Rect пересчитывает визуальный радиус от текущего размера при том же значении скругления', () => {
     const shape = new Rect({
       width: 100,

--- a/specs/src/editor/shape-manager/shape-manager-add.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-add.spec.ts
@@ -1,3 +1,4 @@
+import '../../../test-utils/shape-manager-module-mocks'
 import { Group } from 'fabric'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import { getShapePreset } from '../../../../src/editor/shape-manager/shape-presets'
@@ -8,94 +9,6 @@ import {
   getShapeManagerUnitMocks,
   resetShapeManagerUnitMocks
 } from '../../../test-utils/shape-manager-spec-helpers'
-
-jest.mock('../../../../src/editor/shape-manager/shape-factory', () => ({
-  createShapeNode: jest.fn(),
-  applyShapeStyle: jest.fn(),
-  resizeShapeNode: jest.fn()
-}))
-
-jest.mock('../../../../src/editor/shape-manager/layout/shape-layout', () => ({
-  applyShapeTextLayout: jest.fn(),
-  resolveMinimumShapeWidthForText: jest.fn(() => 1),
-  resolveRequiredShapeHeightForText: jest.fn(({
-    height
-  }: {
-    height: number
-  }) => Math.max(1, height)),
-  resolveShapeTextFrameLayout: jest.fn(({
-    width,
-    padding
-  }: {
-    width: number
-    padding?: {
-      left?: number
-      right?: number
-    }
-  }) => ({
-    frame: {
-      left: padding?.left ?? 0,
-      width: Math.max(1, width - (padding?.left ?? 0) - (padding?.right ?? 0))
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextFixedWidthLayout: jest.fn(({
-    width,
-    height
-  }: {
-    width: number
-    height: number
-  }) => ({
-    width,
-    height,
-    appliedPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    appliedUserPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    frame: {
-      left: 0,
-      top: 0,
-      width: Math.max(1, width),
-      height: Math.max(1, height)
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextAutoExpandWidthForText: jest.fn(({
-    currentWidth,
-    minimumWidth
-  }: {
-    currentWidth: number
-    minimumWidth: number
-  }) => Math.max(currentWidth, minimumWidth)),
-  resolveGroupCenterPoint: jest.fn(({
-    left,
-    top,
-    canvasCenter
-  }: {
-    left?: number
-    top?: number
-    canvasCenter: { x: number; y: number }
-  }) => {
-    if (typeof left === 'number' && typeof top === 'number') {
-      return {
-        x: left,
-        y: top
-      }
-    }
-
-    return canvasCenter
-  })
-}))
 
 describe('shape-manager add', () => {
   const mocks = getShapeManagerUnitMocks()

--- a/specs/src/editor/shape-manager/shape-manager-events.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-events.spec.ts
@@ -1,3 +1,4 @@
+import '../../../test-utils/shape-manager-module-mocks'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import {
   createShapeManagerEditorStub,
@@ -6,94 +7,6 @@ import {
   getShapeManagerUnitMocks,
   resetShapeManagerUnitMocks
 } from '../../../test-utils/shape-manager-spec-helpers'
-
-jest.mock('../../../../src/editor/shape-manager/shape-factory', () => ({
-  createShapeNode: jest.fn(),
-  applyShapeStyle: jest.fn(),
-  resizeShapeNode: jest.fn()
-}))
-
-jest.mock('../../../../src/editor/shape-manager/layout/shape-layout', () => ({
-  applyShapeTextLayout: jest.fn(),
-  resolveMinimumShapeWidthForText: jest.fn(() => 1),
-  resolveRequiredShapeHeightForText: jest.fn(({
-    height
-  }: {
-    height: number
-  }) => Math.max(1, height)),
-  resolveShapeTextFrameLayout: jest.fn(({
-    width,
-    padding
-  }: {
-    width: number
-    padding?: {
-      left?: number
-      right?: number
-    }
-  }) => ({
-    frame: {
-      left: padding?.left ?? 0,
-      width: Math.max(1, width - (padding?.left ?? 0) - (padding?.right ?? 0))
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextFixedWidthLayout: jest.fn(({
-    width,
-    height
-  }: {
-    width: number
-    height: number
-  }) => ({
-    width,
-    height,
-    appliedPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    appliedUserPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    frame: {
-      left: 0,
-      top: 0,
-      width: Math.max(1, width),
-      height: Math.max(1, height)
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextAutoExpandWidthForText: jest.fn(({
-    currentWidth,
-    minimumWidth
-  }: {
-    currentWidth: number
-    minimumWidth: number
-  }) => Math.max(currentWidth, minimumWidth)),
-  resolveGroupCenterPoint: jest.fn(({
-    left,
-    top,
-    canvasCenter
-  }: {
-    left?: number
-    top?: number
-    canvasCenter: { x: number; y: number }
-  }) => {
-    if (typeof left === 'number' && typeof top === 'number') {
-      return {
-        x: left,
-        y: top
-      }
-    }
-
-    return canvasCenter
-  })
-}))
 
 describe('shape-manager events', () => {
   const mocks = getShapeManagerUnitMocks()

--- a/specs/src/editor/shape-manager/shape-manager-mutation.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-mutation.spec.ts
@@ -1,3 +1,4 @@
+import '../../../test-utils/shape-manager-module-mocks'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import {
   applyShapeTextLayoutToMockGroup,
@@ -7,94 +8,6 @@ import {
   getShapeManagerUnitMocks,
   resetShapeManagerUnitMocks
 } from '../../../test-utils/shape-manager-spec-helpers'
-
-jest.mock('../../../../src/editor/shape-manager/shape-factory', () => ({
-  createShapeNode: jest.fn(),
-  applyShapeStyle: jest.fn(),
-  resizeShapeNode: jest.fn()
-}))
-
-jest.mock('../../../../src/editor/shape-manager/layout/shape-layout', () => ({
-  applyShapeTextLayout: jest.fn(),
-  resolveMinimumShapeWidthForText: jest.fn(() => 1),
-  resolveRequiredShapeHeightForText: jest.fn(({
-    height
-  }: {
-    height: number
-  }) => Math.max(1, height)),
-  resolveShapeTextFrameLayout: jest.fn(({
-    width,
-    padding
-  }: {
-    width: number
-    padding?: {
-      left?: number
-      right?: number
-    }
-  }) => ({
-    frame: {
-      left: padding?.left ?? 0,
-      width: Math.max(1, width - (padding?.left ?? 0) - (padding?.right ?? 0))
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextFixedWidthLayout: jest.fn(({
-    width,
-    height
-  }: {
-    width: number
-    height: number
-  }) => ({
-    width,
-    height,
-    appliedPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    appliedUserPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    frame: {
-      left: 0,
-      top: 0,
-      width: Math.max(1, width),
-      height: Math.max(1, height)
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextAutoExpandWidthForText: jest.fn(({
-    currentWidth,
-    minimumWidth
-  }: {
-    currentWidth: number
-    minimumWidth: number
-  }) => Math.max(currentWidth, minimumWidth)),
-  resolveGroupCenterPoint: jest.fn(({
-    left,
-    top,
-    canvasCenter
-  }: {
-    left?: number
-    top?: number
-    canvasCenter: { x: number; y: number }
-  }) => {
-    if (typeof left === 'number' && typeof top === 'number') {
-      return {
-        x: left,
-        y: top
-      }
-    }
-
-    return canvasCenter
-  })
-}))
 
 describe('shape-manager mutation', () => {
   const mocks = getShapeManagerUnitMocks()

--- a/specs/src/editor/shape-manager/shape-manager-rehydration.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-rehydration.spec.ts
@@ -1,0 +1,139 @@
+import '../../../test-utils/shape-manager-module-mocks'
+import ShapeManager from '../../../../src/editor/shape-manager'
+import {
+  createShapeManagerEditorStub,
+  createShapeRehydrationTarget,
+  getShapeManagerUnitMocks,
+  resetShapeManagerUnitMocks
+} from '../../../test-utils/shape-manager-spec-helpers'
+
+describe('восстановленная фигура', () => {
+  const mocks = getShapeManagerUnitMocks()
+  const { applyShapeTextLayoutMock } = mocks
+
+  beforeEach(() => {
+    resetShapeManagerUnitMocks(mocks)
+  })
+
+  it('получает итоговый размер до пересчёта текста', () => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const { group } = createShapeRehydrationTarget({
+      width: 200,
+      height: 100,
+      scaleX: 1.5,
+      scaleY: 2,
+      manualWidth: 180,
+      manualHeight: 90,
+      replaceBoxWidth: 210,
+      replaceBoxHeight: 120
+    })
+
+    const result = manager.commitRehydratedShapeLayout({
+      target: group
+    })
+    const layoutCall = applyShapeTextLayoutMock.mock.calls.at(-1)?.[0]
+
+    expect(result).toBe(true)
+    expect(layoutCall).toEqual(expect.objectContaining({
+      group,
+      width: 300,
+      height: 200
+    }))
+    expect(group.shapeBaseWidth).toBe(300)
+    expect(group.shapeBaseHeight).toBe(200)
+    expect(group.shapeManualBaseWidth).toBe(270)
+    expect(group.shapeManualBaseHeight).toBe(180)
+    expect(group.shapeReplaceBoxWidth).toBe(315)
+    expect(group.shapeReplaceBoxHeight).toBe(240)
+    expect(group.scaleX).toBe(1)
+    expect(group.scaleY).toBe(1)
+  })
+
+  it('текст внутри восстановленной фигуры масштабируется вместе с шаблоном', () => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const { group, text } = createShapeRehydrationTarget()
+
+    text.set({
+      fontSize: 20,
+      paddingTop: 2,
+      paddingRight: 3,
+      paddingBottom: 4,
+      paddingLeft: 5,
+      radiusTopLeft: 6,
+      radiusTopRight: 7,
+      radiusBottomRight: 8,
+      radiusBottomLeft: 9
+    })
+    text.lineFontDefaults = {
+      0: {
+        fontSize: 10
+      }
+    }
+    group.shapePaddingTop = 3
+    group.shapePaddingRight = 4
+    group.shapePaddingBottom = 5
+    group.shapePaddingLeft = 6
+
+    const result = manager.commitRehydratedShapeLayout({
+      target: group,
+      textScale: 2
+    })
+
+    expect(result).toBe(true)
+    expect(text.fontSize).toBe(40)
+    expect(text.lineFontDefaults?.[0]?.fontSize).toBe(20)
+    expect(text.paddingTop).toBe(4)
+    expect(text.paddingRight).toBe(6)
+    expect(text.paddingBottom).toBe(8)
+    expect(text.paddingLeft).toBe(10)
+    expect(text.radiusTopLeft).toBe(12)
+    expect(text.radiusTopRight).toBe(14)
+    expect(text.radiusBottomRight).toBe(16)
+    expect(text.radiusBottomLeft).toBe(18)
+    expect(group.shapePaddingTop).toBe(6)
+    expect(group.shapePaddingRight).toBe(8)
+    expect(group.shapePaddingBottom).toBe(10)
+    expect(group.shapePaddingLeft).toBe(12)
+  })
+
+  it('при обычном восстановлении не меняет визуальный размер текста', () => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const { group, text } = createShapeRehydrationTarget({
+      width: 200,
+      height: 100,
+      scaleX: 1.25,
+      scaleY: 1.5
+    })
+
+    text.set({
+      fontSize: 24,
+      paddingTop: 3,
+      radiusTopLeft: 5
+    })
+    group.shapePaddingTop = 7
+
+    const result = manager.commitRehydratedShapeLayout({
+      target: group
+    })
+    const layoutCall = applyShapeTextLayoutMock.mock.calls.at(-1)?.[0]
+
+    expect(result).toBe(true)
+    expect(layoutCall).toEqual(expect.objectContaining({
+      width: 250,
+      height: 150
+    }))
+    expect(text.fontSize).toBe(24)
+    expect(text.paddingTop).toBe(3)
+    expect(text.radiusTopLeft).toBe(5)
+    expect(group.shapePaddingTop).toBe(7)
+  })
+})

--- a/specs/src/editor/shape-manager/shape-manager-text.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-text.spec.ts
@@ -1,3 +1,4 @@
+import '../../../test-utils/shape-manager-module-mocks'
 import { Textbox } from 'fabric'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import {
@@ -10,94 +11,6 @@ import {
   getShapeManagerUnitMocks,
   resetShapeManagerUnitMocks
 } from '../../../test-utils/shape-manager-spec-helpers'
-
-jest.mock('../../../../src/editor/shape-manager/shape-factory', () => ({
-  createShapeNode: jest.fn(),
-  applyShapeStyle: jest.fn(),
-  resizeShapeNode: jest.fn()
-}))
-
-jest.mock('../../../../src/editor/shape-manager/layout/shape-layout', () => ({
-  applyShapeTextLayout: jest.fn(),
-  resolveMinimumShapeWidthForText: jest.fn(() => 1),
-  resolveRequiredShapeHeightForText: jest.fn(({
-    height
-  }: {
-    height: number
-  }) => Math.max(1, height)),
-  resolveShapeTextFrameLayout: jest.fn(({
-    width,
-    padding
-  }: {
-    width: number
-    padding?: {
-      left?: number
-      right?: number
-    }
-  }) => ({
-    frame: {
-      left: padding?.left ?? 0,
-      width: Math.max(1, width - (padding?.left ?? 0) - (padding?.right ?? 0))
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextFixedWidthLayout: jest.fn(({
-    width,
-    height
-  }: {
-    width: number
-    height: number
-  }) => ({
-    width,
-    height,
-    appliedPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    appliedUserPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    frame: {
-      left: 0,
-      top: 0,
-      width: Math.max(1, width),
-      height: Math.max(1, height)
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextAutoExpandWidthForText: jest.fn(({
-    currentWidth,
-    minimumWidth
-  }: {
-    currentWidth: number
-    minimumWidth: number
-  }) => Math.max(currentWidth, minimumWidth)),
-  resolveGroupCenterPoint: jest.fn(({
-    left,
-    top,
-    canvasCenter
-  }: {
-    left?: number
-    top?: number
-    canvasCenter: { x: number; y: number }
-  }) => {
-    if (typeof left === 'number' && typeof top === 'number') {
-      return {
-        x: left,
-        y: top
-      }
-    }
-
-    return canvasCenter
-  })
-}))
 
 describe('shape-manager text', () => {
   const mocks = getShapeManagerUnitMocks()

--- a/specs/src/editor/shape-manager/shape-manager-update.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-update.spec.ts
@@ -1,3 +1,4 @@
+import '../../../test-utils/shape-manager-module-mocks'
 import { Textbox } from 'fabric'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import {
@@ -10,94 +11,6 @@ import {
   getShapeManagerUnitMocks,
   resetShapeManagerUnitMocks
 } from '../../../test-utils/shape-manager-spec-helpers'
-
-jest.mock('../../../../src/editor/shape-manager/shape-factory', () => ({
-  createShapeNode: jest.fn(),
-  applyShapeStyle: jest.fn(),
-  resizeShapeNode: jest.fn()
-}))
-
-jest.mock('../../../../src/editor/shape-manager/layout/shape-layout', () => ({
-  applyShapeTextLayout: jest.fn(),
-  resolveMinimumShapeWidthForText: jest.fn(() => 1),
-  resolveRequiredShapeHeightForText: jest.fn(({
-    height
-  }: {
-    height: number
-  }) => Math.max(1, height)),
-  resolveShapeTextFrameLayout: jest.fn(({
-    width,
-    padding
-  }: {
-    width: number
-    padding?: {
-      left?: number
-      right?: number
-    }
-  }) => ({
-    frame: {
-      left: padding?.left ?? 0,
-      width: Math.max(1, width - (padding?.left ?? 0) - (padding?.right ?? 0))
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextFixedWidthLayout: jest.fn(({
-    width,
-    height
-  }: {
-    width: number
-    height: number
-  }) => ({
-    width,
-    height,
-    appliedPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    appliedUserPadding: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    },
-    frame: {
-      left: 0,
-      top: 0,
-      width: Math.max(1, width),
-      height: Math.max(1, height)
-    },
-    splitByGrapheme: false,
-    textTop: 0
-  })),
-  resolveShapeTextAutoExpandWidthForText: jest.fn(({
-    currentWidth,
-    minimumWidth
-  }: {
-    currentWidth: number
-    minimumWidth: number
-  }) => Math.max(currentWidth, minimumWidth)),
-  resolveGroupCenterPoint: jest.fn(({
-    left,
-    top,
-    canvasCenter
-  }: {
-    left?: number
-    top?: number
-    canvasCenter: { x: number; y: number }
-  }) => {
-    if (typeof left === 'number' && typeof top === 'number') {
-      return {
-        x: left,
-        y: top
-      }
-    }
-
-    return canvasCenter
-  })
-}))
 
 describe('shape-manager update', () => {
   const mocks = getShapeManagerUnitMocks()

--- a/specs/src/editor/template-manager/index.spec.ts
+++ b/specs/src/editor/template-manager/index.spec.ts
@@ -53,6 +53,46 @@ describe('TemplateManager', () => {
     expect(editor.historyManager.saveState).toHaveBeenCalled()
   })
 
+  it('текст внутри фигуры из шаблона пересчитывается с масштабом монтажной области', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup({
+      montageBounds: {
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 600
+      }
+    })
+    const group = new ShapeGroupObject([
+      createMockShapeNode() as never,
+      createMockShapeTextbox({ text: 'Template text' })
+    ], {
+      left: 100,
+      top: 100,
+      shapePresetKey: 'square'
+    })
+
+    jest.spyOn(util, 'enlivenObjects').mockResolvedValue([group])
+
+    const result = await manager.applyTemplate({
+      template: createShapeTemplateDefinition()
+    })
+
+    const commitRehydratedShapeLayoutMock = editor.shapeManager.commitRehydratedShapeLayout as jest.Mock
+
+    expect(result).toEqual([group])
+    expect(commitRehydratedShapeLayoutMock).toHaveBeenCalledWith({
+      target: group,
+      textScale: 2
+    })
+    expect(commitRehydratedShapeLayoutMock.mock.invocationCallOrder[0]).toBeLessThan(
+      editor.canvas.add.mock.invocationCallOrder[0]
+    )
+    expect(editor.errorManager.emitError).not.toHaveBeenCalled()
+  })
+
   it('сохраняет auto-expand у текста внутри фигуры из шаблона', async() => {
     const {
       manager,

--- a/specs/src/editor/text-manager/index.spec.ts
+++ b/specs/src/editor/text-manager/index.spec.ts
@@ -46,7 +46,7 @@ describe('TextManager', () => {
       expect(canvas.setActiveObject).toHaveBeenCalledWith(textbox)
       expect(canvas.requestRenderAll).toHaveBeenCalledTimes(1)
 
-      expect(textbox.id).toBe('text-mocked-id')
+      expect(textbox.id).toBe('background-textbox-mocked-id')
       expect(textbox.text).toBe('Привет')
       expect(textbox.textCaseRaw).toBe('Привет')
 

--- a/specs/test-utils/editor-helpers.ts
+++ b/specs/test-utils/editor-helpers.ts
@@ -1481,7 +1481,16 @@ export const createMockActiveSelection = (objects: any[], props: any = {}) => {
   // Добавляем методы моков
   mockSelection.clone = jest.fn().mockImplementation(async() => {
     // Глубокое копирование для избежания shared references
-    const clonedObjects = objects.map((obj) => ({ ...obj }))
+    const clonedObjects = objects.map((object) => {
+      const clonedObject = { ...object }
+
+      clonedObject.set = jest.fn().mockImplementation((newProps) => {
+        Object.assign(clonedObject, newProps)
+      })
+      clonedObject.setCoords = jest.fn()
+
+      return clonedObject
+    })
     const clonedProps = JSON.parse(JSON.stringify(props))
     const cloned = new ActiveSelection(clonedObjects, clonedProps) as any
     cloned.set = jest.fn().mockImplementation((newProps) => {

--- a/specs/test-utils/editor-helpers.ts
+++ b/specs/test-utils/editor-helpers.ts
@@ -453,7 +453,8 @@ export const createEditorStub = () => {
       refresh: jest.fn()
     },
     shapeManager: {
-      addRectangle: jest.fn()
+      addRectangle: jest.fn(),
+      commitRehydratedShapeLayout: jest.fn()
     },
     montageArea,
     options: {
@@ -509,7 +510,8 @@ export const createEditorWithMocks = (options: Partial<CanvasOptions> = {}) => {
   } as any
 
   editor.shapeManager = {
-    addRectangle: jest.fn()
+    addRectangle: jest.fn(),
+    commitRehydratedShapeLayout: jest.fn()
   } as any
 
   editor.panConstraintManager = {
@@ -967,6 +969,9 @@ export const createHistoryManagerTestSetup = (
     textManager: {
       commitStandaloneTextScale: jest.fn()
     },
+    shapeManager: {
+      commitRehydratedShapeLayout: jest.fn()
+    },
     options: {
       maxHistoryLength
     }
@@ -1201,6 +1206,9 @@ export const createTextManagerTestSetup = (
     },
     snappingManager: {
       applyTextResizingSnap: jest.fn()
+    },
+    shapeManager: {
+      commitRehydratedShapeLayout: jest.fn()
     }
   } as any
 

--- a/specs/test-utils/shape-helpers.ts
+++ b/specs/test-utils/shape-helpers.ts
@@ -23,6 +23,8 @@ type PlacementOriginX = 'left' | 'center' | 'right'
 type PlacementOriginY = 'top' | 'center' | 'bottom'
 
 type MockShapeNode = {
+  id?: string
+  type: string
   shapeNodeType: 'shape'
   width: number
   height: number
@@ -112,15 +114,21 @@ export const createMockCanvas = (): MockCanvas => {
  * Создаёт shape-узел с set/setCoords.
  */
 export const createMockShapeNode = ({
+  id,
+  type = 'rect',
   width = 180,
   height = 180,
   opacity = 1
 }: {
+  id?: string
+  type?: string
   width?: number
   height?: number
   opacity?: number
 } = {}): MockShapeNode => {
   const shape = {
+    id,
+    type,
     shapeNodeType: 'shape' as const,
     width,
     height,

--- a/specs/test-utils/shape-manager-module-mocks.ts
+++ b/specs/test-utils/shape-manager-module-mocks.ts
@@ -1,0 +1,89 @@
+jest.mock('../../src/editor/shape-manager/shape-factory', () => ({
+  createShapeNode: jest.fn(),
+  applyShapeStyle: jest.fn(),
+  resizeShapeNode: jest.fn()
+}))
+
+jest.mock('../../src/editor/shape-manager/layout/shape-layout', () => ({
+  applyShapeTextLayout: jest.fn(),
+  resolveMinimumShapeWidthForText: jest.fn(() => 1),
+  resolveRequiredShapeHeightForText: jest.fn(({
+    height
+  }: {
+    height: number
+  }) => Math.max(1, height)),
+  resolveShapeTextFrameLayout: jest.fn(({
+    width,
+    padding
+  }: {
+    width: number
+    padding?: {
+      left?: number
+      right?: number
+    }
+  }) => ({
+    frame: {
+      left: padding?.left ?? 0,
+      width: Math.max(1, width - (padding?.left ?? 0) - (padding?.right ?? 0))
+    },
+    splitByGrapheme: false,
+    textTop: 0
+  })),
+  resolveShapeTextFixedWidthLayout: jest.fn(({
+    width,
+    height
+  }: {
+    width: number
+    height: number
+  }) => ({
+    width,
+    height,
+    appliedPadding: {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0
+    },
+    appliedUserPadding: {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0
+    },
+    frame: {
+      left: 0,
+      top: 0,
+      width: Math.max(1, width),
+      height: Math.max(1, height)
+    },
+    splitByGrapheme: false,
+    textTop: 0
+  })),
+  resolveShapeTextAutoExpandWidthForText: jest.fn(({
+    currentWidth,
+    minimumWidth
+  }: {
+    currentWidth: number
+    minimumWidth: number
+  }) => Math.max(currentWidth, minimumWidth)),
+  resolveGroupCenterPoint: jest.fn(({
+    left,
+    top,
+    canvasCenter
+  }: {
+    left?: number
+    top?: number
+    canvasCenter: { x: number; y: number }
+  }) => {
+    if (typeof left === 'number' && typeof top === 'number') {
+      return {
+        x: left,
+        y: top
+      }
+    }
+
+    return canvasCenter
+  })
+}))
+
+export {}

--- a/specs/test-utils/shape-manager-spec-helpers.ts
+++ b/specs/test-utils/shape-manager-spec-helpers.ts
@@ -13,7 +13,9 @@ import {
 import {
   applyShapeTextLayoutToMockGroup,
   applyTextStyleToShapeText,
+  createMockShapeGroup,
   createMockShapeNode,
+  createMockShapeTextbox,
   createShapeManagerEditorStub,
   getCanvasEventPayloads,
   getCanvasHandler,
@@ -104,6 +106,54 @@ export const resetShapeManagerUnitMocks = ({
     currentWidth: number
     minimumWidth: number
   }) => Math.max(currentWidth, minimumWidth))
+}
+
+export const createShapeRehydrationTarget = ({
+  width = 200,
+  height = 100,
+  scaleX = 1,
+  scaleY = 1,
+  manualWidth = width,
+  manualHeight = height,
+  replaceBoxWidth = width,
+  replaceBoxHeight = height
+}: {
+  width?: number
+  height?: number
+  scaleX?: number
+  scaleY?: number
+  manualWidth?: number
+  manualHeight?: number
+  replaceBoxWidth?: number
+  replaceBoxHeight?: number
+} = {}) => {
+  const shape = createMockShapeNode({
+    width,
+    height
+  })
+  const text = createMockShapeTextbox({
+    text: 'Shape text',
+    width
+  })
+  const group = createMockShapeGroup({
+    shape,
+    text,
+    width,
+    height
+  })
+
+  group.scaleX = scaleX
+  group.scaleY = scaleY
+  group.shapeManualBaseWidth = manualWidth
+  group.shapeManualBaseHeight = manualHeight
+  group.shapeReplaceBoxWidth = replaceBoxWidth
+  group.shapeReplaceBoxHeight = replaceBoxHeight
+
+  return {
+    group,
+    shape,
+    text
+  }
 }
 
 export {

--- a/src/editor/clipboard-manager/index.ts
+++ b/src/editor/clipboard-manager/index.ts
@@ -256,7 +256,7 @@ export default class ClipboardManager {
 
     const shouldEnableChildEvented = clonedObject instanceof ActiveSelection
 
-    clonedObject.forEachObject((object) => {
+    clonedObject.getObjects().forEach((object) => {
       this._materializeCloneIdentity({
         clonedObject: object,
         enableEvented: shouldEnableChildEvented

--- a/src/editor/clipboard-manager/index.ts
+++ b/src/editor/clipboard-manager/index.ts
@@ -1,4 +1,4 @@
-import { ActiveSelection, FabricObject } from 'fabric'
+import { ActiveSelection, FabricObject, Group } from 'fabric'
 import { nanoid } from 'nanoid'
 import { CLIPBOARD_DATA_PREFIX, CLIPBOARD_CLONE_OBJECT_KEYS } from '../constants'
 
@@ -57,7 +57,7 @@ export default class ClipboardManager {
 
     try {
       const clonedObject = await activeObject.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
-      this._rehydrateStandaloneTextOnClone({
+      this._materializeCloneGeometry({
         clonedObject
       })
       this.clipboard = clonedObject
@@ -202,15 +202,20 @@ export default class ClipboardManager {
   }
 
   /**
-   * Материализует standalone-text в clone до добавления на canvas и в internal clipboard.
+   * Материализует clone в каноническую геометрию до добавления на canvas и в internal clipboard.
    */
-  private _rehydrateStandaloneTextOnClone({ clonedObject }: { clonedObject: FabricObject }): void {
-    const { textManager } = this.editor
-    if (!textManager) return
+  private _materializeCloneGeometry({ clonedObject }: { clonedObject: FabricObject }): void {
+    const {
+      shapeManager,
+      textManager
+    } = this.editor
 
     if (clonedObject instanceof ActiveSelection) {
       clonedObject.forEachObject((object) => {
         textManager.commitStandaloneTextScale({
+          target: object
+        })
+        shapeManager.commitRehydratedShapeLayout({
           target: object
         })
       })
@@ -220,6 +225,42 @@ export default class ClipboardManager {
 
     textManager.commitStandaloneTextScale({
       target: clonedObject
+    })
+    shapeManager.commitRehydratedShapeLayout({
+      target: clonedObject
+    })
+  }
+
+  /**
+   * Назначает свежие id клону и всем вложенным объектам перед вставкой на canvas.
+   * `evented` восстанавливается только у объектов верхнего уровня, которые реально добавляются на canvas.
+   */
+  private _materializeCloneIdentity({
+    clonedObject,
+    enableEvented = true
+  }: {
+    clonedObject: FabricObject
+    enableEvented?: boolean
+  }): void {
+    clonedObject.set({
+      id: `${clonedObject.type}-${nanoid()}`
+    })
+
+    if (enableEvented) {
+      clonedObject.set({
+        evented: true
+      })
+    }
+
+    if (!(clonedObject instanceof Group)) return
+
+    const shouldEnableChildEvented = clonedObject instanceof ActiveSelection
+
+    clonedObject.forEachObject((object) => {
+      this._materializeCloneIdentity({
+        clonedObject: object,
+        enableEvented: shouldEnableChildEvented
+      })
     })
   }
 
@@ -331,25 +372,16 @@ export default class ClipboardManager {
       // Используем асинхронное клонирование для корректной работы с SVG и сложными объектами
       const clonedObject = await targetObject.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
 
-      // Устанавливаем новые координаты и ID
-      if (clonedObject instanceof ActiveSelection) {
-        // Для ActiveSelection обновляем каждый объект внутри
-        clonedObject.forEachObject((obj) => {
-          obj.set({
-            id: `${obj.type}-${nanoid()}`,
-            evented: true
-          })
-        })
-      }
-
-      clonedObject.set({
-        id: `${clonedObject.type}-${nanoid()}`,
-        left: clonedObject.left + 10,
-        top: clonedObject.top + 10,
-        evented: true
+      this._materializeCloneIdentity({
+        clonedObject
       })
 
-      this._rehydrateStandaloneTextOnClone({
+      clonedObject.set({
+        left: clonedObject.left + 10,
+        top: clonedObject.top + 10
+      })
+
+      this._materializeCloneGeometry({
         clonedObject
       })
 
@@ -461,25 +493,16 @@ export default class ClipboardManager {
 
       canvas.discardActiveObject()
 
-      // Устанавливаем новые координаты и ID
-      if (clonedObj instanceof ActiveSelection) {
-        // Для ActiveSelection обновляем каждый объект внутри
-        clonedObj.forEachObject((obj) => {
-          obj.set({
-            id: `${obj.type}-${nanoid()}`,
-            evented: true
-          })
-        })
-      }
-
-      clonedObj.set({
-        id: `${clonedObj.type}-${nanoid()}`,
-        left: clonedObj.left + 10,
-        top: clonedObj.top + 10,
-        evented: true
+      this._materializeCloneIdentity({
+        clonedObject: clonedObj
       })
 
-      this._rehydrateStandaloneTextOnClone({
+      clonedObj.set({
+        left: clonedObj.left + 10,
+        top: clonedObj.top + 10
+      })
+
+      this._materializeCloneGeometry({
         clonedObject: clonedObj
       })
 

--- a/src/editor/clipboard-manager/index.ts
+++ b/src/editor/clipboard-manager/index.ts
@@ -252,9 +252,10 @@ export default class ClipboardManager {
       })
     }
 
-    if (!(clonedObject instanceof Group)) return
-
     const shouldEnableChildEvented = clonedObject instanceof ActiveSelection
+    const isNestedContainer = shouldEnableChildEvented || clonedObject instanceof Group
+
+    if (!isNestedContainer) return
 
     clonedObject.getObjects().forEach((object) => {
       this._materializeCloneIdentity({

--- a/src/editor/constants.ts
+++ b/src/editor/constants.ts
@@ -22,6 +22,7 @@ export const CLIPBOARD_DATA_PREFIX = 'application/image-editor:'
  * Ключи объекта, которые нужно сохранить при клонировании объекта для отправки в буфер обмена
  */
 export const CLIPBOARD_CLONE_OBJECT_KEYS = [
+  'id',
   'customData',
   'backgroundType',
   'format',

--- a/src/editor/history-manager/index.ts
+++ b/src/editor/history-manager/index.ts
@@ -577,8 +577,9 @@ export default class HistoryManager {
    * Состояние должно быть сохранено уже в канонической scene model.
    * После десериализации редактор синхронизирует derived geometry и camera-state
    * с текущим viewport контейнера, не восстанавливая legacy placement.
-   * Для standalone text после loadFromJSON дополнительно материализуется transient scale,
-   * чтобы дальнейшие resize/scale сценарии работали из единого persisted-контракта.
+   * Для standalone text и shape-композиций после loadFromJSON дополнительно материализуется
+   * transient scale, чтобы дальнейшие resize/scale и text-layout сценарии работали
+   * из единого persisted-контракта.
    * @fires editor:history-state-loaded
    */
   public async loadStateFromFullState(fullState: CanvasFullState): Promise<void> {
@@ -630,14 +631,19 @@ export default class HistoryManager {
       backgroundManager.backgroundObject = loadedBackgroundObject as Rect | FabricImage
     }
 
-    const { textManager } = this.editor
-    if (textManager) {
-      canvas.getObjects().forEach((object) => {
-        textManager.commitStandaloneTextScale({
-          target: object
-        })
+    const {
+      textManager,
+      shapeManager
+    } = this.editor
+
+    canvas.getObjects().forEach((object) => {
+      textManager.commitStandaloneTextScale({
+        target: object
       })
-    }
+      shapeManager.commitRehydratedShapeLayout({
+        target: object
+      })
+    })
 
     if (loadedMontage) {
       interactionBlocker.ensureOverlay()

--- a/src/editor/shape-manager/index.ts
+++ b/src/editor/shape-manager/index.ts
@@ -8,6 +8,10 @@ import { nanoid } from 'nanoid'
 import { ImageEditor } from '../index'
 import type { ObjectPlacement } from '../canvas-manager'
 import type { TextStyleOptions } from '../text-manager'
+import {
+  applyScaledTextboxVisualState,
+  captureTextScaleBase
+} from '../text-manager/scaling/text-scaling-materialization'
 import type {
   BeforeTextUpdatedPayload,
   TextUpdatedPayload
@@ -1275,6 +1279,105 @@ export default class ShapeManager {
         withoutSave
       }
     })
+  }
+
+  /**
+   * Материализует shape-группу после clone/deserialize/template-scale
+   * в тот же канонический layout-контракт, который используется в add/update/edit path.
+   * Запекает transient group scale в base/manual/replaceBox размеры и пересчитывает layout текста.
+   * При `textScale` дополнительно запекает scene-scale в визуальное состояние текста внутри фигуры
+   * и в пользовательский padding шейпа до layout-пересчета.
+   */
+  public commitRehydratedShapeLayout({
+    target,
+    textScale = 1
+  }: {
+    target?: ShapeReference
+    textScale?: number
+  }): boolean {
+    const group = this._resolveShapeGroup({ target })
+    if (!group) return false
+
+    const {
+      shape,
+      text
+    } = getShapeNodes({ group })
+    if (!shape || !text) return false
+
+    const placement = this.editor.canvasManager.getObjectPlacement({ object: group })
+    const {
+      shapeAlignHorizontal = SHAPE_DEFAULT_HORIZONTAL_ALIGN,
+      shapeAlignVertical = SHAPE_DEFAULT_VERTICAL_ALIGN,
+      shapeBaseWidth,
+      shapeBaseHeight,
+      shapeManualBaseWidth,
+      shapeManualBaseHeight,
+      shapeReplaceBoxWidth,
+      shapeReplaceBoxHeight,
+      shapePaddingTop = 0,
+      shapePaddingRight = 0,
+      shapePaddingBottom = 0,
+      shapePaddingLeft = 0,
+      width: groupWidth,
+      height: groupHeight
+    } = group
+    const scaleX = Math.abs(group.scaleX ?? 1) || 1
+    const scaleY = Math.abs(group.scaleY ?? 1) || 1
+    const resolvedTextScale = Number.isFinite(textScale) && textScale > 0
+      ? textScale
+      : 1
+    const baseWidth = Math.max(1, shapeBaseWidth ?? groupWidth ?? 1)
+    const baseHeight = Math.max(1, shapeBaseHeight ?? groupHeight ?? 1)
+    const currentDimensions = {
+      width: Math.max(1, baseWidth * scaleX),
+      height: Math.max(1, baseHeight * scaleY)
+    }
+    const manualDimensions = {
+      width: Math.max(1, (shapeManualBaseWidth ?? baseWidth) * scaleX),
+      height: Math.max(1, (shapeManualBaseHeight ?? baseHeight) * scaleY)
+    }
+    const replaceBoxDimensions = {
+      width: Math.max(1, (shapeReplaceBoxWidth ?? baseWidth) * scaleX),
+      height: Math.max(1, (shapeReplaceBoxHeight ?? baseHeight) * scaleY)
+    }
+
+    if (Math.abs(resolvedTextScale - 1) > 0.0001) {
+      const textScaleBase = captureTextScaleBase({
+        textbox: text
+      })
+
+      applyScaledTextboxVisualState({
+        textbox: text,
+        base: textScaleBase,
+        scale: resolvedTextScale
+      })
+
+      group.shapePaddingTop = Math.max(0, shapePaddingTop * resolvedTextScale)
+      group.shapePaddingRight = Math.max(0, shapePaddingRight * resolvedTextScale)
+      group.shapePaddingBottom = Math.max(0, shapePaddingBottom * resolvedTextScale)
+      group.shapePaddingLeft = Math.max(0, shapePaddingLeft * resolvedTextScale)
+    }
+
+    this._detachShapeGroupAutoLayout({
+      group
+    })
+
+    group.shapeManualBaseWidth = manualDimensions.width
+    group.shapeManualBaseHeight = manualDimensions.height
+
+    this._applyCurrentLayout({
+      group,
+      shape,
+      text,
+      placement,
+      width: currentDimensions.width,
+      height: currentDimensions.height,
+      alignH: shapeAlignHorizontal,
+      alignV: shapeAlignVertical,
+      minimumReplaceBox: replaceBoxDimensions
+    })
+
+    return true
   }
 
   /**

--- a/src/editor/shape-manager/shape-factory.ts
+++ b/src/editor/shape-manager/shape-factory.ts
@@ -10,6 +10,7 @@ import {
   loadSVGFromString,
   util
 } from 'fabric'
+import { nanoid } from 'nanoid'
 import {
   ShapeFactoryInput,
   ShapeNode,
@@ -731,7 +732,7 @@ async function createShapeObjectByPreset({
 }
 
 /**
- * Создает объект фигуры из пресета и применяет к нему стили.
+ * Создает объект фигуры из пресета, назначает ему id и применяет стили.
  */
 export async function createShapeNode({
   preset,
@@ -759,6 +760,7 @@ export async function createShapeNode({
   })
 
   shape.set({
+    id: `${shape.type}-${nanoid()}`,
     selectable: false,
     evented: false,
     hasControls: false,

--- a/src/editor/template-manager/index.ts
+++ b/src/editor/template-manager/index.ts
@@ -164,8 +164,8 @@ export default class TemplateManager {
    * Применяет шаблон к монтажной области без очистки текущих объектов.
    * @param options
    * @param options.template - описание шаблона.
-   * Standalone text после rehydration приводится к канонической геометрии до добавления на canvas,
-   * чтобы template-path не оставлял смешанное width/scale состояние.
+   * Standalone text и shape-композиции после rehydration приводятся к канонической геометрии
+   * до добавления на canvas, чтобы template-path не оставлял смешанное width/scale состояние.
    */
   public async applyTemplate({
     template
@@ -175,7 +175,9 @@ export default class TemplateManager {
       montageArea,
       historyManager,
       errorManager,
-      backgroundManager
+      backgroundManager,
+      shapeManager,
+      textManager
     } = this.editor
 
     const { objects, meta: templateMeta, id: templateId } = template ?? {}
@@ -238,7 +240,7 @@ export default class TemplateManager {
         })
       }
 
-      // Применяем текстовые подстановки, трансформируем координаты и добавляем объекты на канвас
+      // Материализуем type-specific geometry, трансформируем координаты и добавляем объекты на канвас
       const insertedObjects = contentObjects.map((object) => {
         this._adaptTextboxWidth({
           object,
@@ -254,8 +256,12 @@ export default class TemplateManager {
           useRelativePositions
         })
 
-        this.editor.textManager?.commitStandaloneTextScale({
+        textManager.commitStandaloneTextScale({
           target: object
+        })
+        shapeManager.commitRehydratedShapeLayout({
+          target: object,
+          textScale: scale
         })
 
         snapObjectToPixelGrid({ object })

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -142,7 +142,7 @@ export default class TextManager {
    */
   public addText(
     {
-      id = `text-${nanoid()}`,
+      id = `background-textbox-${nanoid()}`,
       text = 'Новый текст',
       autoExpand = true,
       fontFamily,

--- a/src/editor/text-manager/scaling/text-scaling-materialization.ts
+++ b/src/editor/text-manager/scaling/text-scaling-materialization.ts
@@ -50,6 +50,15 @@ type CommitStandaloneTextScaleOptions = {
   shouldRoundDimensions?: boolean
 }
 
+type ApplyScaledTextboxVisualStateOptions = {
+  textbox: EditorTextbox
+  base: TextScaleBaseState
+  scale: number
+  shouldScaleFontSize?: boolean
+  shouldScalePadding?: boolean
+  shouldScaleRadii?: boolean
+}
+
 /**
  * Снимает с textbox базовое состояние, относительно которого можно материализовать transient scale.
  */
@@ -138,6 +147,105 @@ export const resolveMinimumTextScalingBounds = (
 }
 
 /**
+ * Запекает масштаб в визуальные свойства textbox без изменения его placement и ширины.
+ * Используется там, где геометрией объекта управляет другой доменный слой.
+ */
+export const applyScaledTextboxVisualState = ({
+  textbox,
+  base,
+  scale,
+  shouldScaleFontSize = true,
+  shouldScalePadding = true,
+  shouldScaleRadii = true
+}: ApplyScaledTextboxVisualStateOptions): void => {
+  const {
+    fontSize: baseFontSize,
+    padding: basePadding,
+    radii: baseRadii,
+    styles: baseStyles,
+    lineFontDefaults: baseLineFontDefaults
+  } = base
+  const minimumBaseFontSize = Math.min(MIN_TEXTBOX_FONT_SIZE, baseFontSize)
+  const nextFontSize = Math.max(minimumBaseFontSize, baseFontSize * scale)
+  const hasBaseStyles = Object.keys(baseStyles).length > 0
+  let nextStyles: EditorTextbox['styles'] | undefined
+
+  if (shouldScaleFontSize && hasBaseStyles) {
+    const scaledStyles: TextboxStyles = {}
+
+    Object.entries(baseStyles).forEach(([lineIndex, lineStyles]) => {
+      if (!lineStyles) return
+
+      const scaledLineStyles: Record<string, TextboxProps> = {}
+      Object.entries(lineStyles as Record<string, TextboxProps>).forEach(([charIndex, charStyle]) => {
+        if (!charStyle) return
+
+        const nextCharStyle: TextboxProps = { ...charStyle }
+        if (typeof charStyle.fontSize === 'number') {
+          const minimumCharFontSize = Math.min(MIN_TEXTBOX_FONT_SIZE, charStyle.fontSize)
+          nextCharStyle.fontSize = Math.max(minimumCharFontSize, charStyle.fontSize * scale)
+        }
+
+        scaledLineStyles[charIndex] = nextCharStyle
+      })
+
+      if (Object.keys(scaledLineStyles).length) {
+        scaledStyles[lineIndex] = scaledLineStyles
+      }
+    })
+
+    if (Object.keys(scaledStyles).length) {
+      nextStyles = scaledStyles
+    }
+  }
+
+  let nextLineFontDefaults: LineFontDefaults | undefined
+  if (shouldScaleFontSize) {
+    nextLineFontDefaults = scaleLineFontDefaults({
+      lineFontDefaults: baseLineFontDefaults,
+      scale
+    })
+  }
+
+  const nextPadding: PaddingValues = shouldScalePadding
+    ? {
+      top: Math.max(0, basePadding.top * scale),
+      right: Math.max(0, basePadding.right * scale),
+      bottom: Math.max(0, basePadding.bottom * scale),
+      left: Math.max(0, basePadding.left * scale)
+    }
+    : basePadding
+  const nextRadii: CornerRadiiValues = shouldScaleRadii
+    ? {
+      topLeft: Math.max(0, baseRadii.topLeft * scale),
+      topRight: Math.max(0, baseRadii.topRight * scale),
+      bottomRight: Math.max(0, baseRadii.bottomRight * scale),
+      bottomLeft: Math.max(0, baseRadii.bottomLeft * scale)
+    }
+    : baseRadii
+
+  if (nextStyles) {
+    textbox.styles = nextStyles
+  }
+
+  if (nextLineFontDefaults) {
+    textbox.lineFontDefaults = nextLineFontDefaults
+  }
+
+  textbox.set({
+    fontSize: shouldScaleFontSize ? nextFontSize : baseFontSize,
+    paddingTop: nextPadding.top,
+    paddingRight: nextPadding.right,
+    paddingBottom: nextPadding.bottom,
+    paddingLeft: nextPadding.left,
+    radiusTopLeft: nextRadii.topLeft,
+    radiusTopRight: nextRadii.topRight,
+    radiusBottomRight: nextRadii.bottomRight,
+    radiusBottomLeft: nextRadii.bottomLeft
+  })
+}
+
+/**
  * Материализует transient scale standalone-textbox в канонические width/font/padding/radius значения.
  * `placement` здесь означает стабильный placement самого объекта,
  * а `anchorPlacement` — временную точку удержания текущего drag.
@@ -158,75 +266,10 @@ export const commitStandaloneTextboxScale = (
     shouldRoundDimensions = true
   }: CommitStandaloneTextScaleOptions
 ): CommitStandaloneTextScaleResult => {
-  const {
-    width: baseWidth,
-    fontSize: baseFontSize,
-    padding: basePadding,
-    radii: baseRadii,
-    styles: baseStyles,
-    lineFontDefaults: baseLineFontDefaults
-  } = base
+  const { width: baseWidth } = base
   const nextWidth = Math.max(1, baseWidth * widthScale)
   const roundedNextWidth = Math.max(1, Math.round(nextWidth))
   const committedWidth = shouldRoundDimensions ? roundedNextWidth : nextWidth
-  const minimumBaseFontSize = Math.min(MIN_TEXTBOX_FONT_SIZE, baseFontSize)
-  const nextFontSize = Math.max(minimumBaseFontSize, baseFontSize * heightScale)
-  const hasBaseStyles = Object.keys(baseStyles).length > 0
-  let nextStyles: EditorTextbox['styles'] | undefined
-
-  if (shouldScaleFontSize && hasBaseStyles) {
-    const scaledStyles: TextboxStyles = {}
-
-    Object.entries(baseStyles).forEach(([lineIndex, lineStyles]) => {
-      if (!lineStyles) return
-
-      const scaledLineStyles: Record<string, TextboxProps> = {}
-      Object.entries(lineStyles as Record<string, TextboxProps>).forEach(([charIndex, charStyle]) => {
-        if (!charStyle) return
-
-        const nextCharStyle: TextboxProps = { ...charStyle }
-        if (typeof charStyle.fontSize === 'number') {
-          const minimumCharFontSize = Math.min(MIN_TEXTBOX_FONT_SIZE, charStyle.fontSize)
-          nextCharStyle.fontSize = Math.max(minimumCharFontSize, charStyle.fontSize * heightScale)
-        }
-
-        scaledLineStyles[charIndex] = nextCharStyle
-      })
-
-      if (Object.keys(scaledLineStyles).length) {
-        scaledStyles[lineIndex] = scaledLineStyles
-      }
-    })
-
-    if (Object.keys(scaledStyles).length) {
-      nextStyles = scaledStyles
-    }
-  }
-
-  let nextLineFontDefaults: LineFontDefaults | undefined
-  if (shouldScaleFontSize) {
-    nextLineFontDefaults = scaleLineFontDefaults({
-      lineFontDefaults: baseLineFontDefaults,
-      scale: heightScale
-    })
-  }
-
-  const nextPadding: PaddingValues = shouldScalePadding
-    ? {
-      top: Math.max(0, basePadding.top * heightScale),
-      right: Math.max(0, basePadding.right * heightScale),
-      bottom: Math.max(0, basePadding.bottom * heightScale),
-      left: Math.max(0, basePadding.left * heightScale)
-    }
-    : basePadding
-  const nextRadii: CornerRadiiValues = shouldScaleRadii
-    ? {
-      topLeft: Math.max(0, baseRadii.topLeft * heightScale),
-      topRight: Math.max(0, baseRadii.topRight * heightScale),
-      bottomRight: Math.max(0, baseRadii.bottomRight * heightScale),
-      bottomLeft: Math.max(0, baseRadii.bottomLeft * heightScale)
-    }
-    : baseRadii
   const currentWidth = textbox.width ?? baseWidth
   const widthChanged = Math.abs(committedWidth - currentWidth) > DIMENSION_EPSILON
 
@@ -234,25 +277,17 @@ export const commitStandaloneTextboxScale = (
     textbox.autoExpand = false
   }
 
-  if (nextStyles) {
-    textbox.styles = nextStyles
-  }
-
-  if (nextLineFontDefaults) {
-    textbox.lineFontDefaults = nextLineFontDefaults
-  }
+  applyScaledTextboxVisualState({
+    textbox,
+    base,
+    scale: heightScale,
+    shouldScaleFontSize,
+    shouldScalePadding,
+    shouldScaleRadii
+  })
 
   textbox.set({
     width: committedWidth,
-    fontSize: shouldScaleFontSize ? nextFontSize : baseFontSize,
-    paddingTop: nextPadding.top,
-    paddingRight: nextPadding.right,
-    paddingBottom: nextPadding.bottom,
-    paddingLeft: nextPadding.left,
-    radiusTopLeft: nextRadii.topLeft,
-    radiusTopRight: nextRadii.topRight,
-    radiusBottomRight: nextRadii.bottomRight,
-    radiusBottomLeft: nextRadii.bottomLeft,
     scaleX: 1,
     scaleY: 1
   })


### PR DESCRIPTION
- TemplateManager. При применении шаблона пересчитываем размеры шейпов, а также тексты внутри шейпов.
- ClipboardManager. При копировании объектов всегда сохраняем ID, а при вставке генерируем новые в зависимости от типа объекта. 
- TextManager. id при добавлении объекта должен быть background-textbox, а не text. 
- ShapeManager. При добавлении шейпа не забываем задавать id для дочерних объектов группы.