### PR TITLE
TextManager. Сохраняем стилизации для разных строк в текстовых объектах

### DIFF
--- a/e2e/fixtures/data/text-line-style.data.ts
+++ b/e2e/fixtures/data/text-line-style.data.ts
@@ -1,0 +1,107 @@
+import type {
+  ShapeAddParams,
+  ShapeTextStyleParams,
+  TextAddParams,
+  TextSelectionStyleInfo,
+  TextStyleParams
+} from '../../types'
+
+export const TEXT_LINE_STYLE_INITIAL_TEXT = 'TEST \n TEST TEXT'
+export const TEXT_LINE_STYLE_FIRST_LINE_TEXT = 'FIRST LINE'
+export const TEXT_LINE_STYLE_SECOND_LINE_TEXT = 'SECOND LINE'
+export const TEXT_LINE_STYLE_THREE_LINE_TEXT = 'FIRST\nSECOND\nTHIRD'
+export const TEXT_LINE_STYLE_AFTER_LINE_REMOVAL_TEXT = 'FIRST\nTHIRD'
+export const TEXT_LINE_STYLE_AFTER_LINE_INSERT_TEXT = 'FIRST\nNEW\nTHIRD'
+
+export const TEXT_LINE_STYLE_FIRST_LINE_SELECTION = {
+  start: 0,
+  end: 5
+}
+
+export const TEXT_LINE_STYLE_SECOND_LINE_SELECTION = {
+  start: 6,
+  end: TEXT_LINE_STYLE_INITIAL_TEXT.length
+}
+
+export const TEXT_LINE_STYLE_DELETED_LINE_SELECTION = {
+  start: 6,
+  end: 12
+}
+
+export const TEXT_LINE_STYLE_BASE_TEXT_STYLE = {
+  color: '#111111',
+  fontFamily: 'Roboto',
+  fontSize: 48
+} satisfies TextStyleParams & ShapeTextStyleParams
+
+export const TEXT_LINE_STYLE_FIRST_LINE_STYLE = {
+  bold: true,
+  color: '#ff8800',
+  fontFamily: 'Exo 2',
+  fontSize: 36,
+  italic: true,
+  strokeColor: '#333333',
+  strokeWidth: 1,
+  strikethrough: true,
+  underline: true
+} satisfies TextStyleParams & ShapeTextStyleParams
+
+export const TEXT_LINE_STYLE_SECOND_LINE_STYLE = {
+  bold: true,
+  color: '#ff8800',
+  fontFamily: 'Oswald',
+  fontSize: 24,
+  italic: true,
+  strokeColor: '#333333',
+  strokeWidth: 1,
+  strikethrough: true,
+  underline: true
+} satisfies TextStyleParams & ShapeTextStyleParams
+
+export const TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE = {
+  fill: '#ff8800',
+  fontFamily: 'Exo 2',
+  fontSize: 36,
+  fontStyle: 'italic',
+  fontWeight: 'bold',
+  linethrough: true,
+  stroke: '#333333',
+  strokeWidth: 1,
+  underline: true
+} satisfies Partial<TextSelectionStyleInfo>
+
+export const TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE = {
+  fill: '#ff8800',
+  fontFamily: 'Oswald',
+  fontSize: 24,
+  fontStyle: 'italic',
+  fontWeight: 'bold',
+  linethrough: true,
+  stroke: '#333333',
+  strokeWidth: 1,
+  underline: true
+} satisfies Partial<TextSelectionStyleInfo>
+
+export const TEXT_LINE_STYLE_ADD_OPTIONS = {
+  text: TEXT_LINE_STYLE_INITIAL_TEXT,
+  autoExpand: false,
+  width: 260,
+  ...TEXT_LINE_STYLE_BASE_TEXT_STYLE
+} satisfies TextAddParams
+
+export const TEXT_LINE_STYLE_THREE_LINE_ADD_OPTIONS = {
+  text: TEXT_LINE_STYLE_THREE_LINE_TEXT,
+  autoExpand: false,
+  width: 260,
+  ...TEXT_LINE_STYLE_BASE_TEXT_STYLE
+} satisfies TextAddParams
+
+export const TEXT_LINE_STYLE_SHAPE_ADD_OPTIONS = {
+  presetKey: 'square',
+  options: {
+    text: TEXT_LINE_STYLE_INITIAL_TEXT,
+    textStyle: TEXT_LINE_STYLE_BASE_TEXT_STYLE,
+    width: 320,
+    height: 180
+  }
+} satisfies ShapeAddParams

--- a/e2e/helpers/browser/editor-browser-helpers.installer.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.installer.ts
@@ -726,6 +726,7 @@ export function installEditorBrowserHelpers(): void {
   }): BrowserTextSelectionStyleInfo {
     return {
       fill: resolveNullableString({ value: style.fill }),
+      fontFamily: resolveNullableString({ value: style.fontFamily }),
       stroke: resolveNullableString({ value: style.stroke }),
       strokeWidth: resolveNullableNumber({ value: style.strokeWidth }),
       fontSize: resolveNullableNumber({ value: style.fontSize }),

--- a/e2e/helpers/browser/editor-browser-helpers.types.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.types.ts
@@ -87,6 +87,7 @@ export type BrowserSerializableObject = BrowserObject & {
 
 export type BrowserTextSelectionStyleInfo = {
   fill: string | null
+  fontFamily: string | null
   stroke: string | null
   strokeWidth: number | null
   fontSize: number | null

--- a/e2e/models/shape.model.ts
+++ b/e2e/models/shape.model.ts
@@ -19,6 +19,7 @@ import type {
   ShapeHorizontalAlign,
   ShapeVerticalAlign,
   ObjectTargetParams,
+  ShapeTextEditingUpdateParams,
   ShapeTextSelectionParams,
   ShapeTextSelectionStyleInfo
 } from '../types'
@@ -1680,8 +1681,15 @@ export class ShapeModel {
   }
 
   /** Меняет текст активного text-edit внутри shape */
-  async updateEditingText(params: { text: string } & ObjectTargetParams): Promise<ShapeTextInfo | null> {
-    const updatedTextNode = await this.page.evaluate(({ text, objectIndex, id }) => {
+  async updateEditingText(params: ShapeTextEditingUpdateParams): Promise<ShapeTextInfo | null> {
+    const updatedTextNode = await this.page.evaluate((payload) => {
+      const {
+        text,
+        selectionStart,
+        selectionEnd,
+        objectIndex,
+        id
+      } = payload
       const {
         editor,
         __editorHelpers: helpers
@@ -1692,14 +1700,18 @@ export class ShapeModel {
       if (!textNode) return null
 
       const { hiddenTextarea } = textNode
+      const nextSelectionStart = typeof selectionStart === 'number' ? selectionStart : text.length
+      const nextSelectionEnd = typeof selectionEnd === 'number' ? selectionEnd : nextSelectionStart
 
       if (hiddenTextarea instanceof HTMLTextAreaElement) {
         hiddenTextarea.value = text
-        hiddenTextarea.selectionStart = text.length
-        hiddenTextarea.selectionEnd = text.length
+        hiddenTextarea.selectionStart = nextSelectionStart
+        hiddenTextarea.selectionEnd = nextSelectionEnd
         hiddenTextarea.dispatchEvent(new Event('input', { bubbles: true }))
       } else {
         textNode.set({ text })
+        textNode.selectionStart = nextSelectionStart
+        textNode.selectionEnd = nextSelectionEnd
         editor.canvas.fire('text:changed', {
           target: textNode
         })
@@ -1785,11 +1797,59 @@ export class ShapeModel {
       const textNode = editor.shapeManager.getTextNode({ target })
       if (!textNode) return null
 
-      textNode.selectionStart = start
-      textNode.selectionEnd = end
+      if (typeof textNode.setSelectionStart === 'function') {
+        textNode.setSelectionStart(start)
+      } else {
+        textNode.selectionStart = start
+      }
+
+      if (typeof textNode.setSelectionEnd === 'function') {
+        textNode.setSelectionEnd(end)
+      } else {
+        textNode.selectionEnd = end
+      }
+      const { hiddenTextarea } = textNode
+
+      if (hiddenTextarea instanceof HTMLTextAreaElement) {
+        hiddenTextarea.focus()
+        hiddenTextarea.selectionStart = start
+        hiddenTextarea.selectionEnd = end
+      }
 
       return helpers.serializeShapeTextObject(textNode)
     }, params)
+  }
+
+  /** Удаляет выделенный текст внутри shape через реальное keyboard-событие. */
+  async deleteSelectedText(params: ObjectTargetParams = {}): Promise<ShapeTextInfo | null> {
+    await this.page.keyboard.press('Delete')
+    await waitForCanvasRender({ page: this.page })
+
+    return this.getTextNode(params)
+  }
+
+  /** Вводит текст внутрь shape в текущую позицию курсора через реальные keyboard-события. */
+  async typeText(params: { text: string } & ObjectTargetParams): Promise<ShapeTextInfo | null> {
+    const {
+      text,
+      ...targetParams
+    } = params
+    const parts = text.split('\n')
+
+    for (let index = 0; index < parts.length; index += 1) {
+      const part = parts[index]
+      if (part.length > 0) {
+        await this.page.keyboard.type(part)
+      }
+
+      if (index < parts.length - 1) {
+        await this.page.keyboard.press('Enter')
+      }
+    }
+
+    await waitForCanvasRender({ page: this.page })
+
+    return this.getTextNode(targetParams)
   }
 
   /** Возвращает стиль текущего или явного выделенного диапазона текста внутри shape. */

--- a/e2e/models/text.model.ts
+++ b/e2e/models/text.model.ts
@@ -362,7 +362,14 @@ export class TextModel {
 
   /** Меняет текст в активном режиме редактирования текстового объекта. */
   async updateEditingText(params: TextEditingUpdateParams): Promise<TextObjectInfo | null> {
-    const textObject = await this.page.evaluate(({ text, objectIndex, id }) => {
+    const textObject = await this.page.evaluate((payload) => {
+      const {
+        text,
+        selectionStart,
+        selectionEnd,
+        objectIndex,
+        id
+      } = payload
       const {
         editor,
         __editorHelpers: helpers
@@ -372,14 +379,18 @@ export class TextModel {
       if (!target) return null
 
       const { hiddenTextarea } = target
+      const nextSelectionStart = typeof selectionStart === 'number' ? selectionStart : text.length
+      const nextSelectionEnd = typeof selectionEnd === 'number' ? selectionEnd : nextSelectionStart
 
       if (hiddenTextarea instanceof HTMLTextAreaElement) {
         hiddenTextarea.value = text
-        hiddenTextarea.selectionStart = text.length
-        hiddenTextarea.selectionEnd = text.length
+        hiddenTextarea.selectionStart = nextSelectionStart
+        hiddenTextarea.selectionEnd = nextSelectionEnd
         hiddenTextarea.dispatchEvent(new Event('input', { bubbles: true }))
       } else {
         target.set({ text })
+        target.selectionStart = nextSelectionStart
+        target.selectionEnd = nextSelectionEnd
         editor.canvas.fire('text:changed', {
           target
         })
@@ -438,11 +449,59 @@ export class TextModel {
       const target = helpers.resolveCanvasObject(objectIndex, id)
       if (!target) return null
 
-      target.selectionStart = start
-      target.selectionEnd = end
+      if (typeof target.setSelectionStart === 'function') {
+        target.setSelectionStart(start)
+      } else {
+        target.selectionStart = start
+      }
+
+      if (typeof target.setSelectionEnd === 'function') {
+        target.setSelectionEnd(end)
+      } else {
+        target.selectionEnd = end
+      }
+      const { hiddenTextarea } = target
+
+      if (hiddenTextarea instanceof HTMLTextAreaElement) {
+        hiddenTextarea.focus()
+        hiddenTextarea.selectionStart = start
+        hiddenTextarea.selectionEnd = end
+      }
 
       return helpers.serializeTextObject(target)
     }, params)
+  }
+
+  /** Удаляет выделенный текст через реальное keyboard-событие. */
+  async deleteSelectedText(params: ObjectTargetParams = {}): Promise<TextObjectInfo | null> {
+    await this.page.keyboard.press('Delete')
+    await waitForCanvasRender({ page: this.page })
+
+    return this.getObject(params)
+  }
+
+  /** Вводит текст в текущую позицию курсора через реальные keyboard-события. */
+  async typeText(params: { text: string } & ObjectTargetParams): Promise<TextObjectInfo | null> {
+    const {
+      text,
+      ...targetParams
+    } = params
+    const parts = text.split('\n')
+
+    for (let index = 0; index < parts.length; index += 1) {
+      const part = parts[index]
+      if (part.length > 0) {
+        await this.page.keyboard.type(part)
+      }
+
+      if (index < parts.length - 1) {
+        await this.page.keyboard.press('Enter')
+      }
+    }
+
+    await waitForCanvasRender({ page: this.page })
+
+    return this.getObject(targetParams)
   }
 
   /** Возвращает стиль текущего или явного выделенного диапазона текста. */

--- a/e2e/tests/shape-manager/shape-editing.spec.ts
+++ b/e2e/tests/shape-manager/shape-editing.spec.ts
@@ -14,6 +14,17 @@ import {
   SHAPE_TEXT_LAYOUT_SECOND_POSITION,
   SHAPE_TEXT_LAYOUT_WRAP_FONT_SIZE
 } from '../../fixtures/data/shape-text-layout.data'
+import {
+  TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE,
+  TEXT_LINE_STYLE_FIRST_LINE_SELECTION,
+  TEXT_LINE_STYLE_FIRST_LINE_STYLE,
+  TEXT_LINE_STYLE_FIRST_LINE_TEXT,
+  TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE,
+  TEXT_LINE_STYLE_SECOND_LINE_SELECTION,
+  TEXT_LINE_STYLE_SECOND_LINE_STYLE,
+  TEXT_LINE_STYLE_SECOND_LINE_TEXT,
+  TEXT_LINE_STYLE_SHAPE_ADD_OPTIONS
+} from '../../fixtures/data/text-line-style.data'
 
 test.describe('Текст внутри фигуры', () => {
   test.beforeEach(async({ shapes }) => {
@@ -511,6 +522,112 @@ test.describe('Текст внутри фигуры', () => {
       expect(textNode?.text).toBe('Текст после изменения')
       expect(textNode?.textAlign).toBe('right')
       expect(textNode?.isEditing).toBe(false)
+    })
+  })
+})
+
+test.describe('Стили строк текста внутри фигуры после удаления текста', () => {
+  test('текст внутри фигуры после удаления текста строки сохраняет стиль этой строки', async({ shapes }) => {
+    await test.step('Добавить фигуру с двумя строками и применить разные стили строк', async() => {
+      const shape = await shapes.add(TEXT_LINE_STYLE_SHAPE_ADD_OPTIONS)
+
+      shapes.checkCreation({
+        shape,
+        presetKey: 'square'
+      })
+
+      await shapes.enterTextEditing({ objectIndex: 0 })
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+      })
+      await shapes.updateTextStyle({
+        objectIndex: 0,
+        style: TEXT_LINE_STYLE_FIRST_LINE_STYLE
+      })
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        ...TEXT_LINE_STYLE_SECOND_LINE_SELECTION
+      })
+      await shapes.updateTextStyle({
+        objectIndex: 0,
+        style: TEXT_LINE_STYLE_SECOND_LINE_STYLE
+      })
+    })
+
+    await test.step('Стереть первую строку и проверить стиль первого нового символа', async() => {
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+      })
+      await shapes.deleteSelectedText({ objectIndex: 0 })
+      await shapes.typeText({
+        objectIndex: 0,
+        text: 'F'
+      })
+
+      const firstCharacterStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: 0,
+        end: 1
+      })
+
+      expect(firstCharacterStyle).toMatchObject(TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE)
+    })
+
+    await test.step('Заполнить первую строку целиком', async() => {
+      await shapes.typeText({
+        objectIndex: 0,
+        text: 'IRST LINE'
+      })
+    })
+
+    await test.step('Стереть вторую строку и проверить стиль первого нового символа', async() => {
+      const secondLineStart = TEXT_LINE_STYLE_FIRST_LINE_TEXT.length + 1
+
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: `${TEXT_LINE_STYLE_FIRST_LINE_TEXT}\n TEST TEXT`.length
+      })
+      await shapes.deleteSelectedText({ objectIndex: 0 })
+      await shapes.typeText({
+        objectIndex: 0,
+        text: 'S'
+      })
+
+      const secondCharacterStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineStart + 1
+      })
+
+      expect(secondCharacterStyle).toMatchObject(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE)
+    })
+
+    await test.step('Проверить финальный текст и стили обеих строк', async() => {
+      const secondLineStart = TEXT_LINE_STYLE_FIRST_LINE_TEXT.length + 1
+
+      await shapes.typeText({
+        objectIndex: 0,
+        text: 'ECOND LINE'
+      })
+
+      const firstLineStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: 0,
+        end: TEXT_LINE_STYLE_FIRST_LINE_TEXT.length
+      })
+      const secondLineStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineStart + TEXT_LINE_STYLE_SECOND_LINE_TEXT.length
+      })
+      const textNode = await shapes.getTextNode({ objectIndex: 0 })
+
+      expect(textNode?.text).toBe(`${TEXT_LINE_STYLE_FIRST_LINE_TEXT}\n${TEXT_LINE_STYLE_SECOND_LINE_TEXT}`)
+      expect(firstLineStyle).toMatchObject(TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE)
+      expect(secondLineStyle).toMatchObject(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE)
     })
   })
 })

--- a/e2e/tests/text-manager/text-runtime.spec.ts
+++ b/e2e/tests/text-manager/text-runtime.spec.ts
@@ -1,4 +1,19 @@
 import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  TEXT_LINE_STYLE_ADD_OPTIONS,
+  TEXT_LINE_STYLE_AFTER_LINE_INSERT_TEXT,
+  TEXT_LINE_STYLE_AFTER_LINE_REMOVAL_TEXT,
+  TEXT_LINE_STYLE_DELETED_LINE_SELECTION,
+  TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE,
+  TEXT_LINE_STYLE_FIRST_LINE_SELECTION,
+  TEXT_LINE_STYLE_FIRST_LINE_STYLE,
+  TEXT_LINE_STYLE_FIRST_LINE_TEXT,
+  TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE,
+  TEXT_LINE_STYLE_SECOND_LINE_SELECTION,
+  TEXT_LINE_STYLE_SECOND_LINE_STYLE,
+  TEXT_LINE_STYLE_SECOND_LINE_TEXT,
+  TEXT_LINE_STYLE_THREE_LINE_ADD_OPTIONS
+} from '../../fixtures/data/text-line-style.data'
 
 test.describe('Редактирование текста и история объекта', () => {
   test.describe('изменение текста и история', () => {
@@ -288,6 +303,287 @@ test.describe('Редактирование текста и история об�
         expect(activeObject?.id).toBe(textObject.id)
         expect(activeObject?.type).toBe('background-textbox')
         expect(updatedTextObject?.isEditing).toBe(false)
+      })
+    })
+  })
+
+  test.describe('Стили строк после удаления текста', () => {
+    test('после удаления текста строки новый текст сохраняет стиль этой строки', async({ text }) => {
+      await test.step('Добавить текст с двумя строками и применить разные стили строк', async() => {
+        const textObject = await text.add(TEXT_LINE_STYLE_ADD_OPTIONS)
+
+        text.checkCreation({ textObject })
+
+        await text.enterTextEditing({ objectIndex: 0 })
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+        })
+        await text.updateStyle({
+          objectIndex: 0,
+          style: TEXT_LINE_STYLE_FIRST_LINE_STYLE
+        })
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_SECOND_LINE_SELECTION
+        })
+        await text.updateStyle({
+          objectIndex: 0,
+          style: TEXT_LINE_STYLE_SECOND_LINE_STYLE
+        })
+      })
+
+      await test.step('Стереть первую строку и проверить стиль первого нового символа', async() => {
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+        })
+        await text.deleteSelectedText({ objectIndex: 0 })
+        await text.typeText({
+          objectIndex: 0,
+          text: 'F'
+        })
+
+        const firstCharacterStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: 0,
+          end: 1
+        })
+
+        expect(firstCharacterStyle).toMatchObject(TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE)
+      })
+
+      await test.step('Заполнить первую строку целиком', async() => {
+        await text.typeText({
+          objectIndex: 0,
+          text: 'IRST LINE'
+        })
+      })
+
+      await test.step('Стереть вторую строку и проверить стиль первого нового символа', async() => {
+        const secondLineStart = TEXT_LINE_STYLE_FIRST_LINE_TEXT.length + 1
+
+        await text.setTextSelection({
+          objectIndex: 0,
+          start: secondLineStart,
+          end: `${TEXT_LINE_STYLE_FIRST_LINE_TEXT}\n TEST TEXT`.length
+        })
+        await text.deleteSelectedText({ objectIndex: 0 })
+        await text.typeText({
+          objectIndex: 0,
+          text: 'S'
+        })
+
+        const secondCharacterStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: secondLineStart,
+          end: secondLineStart + 1
+        })
+
+        expect(secondCharacterStyle).toMatchObject(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE)
+      })
+
+      await test.step('Проверить финальный текст и стили обеих строк', async() => {
+        const secondLineStart = TEXT_LINE_STYLE_FIRST_LINE_TEXT.length + 1
+
+        await text.typeText({
+          objectIndex: 0,
+          text: 'ECOND LINE'
+        })
+
+        const firstLineStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: 0,
+          end: TEXT_LINE_STYLE_FIRST_LINE_TEXT.length
+        })
+        const secondLineStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: secondLineStart,
+          end: secondLineStart + TEXT_LINE_STYLE_SECOND_LINE_TEXT.length
+        })
+        const textObject = await text.getObject({ objectIndex: 0 })
+
+        expect(textObject?.text).toBe(`${TEXT_LINE_STYLE_FIRST_LINE_TEXT}\n${TEXT_LINE_STYLE_SECOND_LINE_TEXT}`)
+        expect(firstLineStyle).toMatchObject(TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE)
+        expect(secondLineStyle).toMatchObject(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE)
+      })
+    })
+
+    test('после удаления строки вместе с переносом новый текст не получает стиль удалённой строки', async({ text }) => {
+      await test.step('Добавить три строки и применить стиль ко второй строке', async() => {
+        const textObject = await text.add(TEXT_LINE_STYLE_THREE_LINE_ADD_OPTIONS)
+
+        text.checkCreation({ textObject })
+
+        await text.enterTextEditing({ objectIndex: 0 })
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_DELETED_LINE_SELECTION
+        })
+        await text.updateStyle({
+          objectIndex: 0,
+          style: TEXT_LINE_STYLE_SECOND_LINE_STYLE
+        })
+      })
+
+      await test.step('Удалить вторую строку вместе с переносом', async() => {
+        const lineWithNextBreakSelection = {
+          start: 'FIRST\n'.length,
+          end: 'FIRST\nSECOND\n'.length
+        }
+        const insertedLineStart = 'FIRST\n'.length
+
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...lineWithNextBreakSelection
+        })
+        await text.deleteSelectedText({ objectIndex: 0 })
+
+        const nextLineStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: insertedLineStart,
+          end: TEXT_LINE_STYLE_AFTER_LINE_REMOVAL_TEXT.length
+        })
+        const textObject = await text.getObject({ objectIndex: 0 })
+
+        expect(textObject?.text).toBe(TEXT_LINE_STYLE_AFTER_LINE_REMOVAL_TEXT)
+        expect(nextLineStyle?.fontFamily).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontFamily)
+        expect(nextLineStyle?.fontSize).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontSize)
+        expect(nextLineStyle?.fontWeight).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontWeight)
+        expect(nextLineStyle?.fontStyle).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontStyle)
+        expect(nextLineStyle?.underline).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.underline)
+        expect(nextLineStyle?.linethrough).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.linethrough)
+      })
+
+      await test.step('Вставить новую строку на место удалённой и проверить её стиль', async() => {
+        const insertedLineStart = 'FIRST\n'.length
+        const insertedLineEnd = insertedLineStart + 'NEW'.length
+
+        await text.typeText({
+          objectIndex: 0,
+          text: 'NEW\n'
+        })
+
+        const insertedLineStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: insertedLineStart,
+          end: insertedLineEnd
+        })
+        const textObject = await text.getObject({ objectIndex: 0 })
+
+        expect(textObject?.text).toBe(TEXT_LINE_STYLE_AFTER_LINE_INSERT_TEXT)
+        expect(insertedLineStyle?.fontFamily).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontFamily)
+        expect(insertedLineStyle?.fontSize).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontSize)
+        expect(insertedLineStyle?.fontWeight).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontWeight)
+        expect(insertedLineStyle?.fontStyle).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.fontStyle)
+        expect(insertedLineStyle?.underline).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.underline)
+        expect(insertedLineStyle?.linethrough).not.toBe(TEXT_LINE_STYLE_SECOND_LINE_EXPECTED_STYLE.linethrough)
+      })
+    })
+
+    test('после undo/redo новый текст в строке сохраняет стиль строки', async({ history, text }) => {
+      await test.step('Добавить текст, применить стиль первой строки и сохранить состояние', async() => {
+        const textObject = await text.add(TEXT_LINE_STYLE_ADD_OPTIONS)
+
+        text.checkCreation({ textObject })
+
+        await text.enterTextEditing({ objectIndex: 0 })
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+        })
+        await text.updateStyle({
+          objectIndex: 0,
+          style: TEXT_LINE_STYLE_FIRST_LINE_STYLE
+        })
+        await text.exitTextEditing({ objectIndex: 0 })
+        await history.flushPendingSave()
+      })
+
+      await test.step('Сделать undo и redo', async() => {
+        await history.undo()
+        await history.redo()
+      })
+
+      await test.step('Стереть первую строку после redo и проверить стиль нового текста', async() => {
+        await text.enterTextEditing({ objectIndex: 0 })
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+        })
+        await text.deleteSelectedText({ objectIndex: 0 })
+        await text.typeText({
+          objectIndex: 0,
+          text: 'F'
+        })
+
+        const firstCharacterStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: 0,
+          end: 1
+        })
+
+        expect(firstCharacterStyle).toMatchObject(TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE)
+      })
+    })
+
+    test('объект из шаблона после удаления текста строки сохраняет стиль строки', async({
+      editorModel,
+      template,
+      text
+    }) => {
+      await test.step('Создать текст со стилем первой строки и сохранить его как шаблон', async() => {
+        const textObject = await text.add(TEXT_LINE_STYLE_ADD_OPTIONS)
+
+        text.checkCreation({ textObject })
+
+        await text.enterTextEditing({ objectIndex: 0 })
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+        })
+        await text.updateStyle({
+          objectIndex: 0,
+          style: TEXT_LINE_STYLE_FIRST_LINE_STYLE
+        })
+        await text.exitTextEditing({ objectIndex: 0 })
+        await text.select({ objectIndex: 0 })
+      })
+
+      const serializedTemplate = await test.step('Сериализовать текстовый объект', () => template.serializeSelection())
+
+      await test.step('Удалить исходный объект и применить шаблон', async() => {
+        expect(serializedTemplate).not.toBeNull()
+
+        await editorModel.deleteSelectedObject()
+        await editorModel.checkObjectCount({ count: 0 })
+
+        const insertedCount = await template.applyTemplate({
+          template: serializedTemplate!
+        })
+
+        expect(insertedCount).toBe(1)
+      })
+
+      await test.step('Стереть первую строку у объекта из шаблона и проверить стиль нового текста', async() => {
+        await text.enterTextEditing({ objectIndex: 0 })
+        await text.setTextSelection({
+          objectIndex: 0,
+          ...TEXT_LINE_STYLE_FIRST_LINE_SELECTION
+        })
+        await text.deleteSelectedText({ objectIndex: 0 })
+        await text.typeText({
+          objectIndex: 0,
+          text: 'F'
+        })
+
+        const firstCharacterStyle = await text.getSelectionStyles({
+          objectIndex: 0,
+          start: 0,
+          end: 1
+        })
+
+        expect(firstCharacterStyle).toMatchObject(TEXT_LINE_STYLE_FIRST_LINE_EXPECTED_STYLE)
       })
     })
   })

--- a/e2e/types/shape.types.ts
+++ b/e2e/types/shape.types.ts
@@ -70,9 +70,17 @@ export interface ShapeTextSelectionParams {
   end: number
 }
 
+/** Параметры изменения текста внутри shape в режиме editing */
+export interface ShapeTextEditingUpdateParams extends ObjectTargetParams {
+  text: string
+  selectionEnd?: number
+  selectionStart?: number
+}
+
 /** Сериализованный стиль выделенного диапазона текста внутри shape */
 export interface ShapeTextSelectionStyleInfo {
   fill: string | null
+  fontFamily: string | null
   stroke: string | null
   strokeWidth: number | null
   fontSize: number | null

--- a/e2e/types/text.types.ts
+++ b/e2e/types/text.types.ts
@@ -137,6 +137,7 @@ export interface TextSelectionParams extends ObjectTargetParams {
 /** Сериализованный стиль выделенного диапазона текстового объекта. */
 export interface TextSelectionStyleInfo {
   fill: string | null
+  fontFamily: string | null
   stroke: string | null
   strokeWidth: number | null
   fontSize: number | null
@@ -154,6 +155,8 @@ export interface TextRotateParams extends ObjectTargetParams {
 /** Параметры изменения текста в режиме редактирования. */
 export interface TextEditingUpdateParams extends ObjectTargetParams {
   text: string
+  selectionEnd?: number
+  selectionStart?: number
 }
 
 /** Параметры одного live-шагa horizontal resize standalone text. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/text-manager/background-textbox.spec.ts
+++ b/specs/src/editor/text-manager/background-textbox.spec.ts
@@ -395,8 +395,13 @@ describe('BackgroundTextbox', () => {
         0: {
           fontFamily: 'Arial',
           fontSize: 20,
+          fontStyle: 'italic',
+          fontWeight: 'bold',
           fill: '#111111',
-          stroke: '#222222'
+          linethrough: true,
+          stroke: '#222222',
+          strokeWidth: 2,
+          underline: true
         },
         2: {
           fontFamily: 'Roboto',

--- a/specs/src/editor/text-manager/index.spec.ts
+++ b/specs/src/editor/text-manager/index.spec.ts
@@ -460,7 +460,7 @@ describe('TextManager', () => {
       expect(secondLineDefaults).toBeUndefined()
     })
 
-    it('сохраняет fill и stroke в lineFontDefaults при выделении всей строки', () => {
+    it('запоминает стиль всей строки для дальнейшего ввода', () => {
       const { textManager } = createTextManagerTestSetup()
 
       const textbox = textManager.addText({
@@ -479,9 +479,15 @@ describe('TextManager', () => {
         target: textbox,
         withoutSave: true,
         style: {
+          bold: true,
           color: '#ff0000',
+          fontFamily: 'Roboto',
+          fontSize: 40,
+          italic: true,
           strokeColor: '#00ff00',
-          strokeWidth: 2
+          strokeWidth: 2,
+          strikethrough: true,
+          underline: true
         }
       })
 
@@ -490,10 +496,62 @@ describe('TextManager', () => {
       const secondLineDefaults = lineFontDefaults?.[1]
 
       expect(firstLineDefaults).toMatchObject({
+        fontFamily: 'Roboto',
+        fontSize: 40,
+        fontStyle: 'italic',
+        fontWeight: 'bold',
         fill: '#ff0000',
-        stroke: '#00ff00'
+        linethrough: true,
+        stroke: '#00ff00',
+        strokeWidth: 2,
+        underline: true
       })
       expect(secondLineDefaults).toBeUndefined()
+    })
+
+    it('не запоминает стиль части строки как стиль всей строки', () => {
+      const { textManager } = createTextManagerTestSetup()
+
+      const textbox = textManager.addText({
+        text: 'LineOne\nLineTwo',
+        fontFamily: 'Arial',
+        fontSize: 32,
+        color: '#111111'
+      })
+
+      textbox.isEditing = true
+      textbox.selectionStart = 1
+      textbox.selectionEnd = 4
+
+      textManager.updateText({
+        target: textbox,
+        withoutSave: true,
+        style: {
+          bold: true,
+          color: '#ff0000',
+          italic: true,
+          strokeColor: '#00ff00',
+          strokeWidth: 2,
+          strikethrough: true,
+          underline: true
+        }
+      })
+
+      const selectionStyles = textbox.getSelectionStyles(1, 4)
+      expect(selectionStyles).toHaveLength(3)
+      selectionStyles.forEach((style) => {
+        expect(style).toMatchObject({
+          fill: '#ff0000',
+          fontStyle: 'italic',
+          fontWeight: 'bold',
+          linethrough: true,
+          stroke: '#00ff00',
+          strokeWidth: 2,
+          underline: true
+        })
+      })
+      expect(textbox.lineFontDefaults?.[0]).toBeUndefined()
+      expect(textbox.lineFontDefaults?.[1]).toBeUndefined()
     })
 
     it('пересчитывает размеры при смене шрифта для выделенного текста', () => {
@@ -973,8 +1031,13 @@ describe('TextManager', () => {
         2: {
           fontFamily: 'Arial',
           fontSize: 28,
+          fontStyle: 'italic',
+          fontWeight: 'bold',
           fill: '#111111',
-          stroke: '#222222'
+          linethrough: true,
+          stroke: '#222222',
+          strokeWidth: 3,
+          underline: true
         }
       }
       textbox.styles = {
@@ -996,22 +1059,119 @@ describe('TextManager', () => {
         fontSize: 28,
         fill: '#ff0000',
         fontFamily: 'Arial',
-        stroke: '#222222'
+        fontStyle: 'italic',
+        fontWeight: 'bold',
+        linethrough: true,
+        stroke: '#222222',
+        strokeWidth: 3,
+        underline: true
       })
       expect(lineStyles?.[1]).toMatchObject({
         fontSize: 28,
         fill: '#111111',
         fontFamily: 'Arial',
-        stroke: '#222222'
+        fontStyle: 'italic',
+        fontWeight: 'bold',
+        linethrough: true,
+        stroke: '#222222',
+        strokeWidth: 3,
+        underline: true
       })
       expect(lineStyles?.[2]).toMatchObject({
         fontSize: 28,
         fill: '#111111',
         fontFamily: 'Arial',
-        stroke: '#222222'
+        fontStyle: 'italic',
+        fontWeight: 'bold',
+        linethrough: true,
+        stroke: '#222222',
+        strokeWidth: 3,
+        underline: true
       })
       expect(lineStyles?.[10]).toBeUndefined()
       expect(lineStyles?.['foo']).toBeUndefined()
+    })
+
+    it('text:changed сохраняет стиль пустой строки для дальнейшего ввода', () => {
+      const { canvas, textManager } = createTextManagerTestSetup()
+
+      const textbox = textManager.addText({
+        text: 'FIRST\nSECOND',
+        autoExpand: false,
+        fontFamily: 'Arial',
+        fontSize: 48,
+        color: '#000000'
+      })
+      textbox.lineFontDefaults = {
+        0: {
+          fontFamily: 'Exo 2',
+          fontSize: 36,
+          fontStyle: 'italic',
+          fontWeight: 'bold',
+          fill: '#ff8800',
+          linethrough: true,
+          stroke: '#333333',
+          strokeWidth: 1,
+          underline: true
+        }
+      }
+
+      textbox.text = '\nSECOND'
+      canvas.fire('text:changed', { target: textbox })
+
+      expect(textbox.styles?.[0]?.[0]).toMatchObject({
+        fill: '#ff8800',
+        fontFamily: 'Exo 2',
+        fontSize: 36,
+        fontStyle: 'italic',
+        fontWeight: 'bold',
+        linethrough: true,
+        stroke: '#333333',
+        strokeWidth: 1,
+        underline: true
+      })
+      expect(textbox.lineFontDefaults?.[0]).toMatchObject({
+        fill: '#ff8800',
+        fontFamily: 'Exo 2',
+        fontSize: 36,
+        fontStyle: 'italic',
+        fontWeight: 'bold',
+        linethrough: true,
+        stroke: '#333333',
+        strokeWidth: 1,
+        underline: true
+      })
+    })
+
+    it('text:changed удаляет стиль строки, если строку удалили вместе с переносом', () => {
+      const { canvas, textManager } = createTextManagerTestSetup()
+
+      const textbox = textManager.addText({
+        text: 'FIRST\nSECOND\nTHIRD',
+        autoExpand: false,
+        fontFamily: 'Arial',
+        fontSize: 48,
+        color: '#000000'
+      })
+      textbox.lineFontDefaults = {
+        1: {
+          fontFamily: 'Oswald',
+          fontSize: 24,
+          fontStyle: 'italic',
+          fontWeight: 'bold',
+          fill: '#ff8800',
+          linethrough: true,
+          stroke: '#333333',
+          strokeWidth: 1,
+          underline: true
+        }
+      }
+      textbox.__lineDefaultsPrevText = textbox.text ?? ''
+
+      textbox.text = 'FIRST\nTHIRD'
+      canvas.fire('text:changed', { target: textbox })
+
+      expect(textbox.lineFontDefaults?.[1]).toBeUndefined()
     })
   })
 

--- a/specs/src/editor/text-manager/scaling/text-scaling-materialization.spec.ts
+++ b/specs/src/editor/text-manager/scaling/text-scaling-materialization.spec.ts
@@ -13,6 +13,19 @@ describe('масштабирование текста', () => {
   describe('подготовка базового состояния', () => {
     it('сохраняет стили и размеры отдельно от исходного объекта', () => {
       const textbox = createStyledScalingTextbox()
+      textbox.lineFontDefaults = {
+        1: {
+          fontFamily: 'Open Sans',
+          fontSize: 24,
+          fontStyle: 'italic',
+          fontWeight: 'bold',
+          fill: '#333333',
+          linethrough: true,
+          stroke: '#222222',
+          strokeWidth: 2,
+          underline: true
+        }
+      }
 
       const base = captureTextScaleBase({ textbox })
 
@@ -36,7 +49,17 @@ describe('масштабирование текста', () => {
       expect(base.padding.top).toBe(21)
       expect(base.radii.topLeft).toBe(24)
       expect(base.styles['1']?.['0']?.fontSize).toBe(24)
-      expect(base.lineFontDefaults?.[1]?.fontSize).toBe(24)
+      expect(base.lineFontDefaults?.[1]).toMatchObject({
+        fontFamily: 'Open Sans',
+        fontSize: 24,
+        fontStyle: 'italic',
+        fontWeight: 'bold',
+        fill: '#333333',
+        linethrough: true,
+        stroke: '#222222',
+        strokeWidth: 2,
+        underline: true
+      })
     })
   })
 
@@ -80,7 +103,7 @@ describe('масштабирование текста', () => {
   })
 
   describe('запекание временного масштаба', () => {
-    it('при сильном уменьшении по диагонали останавливает шрифт на минимальном размере', () => {
+    it('при сильном уменьшении по диагонали останавливает шрифт на минимальном размере и сохраняет стиль строки', () => {
       const { editor } = createTextManagerTestSetup()
       const textbox = new BackgroundTextbox('69\nЧасов музыки', {
         width: 160,
@@ -100,7 +123,14 @@ describe('масштабирование текста', () => {
       }
       textbox.lineFontDefaults = {
         1: {
-          fontSize: 10
+          fontSize: 10,
+          fontStyle: 'italic',
+          fontWeight: 'bold',
+          fill: '#333333',
+          linethrough: true,
+          stroke: '#222222',
+          strokeWidth: 2,
+          underline: true
         }
       }
       jest.spyOn(textbox, 'initDimensions').mockImplementation(() => undefined)
@@ -121,7 +151,16 @@ describe('масштабирование текста', () => {
       })
 
       expect(textbox.fontSize).toBe(8)
-      expect(textbox.lineFontDefaults?.[1]?.fontSize).toBe(8)
+      expect(textbox.lineFontDefaults?.[1]).toMatchObject({
+        fontSize: 8,
+        fontStyle: 'italic',
+        fontWeight: 'bold',
+        fill: '#333333',
+        linethrough: true,
+        stroke: '#222222',
+        strokeWidth: 2,
+        underline: true
+      })
       expect(textbox.styles?.['1']?.['0']?.fontSize).toBe(8)
     })
 

--- a/src/editor/text-manager/background-textbox.ts
+++ b/src/editor/text-manager/background-textbox.ts
@@ -10,10 +10,15 @@ import ErrorManager from '../error-manager'
 import { resolveStrokeColor, resolveStrokeWidth } from '../utils/text'
 
 export type LineFontDefault = {
+  fill?: string
   fontFamily?: string
   fontSize?: number
-  fill?: string
+  fontStyle?: TextboxProps['fontStyle']
+  fontWeight?: TextboxProps['fontWeight']
+  linethrough?: boolean
   stroke?: string
+  strokeWidth?: number
+  underline?: boolean
 }
 
 export type LineFontDefaults = Record<number, LineFontDefault>

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -26,6 +26,7 @@ import {
 import TextScalingController from './scaling/text-scaling'
 import {
   applyLineDefaultUpdates,
+  createLineDefaultStyle,
   syncLineDefaultStyles
 } from './line-defaults'
 import {
@@ -99,11 +100,6 @@ export default class TextManager {
   private editingPlacementState?: WeakMap<EditorTextbox, ObjectPlacement>
 
   /**
-   * Хранилище для защиты от повторной синхронизации lineFontDefaults.
-   */
-  private lineDefaultsSyncing: WeakSet<EditorTextbox>
-
-  /**
    * Флаг, указывающий что текст находится в режиме редактирования или недавно вышел из него.
    * Используется для предотвращения сохранения состояния с временными lock-свойствами.
    */
@@ -124,7 +120,6 @@ export default class TextManager {
       }
     })
     this.editingPlacementState = new WeakMap()
-    this.lineDefaultsSyncing = new WeakSet()
     this.isTextEditingActive = false
 
     this._bindEvents()
@@ -397,6 +392,8 @@ export default class TextManager {
     const selectionStyles: Partial<TextboxProps> = {}
     const lineSelectionStyles: Partial<TextboxProps> = {}
     const wholeTextStyles: Partial<TextboxProps> = {}
+    let resolvedFontWeight: TextboxProps['fontWeight'] | undefined
+    let resolvedFontStyle: TextboxProps['fontStyle'] | undefined
     let resolvedStrokeColor: string | null | undefined
     let resolvedStrokeWidth: number | undefined
     const isSelectionForWholeText = isFullTextSelection({ textbox, range: selectionRange })
@@ -430,29 +427,29 @@ export default class TextManager {
     }
 
     if (bold !== undefined) {
-      const fontWeight = bold ? 'bold' : 'normal'
+      resolvedFontWeight = bold ? 'bold' : 'normal'
       if (selectionRange) {
-        selectionStyles.fontWeight = fontWeight
+        selectionStyles.fontWeight = resolvedFontWeight
       }
 
       if (shouldUpdateWholeObject) {
-        updates.fontWeight = fontWeight
+        updates.fontWeight = resolvedFontWeight
         if (shouldApplyWholeTextStyles) {
-          wholeTextStyles.fontWeight = fontWeight
+          wholeTextStyles.fontWeight = resolvedFontWeight
         }
       }
     }
 
     if (italic !== undefined) {
-      const fontStyle = italic ? 'italic' : 'normal'
+      resolvedFontStyle = italic ? 'italic' : 'normal'
       if (selectionRange) {
-        selectionStyles.fontStyle = fontStyle
+        selectionStyles.fontStyle = resolvedFontStyle
       }
 
       if (shouldUpdateWholeObject) {
-        updates.fontStyle = fontStyle
+        updates.fontStyle = resolvedFontStyle
         if (shouldApplyWholeTextStyles) {
-          wholeTextStyles.fontStyle = fontStyle
+          wholeTextStyles.fontStyle = resolvedFontStyle
         }
       }
     }
@@ -678,13 +675,37 @@ export default class TextManager {
 
     if (
       selectionRange
-      && (color !== undefined || strokeColor !== undefined || strokeWidth !== undefined)
+      && (
+        bold !== undefined
+        || italic !== undefined
+        || underline !== undefined
+        || strikethrough !== undefined
+        || color !== undefined
+        || strokeColor !== undefined
+        || strokeWidth !== undefined
+      )
     ) {
       const fullLineIndices = getFullLineIndicesForRange({
         textbox,
         range: selectionRange
       })
       const lineDefaultsUpdates: LineFontDefaultUpdate = {}
+
+      if (resolvedFontWeight !== undefined) {
+        lineDefaultsUpdates.fontWeight = resolvedFontWeight
+      }
+
+      if (resolvedFontStyle !== undefined) {
+        lineDefaultsUpdates.fontStyle = resolvedFontStyle
+      }
+
+      if (underline !== undefined) {
+        lineDefaultsUpdates.underline = underline
+      }
+
+      if (strikethrough !== undefined) {
+        lineDefaultsUpdates.linethrough = strikethrough
+      }
 
       if (color !== undefined) {
         lineDefaultsUpdates.fill = color
@@ -697,6 +718,10 @@ export default class TextManager {
 
         if (resolvedStrokeColor !== null && resolvedStrokeColor !== undefined) {
           lineDefaultsUpdates.stroke = resolvedStrokeColor
+        }
+
+        if (resolvedStrokeWidth !== undefined) {
+          lineDefaultsUpdates.strokeWidth = resolvedStrokeWidth
         }
       }
 
@@ -1092,7 +1117,6 @@ export default class TextManager {
   private _handleTextChanged = (event: IEvent): void => {
     const { target } = event
     if (!TextManager._isTextbox(target)) return
-    if (this.lineDefaultsSyncing.has(target)) return
 
     const isShapeOwnedTextbox = TextManager._isShapeOwnedTextbox(target)
     const { text = '', uppercase, autoExpand } = target
@@ -1134,7 +1158,7 @@ export default class TextManager {
   }
 
   /**
-   * Синхронизирует lineFontDefaults при изменении текста и сохраняет typing style для пустых строк.
+   * Синхронизирует lineFontDefaults при изменении текста и сохраняет служебный Fabric-стиль для пустых строк.
    */
   private _syncLineFontDefaultsOnTextChanged({ textbox }: { textbox: EditorTextbox }): void {
     const {
@@ -1143,10 +1167,13 @@ export default class TextManager {
       styles,
       fontFamily: globalFontFamily,
       fontSize: globalFontSize,
+      fontStyle: globalFontStyle,
+      fontWeight: globalFontWeight,
       fill: rawGlobalFill,
       stroke: rawGlobalStroke,
-      selectionStart,
-      isEditing
+      strokeWidth: globalStrokeWidth,
+      linethrough: globalLinethrough,
+      underline: globalUnderline
     } = textbox
     const currentText = text
     const previousText = textbox.__lineDefaultsPrevText ?? currentText
@@ -1239,20 +1266,10 @@ export default class TextManager {
       }
     }
 
-    let cursorLineIndex: number | null = null
-    if (isEditing && typeof selectionStart === 'number') {
-      const cursorLocation = textbox.get2DCursorLocation(selectionStart)
-      const { lineIndex } = cursorLocation
-      if (Number.isFinite(lineIndex)) {
-        cursorLineIndex = lineIndex
-      }
-    }
-
     let nextStyles = styles
     let stylesChanged = false
     let stylesCloned = false
     let lastLineDefaults: LineFontDefault | undefined
-    let cursorLineDefaults: LineFontDefault | null = null
 
     for (let lineIndex = 0; lineIndex < currentLines.length; lineIndex += 1) {
       const lineText = currentLines[lineIndex] ?? ''
@@ -1312,6 +1329,30 @@ export default class TextManager {
         resolvedDefaults.fontSize = globalFontSize
       }
 
+      if (sourceDefaults?.fontWeight !== undefined) {
+        resolvedDefaults.fontWeight = sourceDefaults.fontWeight
+      } else if (globalFontWeight !== undefined) {
+        resolvedDefaults.fontWeight = globalFontWeight
+      }
+
+      if (sourceDefaults?.fontStyle !== undefined) {
+        resolvedDefaults.fontStyle = sourceDefaults.fontStyle
+      } else if (globalFontStyle !== undefined) {
+        resolvedDefaults.fontStyle = globalFontStyle
+      }
+
+      if (sourceDefaults?.underline !== undefined) {
+        resolvedDefaults.underline = sourceDefaults.underline
+      } else if (globalUnderline !== undefined) {
+        resolvedDefaults.underline = globalUnderline
+      }
+
+      if (sourceDefaults?.linethrough !== undefined) {
+        resolvedDefaults.linethrough = sourceDefaults.linethrough
+      } else if (globalLinethrough !== undefined) {
+        resolvedDefaults.linethrough = globalLinethrough
+      }
+
       if (sourceDefaults?.fill !== undefined) {
         resolvedDefaults.fill = sourceDefaults.fill
       } else if (resolvedGlobalFill !== undefined) {
@@ -1322,6 +1363,12 @@ export default class TextManager {
         resolvedDefaults.stroke = sourceDefaults.stroke
       } else if (resolvedGlobalStroke !== undefined) {
         resolvedDefaults.stroke = resolvedGlobalStroke
+      }
+
+      if (sourceDefaults?.strokeWidth !== undefined) {
+        resolvedDefaults.strokeWidth = sourceDefaults.strokeWidth
+      } else if (resolvedDefaults.stroke !== undefined && globalStrokeWidth !== undefined) {
+        resolvedDefaults.strokeWidth = globalStrokeWidth
       }
 
       if (!storedLineDefaults && Object.keys(resolvedDefaults).length) {
@@ -1344,27 +1391,7 @@ export default class TextManager {
         lastLineDefaults = storedLineDefaults
       }
 
-      if (cursorLineIndex !== null && cursorLineIndex === lineIndex) {
-        cursorLineDefaults = resolvedDefaults
-      }
-
-      const allowedStyles: Partial<TextboxProps> = {}
-      if (resolvedDefaults.fontFamily !== undefined) {
-        allowedStyles.fontFamily = resolvedDefaults.fontFamily
-      }
-
-      if (resolvedDefaults.fontSize !== undefined) {
-        allowedStyles.fontSize = resolvedDefaults.fontSize
-      }
-
-      if (resolvedDefaults.fill !== undefined) {
-        allowedStyles.fill = resolvedDefaults.fill
-      }
-
-      if (resolvedDefaults.stroke !== undefined) {
-        allowedStyles.stroke = resolvedDefaults.stroke
-      }
-
+      const allowedStyles = createLineDefaultStyle({ lineDefaults: resolvedDefaults })
       const hasAllowedStyles = Object.keys(allowedStyles).length > 0
       if (hasAllowedStyles || (nextStyles && nextStyles[lineIndex])) {
         if (!nextStyles) {
@@ -1396,35 +1423,6 @@ export default class TextManager {
     if (stylesChanged) {
       textbox.styles = nextStyles
       textbox.dirty = true
-    }
-
-    if (cursorLineDefaults && typeof selectionStart === 'number') {
-      const typingStyles: Partial<TextboxProps> = {}
-
-      if (cursorLineDefaults.fontFamily !== undefined) {
-        typingStyles.fontFamily = cursorLineDefaults.fontFamily
-      }
-
-      if (cursorLineDefaults.fontSize !== undefined) {
-        typingStyles.fontSize = cursorLineDefaults.fontSize
-      }
-
-      if (cursorLineDefaults.fill !== undefined) {
-        typingStyles.fill = cursorLineDefaults.fill
-      }
-
-      if (cursorLineDefaults.stroke !== undefined) {
-        typingStyles.stroke = cursorLineDefaults.stroke
-      }
-
-      if (Object.keys(typingStyles).length) {
-        this.lineDefaultsSyncing.add(textbox)
-        try {
-          textbox.setSelectionStyles(typingStyles, selectionStart, selectionStart)
-        } finally {
-          this.lineDefaultsSyncing.delete(textbox)
-        }
-      }
     }
 
     textbox.__lineDefaultsPrevText = currentText

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -16,9 +16,7 @@ import type { EditorFontDefinition } from '../types/font'
 import {
   BackgroundTextbox,
   registerBackgroundTextbox,
-  type BackgroundTextboxProps,
-  type LineFontDefault,
-  type LineFontDefaults
+  type BackgroundTextboxProps
 } from './background-textbox'
 import {
   DIMENSION_EPSILON
@@ -26,18 +24,13 @@ import {
 import TextScalingController from './scaling/text-scaling'
 import {
   applyLineDefaultUpdates,
-  createLineDefaultStyle,
-  removeLineDefaultStyles,
-  syncLineDefaultStyles
+  syncLineFontDefaultsAfterTextChange
 } from './line-defaults'
 import {
   clampSelectionRange,
   expandRangeToFullLines,
-  getFirstDiffIndex,
   getFullLineIndicesForRange,
-  getLineIndexByCharIndex,
-  getLineIndicesForRange,
-  getLineStartIndex
+  getLineIndicesForRange
 } from './selection'
 import {
   clampTextboxToMontage,
@@ -1164,316 +1157,21 @@ export default class TextManager {
    * Синхронизирует lineFontDefaults при изменении текста и сохраняет служебный Fabric-стиль для пустых строк.
    */
   private _syncLineFontDefaultsOnTextChanged({ textbox }: { textbox: EditorTextbox }): void {
-    const {
-      text = '',
-      lineFontDefaults,
-      styles,
-      fontFamily: globalFontFamily,
-      fontSize: globalFontSize,
-      fontStyle: globalFontStyle,
-      fontWeight: globalFontWeight,
-      fill: rawGlobalFill,
-      stroke: rawGlobalStroke,
-      strokeWidth: globalStrokeWidth,
-      linethrough: globalLinethrough,
-      underline: globalUnderline
-    } = textbox
-    const currentText = text
+    const currentText = textbox.text ?? ''
     const previousText = textbox.__lineDefaultsPrevText ?? currentText
-    const previousLines = previousText.split('\n')
-    const currentLines = currentText.split('\n')
-    const oldLineCount = previousLines.length
-    const newLineCount = currentLines.length
-    const deltaLines = newLineCount - oldLineCount
 
-    let nextLineDefaults = lineFontDefaults
-    let lineDefaultsChanged = false
-    let lineDefaultsCloned = false
-    const removedLineDefaultsForStyleCleanup: LineFontDefault[] = []
-    let removedLineStyleCleanupIndex: number | undefined
+    const syncResult = syncLineFontDefaultsAfterTextChange({
+      textbox,
+      previousText,
+      currentText
+    })
 
-    const resolvedGlobalFill = typeof rawGlobalFill === 'string' ? rawGlobalFill : undefined
-    const resolvedGlobalStroke = typeof rawGlobalStroke === 'string' ? rawGlobalStroke : undefined
-
-    if (deltaLines !== 0 && lineFontDefaults && Object.keys(lineFontDefaults).length) {
-      const diffIndex = getFirstDiffIndex({
-        previous: previousText,
-        next: currentText
-      })
-      const lineIndexOld = getLineIndexByCharIndex({
-        text: previousText,
-        charIndex: diffIndex
-      })
-
-      if (deltaLines > 0) {
-        const lineStartOld = getLineStartIndex({
-          text: previousText,
-          lineIndex: lineIndexOld
-        })
-        let shiftStartIndex = lineIndexOld + 1
-        if (diffIndex === lineStartOld) {
-          shiftStartIndex = lineIndexOld
-        }
-
-        const shiftedDefaults: LineFontDefaults = {}
-        for (const key in lineFontDefaults) {
-          if (!Object.prototype.hasOwnProperty.call(lineFontDefaults, key)) continue
-          const numericIndex = Number(key)
-          if (!Number.isFinite(numericIndex)) continue
-          const lineDefault = lineFontDefaults[numericIndex]
-          if (!lineDefault) continue
-
-          const nextIndex = numericIndex >= shiftStartIndex
-            ? numericIndex + deltaLines
-            : numericIndex
-          shiftedDefaults[nextIndex] = { ...lineDefault }
-        }
-
-        nextLineDefaults = shiftedDefaults
-        lineDefaultsChanged = true
-        lineDefaultsCloned = true
-      }
-
-      if (deltaLines < 0) {
-        const removedLinesCount = Math.abs(deltaLines)
-        let removedLineStart = lineIndexOld
-        const oldChar = previousText[diffIndex]
-
-        if (oldChar === '\n') {
-          const lineText = previousLines[lineIndexOld] ?? ''
-          if (lineText.length > 0) {
-            removedLineStart = lineIndexOld + 1
-          }
-        }
-
-        const removedLineEnd = removedLineStart + removedLinesCount - 1
-        const shiftedDefaults: LineFontDefaults = {}
-
-        for (let lineIndex = removedLineStart; lineIndex <= removedLineEnd; lineIndex += 1) {
-          const removedLineDefault = lineFontDefaults[lineIndex]
-          if (removedLineDefault) {
-            removedLineDefaultsForStyleCleanup.push(removedLineDefault)
-          }
-        }
-        removedLineStyleCleanupIndex = removedLineStart
-
-        for (const key in lineFontDefaults) {
-          if (!Object.prototype.hasOwnProperty.call(lineFontDefaults, key)) continue
-          const numericIndex = Number(key)
-          if (!Number.isFinite(numericIndex)) continue
-          const lineDefault = lineFontDefaults[numericIndex]
-          if (!lineDefault) continue
-
-          if (numericIndex < removedLineStart) {
-            shiftedDefaults[numericIndex] = { ...lineDefault }
-          }
-
-          if (numericIndex > removedLineEnd) {
-            shiftedDefaults[numericIndex + deltaLines] = { ...lineDefault }
-          }
-        }
-
-        nextLineDefaults = shiftedDefaults
-        lineDefaultsChanged = true
-        lineDefaultsCloned = true
-      }
+    if (syncResult.lineFontDefaultsChanged && syncResult.lineFontDefaults) {
+      textbox.lineFontDefaults = syncResult.lineFontDefaults
     }
 
-    let nextStyles = styles
-    let stylesChanged = false
-    let stylesCloned = false
-    let lastLineDefaults: LineFontDefault | undefined
-
-    if (
-      removedLineStyleCleanupIndex !== undefined
-      && removedLineStyleCleanupIndex < currentLines.length
-      && removedLineDefaultsForStyleCleanup.length
-      && nextStyles
-    ) {
-      let cleanupLineStyles = nextStyles[removedLineStyleCleanupIndex]
-      let cleanupChanged = false
-
-      for (let index = 0; index < removedLineDefaultsForStyleCleanup.length; index += 1) {
-        const lineDefaultsForCleanup = removedLineDefaultsForStyleCleanup[index]
-        if (!lineDefaultsForCleanup) continue
-
-        const cleanupResult = removeLineDefaultStyles({
-          lineStyles: cleanupLineStyles,
-          lineDefaults: lineDefaultsForCleanup
-        })
-        if (!cleanupResult.changed) continue
-
-        cleanupLineStyles = cleanupResult.lineStyles
-        cleanupChanged = true
-      }
-
-      if (cleanupChanged) {
-        if (!stylesCloned) {
-          nextStyles = { ...nextStyles }
-          stylesCloned = true
-        }
-
-        if (cleanupLineStyles) {
-          nextStyles[removedLineStyleCleanupIndex] = cleanupLineStyles
-        } else {
-          delete nextStyles[removedLineStyleCleanupIndex]
-        }
-
-        stylesChanged = true
-      }
-    }
-
-    for (let lineIndex = 0; lineIndex < currentLines.length; lineIndex += 1) {
-      const lineText = currentLines[lineIndex] ?? ''
-      const storedLineDefaults = nextLineDefaults ? nextLineDefaults[lineIndex] : undefined
-
-      if (storedLineDefaults) {
-        lastLineDefaults = storedLineDefaults
-      }
-
-      const hasLineText = lineText.length !== 0
-      if (hasLineText) {
-        if (storedLineDefaults) {
-          const syncResult = syncLineDefaultStyles({
-            lineText,
-            lineStyles: nextStyles ? nextStyles[lineIndex] : undefined,
-            lineDefaults: storedLineDefaults
-          })
-
-          if (syncResult.changed) {
-            if (!nextStyles) {
-              nextStyles = {}
-              stylesCloned = true
-            }
-
-            if (!stylesCloned) {
-              nextStyles = { ...nextStyles }
-              stylesCloned = true
-            }
-
-            if (syncResult.lineStyles) {
-              nextStyles[lineIndex] = syncResult.lineStyles
-            }
-
-            if (!syncResult.lineStyles && nextStyles[lineIndex]) {
-              delete nextStyles[lineIndex]
-            }
-
-            stylesChanged = true
-          }
-        }
-
-        continue
-      }
-
-      const sourceDefaults = storedLineDefaults ?? lastLineDefaults
-      const resolvedDefaults: LineFontDefault = {}
-
-      if (sourceDefaults?.fontFamily !== undefined) {
-        resolvedDefaults.fontFamily = sourceDefaults.fontFamily
-      } else if (globalFontFamily !== undefined) {
-        resolvedDefaults.fontFamily = globalFontFamily
-      }
-
-      if (sourceDefaults?.fontSize !== undefined) {
-        resolvedDefaults.fontSize = sourceDefaults.fontSize
-      } else if (globalFontSize !== undefined) {
-        resolvedDefaults.fontSize = globalFontSize
-      }
-
-      if (sourceDefaults?.fontWeight !== undefined) {
-        resolvedDefaults.fontWeight = sourceDefaults.fontWeight
-      } else if (globalFontWeight !== undefined) {
-        resolvedDefaults.fontWeight = globalFontWeight
-      }
-
-      if (sourceDefaults?.fontStyle !== undefined) {
-        resolvedDefaults.fontStyle = sourceDefaults.fontStyle
-      } else if (globalFontStyle !== undefined) {
-        resolvedDefaults.fontStyle = globalFontStyle
-      }
-
-      if (sourceDefaults?.underline !== undefined) {
-        resolvedDefaults.underline = sourceDefaults.underline
-      } else if (globalUnderline !== undefined) {
-        resolvedDefaults.underline = globalUnderline
-      }
-
-      if (sourceDefaults?.linethrough !== undefined) {
-        resolvedDefaults.linethrough = sourceDefaults.linethrough
-      } else if (globalLinethrough !== undefined) {
-        resolvedDefaults.linethrough = globalLinethrough
-      }
-
-      if (sourceDefaults?.fill !== undefined) {
-        resolvedDefaults.fill = sourceDefaults.fill
-      } else if (resolvedGlobalFill !== undefined) {
-        resolvedDefaults.fill = resolvedGlobalFill
-      }
-
-      if (sourceDefaults?.stroke !== undefined) {
-        resolvedDefaults.stroke = sourceDefaults.stroke
-      } else if (resolvedGlobalStroke !== undefined) {
-        resolvedDefaults.stroke = resolvedGlobalStroke
-      }
-
-      if (sourceDefaults?.strokeWidth !== undefined) {
-        resolvedDefaults.strokeWidth = sourceDefaults.strokeWidth
-      } else if (resolvedDefaults.stroke !== undefined && globalStrokeWidth !== undefined) {
-        resolvedDefaults.strokeWidth = globalStrokeWidth
-      }
-
-      if (!storedLineDefaults && Object.keys(resolvedDefaults).length) {
-        if (!nextLineDefaults) {
-          nextLineDefaults = {}
-          lineDefaultsCloned = true
-        }
-
-        if (!lineDefaultsCloned) {
-          nextLineDefaults = { ...nextLineDefaults }
-          lineDefaultsCloned = true
-        }
-
-        nextLineDefaults[lineIndex] = resolvedDefaults
-        lineDefaultsChanged = true
-        lastLineDefaults = resolvedDefaults
-      }
-
-      if (storedLineDefaults) {
-        lastLineDefaults = storedLineDefaults
-      }
-
-      const allowedStyles = createLineDefaultStyle({ lineDefaults: resolvedDefaults })
-      const hasAllowedStyles = Object.keys(allowedStyles).length > 0
-      if (hasAllowedStyles || (nextStyles && nextStyles[lineIndex])) {
-        if (!nextStyles) {
-          nextStyles = {}
-          stylesCloned = true
-        }
-
-        if (!stylesCloned) {
-          nextStyles = { ...nextStyles }
-          stylesCloned = true
-        }
-
-        if (hasAllowedStyles) {
-          nextStyles[lineIndex] = { 0: allowedStyles }
-        }
-
-        if (!hasAllowedStyles && nextStyles[lineIndex]) {
-          delete nextStyles[lineIndex]
-        }
-
-        stylesChanged = true
-      }
-    }
-
-    if (lineDefaultsChanged && nextLineDefaults) {
-      textbox.lineFontDefaults = nextLineDefaults
-    }
-
-    if (stylesChanged) {
-      textbox.styles = nextStyles
+    if (syncResult.stylesChanged) {
+      textbox.styles = syncResult.styles
       textbox.dirty = true
     }
 

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -27,6 +27,7 @@ import TextScalingController from './scaling/text-scaling'
 import {
   applyLineDefaultUpdates,
   createLineDefaultStyle,
+  removeLineDefaultStyles,
   syncLineDefaultStyles
 } from './line-defaults'
 import {
@@ -1102,6 +1103,8 @@ export default class TextManager {
       historyManager
     } = this.editor
     historyManager.beginAction({ reason: 'text-edit' })
+    target.__lineDefaultsPrevText = target.text ?? ''
+
     if (TextManager._isShapeOwnedTextbox(target)) return
 
     const placementState = this._ensureEditingPlacementState()
@@ -1186,6 +1189,8 @@ export default class TextManager {
     let nextLineDefaults = lineFontDefaults
     let lineDefaultsChanged = false
     let lineDefaultsCloned = false
+    const removedLineDefaultsForStyleCleanup: LineFontDefault[] = []
+    let removedLineStyleCleanupIndex: number | undefined
 
     const resolvedGlobalFill = typeof rawGlobalFill === 'string' ? rawGlobalFill : undefined
     const resolvedGlobalStroke = typeof rawGlobalStroke === 'string' ? rawGlobalStroke : undefined
@@ -1244,6 +1249,14 @@ export default class TextManager {
         const removedLineEnd = removedLineStart + removedLinesCount - 1
         const shiftedDefaults: LineFontDefaults = {}
 
+        for (let lineIndex = removedLineStart; lineIndex <= removedLineEnd; lineIndex += 1) {
+          const removedLineDefault = lineFontDefaults[lineIndex]
+          if (removedLineDefault) {
+            removedLineDefaultsForStyleCleanup.push(removedLineDefault)
+          }
+        }
+        removedLineStyleCleanupIndex = removedLineStart
+
         for (const key in lineFontDefaults) {
           if (!Object.prototype.hasOwnProperty.call(lineFontDefaults, key)) continue
           const numericIndex = Number(key)
@@ -1270,6 +1283,45 @@ export default class TextManager {
     let stylesChanged = false
     let stylesCloned = false
     let lastLineDefaults: LineFontDefault | undefined
+
+    if (
+      removedLineStyleCleanupIndex !== undefined
+      && removedLineStyleCleanupIndex < currentLines.length
+      && removedLineDefaultsForStyleCleanup.length
+      && nextStyles
+    ) {
+      let cleanupLineStyles = nextStyles[removedLineStyleCleanupIndex]
+      let cleanupChanged = false
+
+      for (let index = 0; index < removedLineDefaultsForStyleCleanup.length; index += 1) {
+        const lineDefaultsForCleanup = removedLineDefaultsForStyleCleanup[index]
+        if (!lineDefaultsForCleanup) continue
+
+        const cleanupResult = removeLineDefaultStyles({
+          lineStyles: cleanupLineStyles,
+          lineDefaults: lineDefaultsForCleanup
+        })
+        if (!cleanupResult.changed) continue
+
+        cleanupLineStyles = cleanupResult.lineStyles
+        cleanupChanged = true
+      }
+
+      if (cleanupChanged) {
+        if (!stylesCloned) {
+          nextStyles = { ...nextStyles }
+          stylesCloned = true
+        }
+
+        if (cleanupLineStyles) {
+          nextStyles[removedLineStyleCleanupIndex] = cleanupLineStyles
+        } else {
+          delete nextStyles[removedLineStyleCleanupIndex]
+        }
+
+        stylesChanged = true
+      }
+    }
 
     for (let lineIndex = 0; lineIndex < currentLines.length; lineIndex += 1) {
       const lineText = currentLines[lineIndex] ?? ''
@@ -1533,6 +1585,7 @@ export default class TextManager {
     if (!TextManager._isTextbox(target)) return
     const isShapeOwnedTextbox = TextManager._isShapeOwnedTextbox(target)
     this.editingPlacementState?.delete(target)
+    delete target.__lineDefaultsPrevText
 
     // Обновляем textCaseRaw после редактирования, чтобы сохранить актуальное содержимое
     const currentText = target.text ?? ''

--- a/src/editor/text-manager/line-defaults.ts
+++ b/src/editor/text-manager/line-defaults.ts
@@ -1,4 +1,7 @@
-import type { TextboxProps } from 'fabric'
+import type {
+  TextStyle,
+  TextStyleDeclaration
+} from 'fabric'
 import type {
   LineFontDefault,
   LineFontDefaults
@@ -11,9 +14,199 @@ import {
   DIMENSION_EPSILON,
   MIN_TEXTBOX_FONT_SIZE
 } from './constants'
+import {
+  getFirstDiffIndex,
+  getLineIndexByCharIndex,
+  getLineStartIndex
+} from './selection'
 
-type TextboxLineStyle = Partial<TextboxProps>
-type TextboxLineStyles = Record<string, TextboxLineStyle>
+type TextboxStyles = TextStyle
+type TextboxLineStyle = TextStyleDeclaration
+type TextboxLineStyles = TextboxStyles[string]
+type DeletedLineDefaultsCleanup = {
+  lineIndex: number
+  lineDefaults: LineFontDefault[]
+}
+type LineFontDefaultsTextChangeResult = {
+  lineFontDefaults?: LineFontDefaults
+  changed: boolean
+  deletedLineDefaultsCleanup?: DeletedLineDefaultsCleanup
+}
+type LineFontDefaultsSyncResult = {
+  lineFontDefaults?: LineFontDefaults
+  lineFontDefaultsChanged: boolean
+  styles: TextboxStyles
+  stylesChanged: boolean
+}
+
+/**
+ * Сдвигает lineFontDefaults вниз после вставки одной или нескольких строк.
+ */
+const resolveLineFontDefaultsAfterLineInsertion = ({
+  deltaLines,
+  diffIndex,
+  lineFontDefaults,
+  lineIndexOld,
+  previousText
+}: {
+  deltaLines: number
+  diffIndex: number
+  lineFontDefaults: LineFontDefaults
+  lineIndexOld: number
+  previousText: string
+}): LineFontDefaultsTextChangeResult => {
+  const lineStartOld = getLineStartIndex({
+    text: previousText,
+    lineIndex: lineIndexOld
+  })
+  let shiftStartIndex = lineIndexOld + 1
+  if (diffIndex === lineStartOld) {
+    shiftStartIndex = lineIndexOld
+  }
+
+  const shiftedDefaults: LineFontDefaults = {}
+  for (const key in lineFontDefaults) {
+    if (!Object.prototype.hasOwnProperty.call(lineFontDefaults, key)) continue
+    const numericIndex = Number(key)
+    if (!Number.isFinite(numericIndex)) continue
+    const lineDefault = lineFontDefaults[numericIndex]
+    if (!lineDefault) continue
+
+    const nextIndex = numericIndex >= shiftStartIndex
+      ? numericIndex + deltaLines
+      : numericIndex
+    shiftedDefaults[nextIndex] = { ...lineDefault }
+  }
+
+  return {
+    lineFontDefaults: shiftedDefaults,
+    changed: true
+  }
+}
+
+/**
+ * Удаляет lineFontDefaults исчезнувших строк и сдвигает оставшиеся вверх.
+ */
+const resolveLineFontDefaultsAfterLineRemoval = ({
+  deltaLines,
+  diffIndex,
+  lineFontDefaults,
+  lineIndexOld,
+  previousLines,
+  previousText
+}: {
+  deltaLines: number
+  diffIndex: number
+  lineFontDefaults: LineFontDefaults
+  lineIndexOld: number
+  previousLines: string[]
+  previousText: string
+}): LineFontDefaultsTextChangeResult => {
+  const removedLinesCount = Math.abs(deltaLines)
+  let removedLineStart = lineIndexOld
+  const oldChar = previousText[diffIndex]
+
+  if (oldChar === '\n') {
+    const lineText = previousLines[lineIndexOld] ?? ''
+    if (lineText.length > 0) {
+      removedLineStart = lineIndexOld + 1
+    }
+  }
+
+  const removedLineEnd = removedLineStart + removedLinesCount - 1
+  const shiftedDefaults: LineFontDefaults = {}
+  const removedLineDefaults: LineFontDefault[] = []
+
+  for (let lineIndex = removedLineStart; lineIndex <= removedLineEnd; lineIndex += 1) {
+    const removedLineDefault = lineFontDefaults[lineIndex]
+    if (removedLineDefault) {
+      removedLineDefaults.push(removedLineDefault)
+    }
+  }
+
+  for (const key in lineFontDefaults) {
+    if (!Object.prototype.hasOwnProperty.call(lineFontDefaults, key)) continue
+    const numericIndex = Number(key)
+    if (!Number.isFinite(numericIndex)) continue
+    const lineDefault = lineFontDefaults[numericIndex]
+    if (!lineDefault) continue
+
+    if (numericIndex < removedLineStart) {
+      shiftedDefaults[numericIndex] = { ...lineDefault }
+    }
+
+    if (numericIndex > removedLineEnd) {
+      shiftedDefaults[numericIndex + deltaLines] = { ...lineDefault }
+    }
+  }
+
+  return {
+    lineFontDefaults: shiftedDefaults,
+    changed: true,
+    deletedLineDefaultsCleanup: {
+      lineIndex: removedLineStart,
+      lineDefaults: removedLineDefaults
+    }
+  }
+}
+
+/**
+ * Пересчитывает lineFontDefaults только для структурного изменения строк.
+ */
+const resolveLineFontDefaultsAfterTextChange = ({
+  lineFontDefaults,
+  previousText,
+  currentText
+}: {
+  currentText: string
+  lineFontDefaults?: LineFontDefaults
+  previousText: string
+}): LineFontDefaultsTextChangeResult => {
+  if (!lineFontDefaults || !Object.keys(lineFontDefaults).length) {
+    return {
+      lineFontDefaults,
+      changed: false
+    }
+  }
+
+  const previousLines = previousText.split('\n')
+  const currentLines = currentText.split('\n')
+  const deltaLines = currentLines.length - previousLines.length
+  if (deltaLines === 0) {
+    return {
+      lineFontDefaults,
+      changed: false
+    }
+  }
+
+  const diffIndex = getFirstDiffIndex({
+    previous: previousText,
+    next: currentText
+  })
+  const lineIndexOld = getLineIndexByCharIndex({
+    text: previousText,
+    charIndex: diffIndex
+  })
+
+  if (deltaLines > 0) {
+    return resolveLineFontDefaultsAfterLineInsertion({
+      deltaLines,
+      diffIndex,
+      lineFontDefaults,
+      lineIndexOld,
+      previousText
+    })
+  }
+
+  return resolveLineFontDefaultsAfterLineRemoval({
+    deltaLines,
+    diffIndex,
+    lineFontDefaults,
+    lineIndexOld,
+    previousLines,
+    previousText
+  })
+}
 
 /**
  * Создаёт Fabric style-объект из lineFontDefaults.
@@ -204,7 +397,7 @@ export const removeLineDefaultStyles = ({
   if (!lineStyles) return { lineStyles, changed: false }
 
   const defaultStyles = createLineDefaultStyle({ lineDefaults })
-  const defaultStyleKeys = Object.keys(defaultStyles) as Array<keyof TextboxProps>
+  const defaultStyleKeys = Object.keys(defaultStyles) as Array<keyof TextboxLineStyle>
   if (!defaultStyleKeys.length) return { lineStyles, changed: false }
 
   let nextLineStyles = lineStyles
@@ -262,6 +455,187 @@ export const removeLineDefaultStyles = ({
 }
 
 /**
+ * Удаляет из inline styles служебные значения строки, которая была полностью удалена.
+ */
+const removeDeletedLineDefaultStyles = ({
+  cleanup,
+  lineCount,
+  styles
+}: {
+  cleanup?: DeletedLineDefaultsCleanup
+  lineCount: number
+  styles: TextboxStyles
+}): { styles: TextboxStyles; changed: boolean } => {
+  if (!cleanup) return { styles, changed: false }
+  if (cleanup.lineIndex >= lineCount) return { styles, changed: false }
+
+  let cleanupLineStyles: TextboxLineStyles | undefined = styles[cleanup.lineIndex]
+  let cleanupChanged = false
+
+  for (let index = 0; index < cleanup.lineDefaults.length; index += 1) {
+    const lineDefaultsForCleanup = cleanup.lineDefaults[index]
+    if (!lineDefaultsForCleanup) continue
+
+    const cleanupResult = removeLineDefaultStyles({
+      lineStyles: cleanupLineStyles,
+      lineDefaults: lineDefaultsForCleanup
+    })
+    if (!cleanupResult.changed) continue
+
+    cleanupLineStyles = cleanupResult.lineStyles
+    cleanupChanged = true
+  }
+
+  if (!cleanupChanged) {
+    return { styles, changed: false }
+  }
+
+  const nextStyles = { ...styles }
+
+  if (cleanupLineStyles) {
+    nextStyles[cleanup.lineIndex] = cleanupLineStyles
+  } else {
+    delete nextStyles[cleanup.lineIndex]
+  }
+
+  return {
+    styles: nextStyles,
+    changed: true
+  }
+}
+
+/**
+ * Собирает глобальные текстовые стили textbox в формате line defaults.
+ */
+const createGlobalLineDefaults = ({
+  textbox
+}: {
+  textbox: EditorTextbox
+}): LineFontDefault => {
+  const {
+    fontFamily,
+    fontSize,
+    fontStyle,
+    fontWeight,
+    fill: rawFill,
+    stroke: rawStroke,
+    strokeWidth,
+    linethrough,
+    underline
+  } = textbox
+  const globalLineDefaults: LineFontDefault = {}
+  const fill = typeof rawFill === 'string' ? rawFill : undefined
+  const stroke = typeof rawStroke === 'string' ? rawStroke : undefined
+
+  if (fontFamily !== undefined) {
+    globalLineDefaults.fontFamily = fontFamily
+  }
+
+  if (fontSize !== undefined) {
+    globalLineDefaults.fontSize = fontSize
+  }
+
+  if (fontWeight !== undefined) {
+    globalLineDefaults.fontWeight = fontWeight
+  }
+
+  if (fontStyle !== undefined) {
+    globalLineDefaults.fontStyle = fontStyle
+  }
+
+  if (underline !== undefined) {
+    globalLineDefaults.underline = underline
+  }
+
+  if (linethrough !== undefined) {
+    globalLineDefaults.linethrough = linethrough
+  }
+
+  if (fill !== undefined) {
+    globalLineDefaults.fill = fill
+  }
+
+  if (stroke !== undefined) {
+    globalLineDefaults.stroke = stroke
+  }
+
+  if (strokeWidth !== undefined) {
+    globalLineDefaults.strokeWidth = strokeWidth
+  }
+
+  return globalLineDefaults
+}
+
+/**
+ * Разрешает line defaults для пустой строки от ближайшего line default или глобальных стилей textbox.
+ */
+const createEmptyLineDefaults = ({
+  sourceDefaults,
+  globalLineDefaults
+}: {
+  globalLineDefaults: LineFontDefault
+  sourceDefaults?: LineFontDefault
+}): LineFontDefault => {
+  const resolvedDefaults: LineFontDefault = {}
+
+  if (sourceDefaults?.fontFamily !== undefined) {
+    resolvedDefaults.fontFamily = sourceDefaults.fontFamily
+  } else if (globalLineDefaults.fontFamily !== undefined) {
+    resolvedDefaults.fontFamily = globalLineDefaults.fontFamily
+  }
+
+  if (sourceDefaults?.fontSize !== undefined) {
+    resolvedDefaults.fontSize = sourceDefaults.fontSize
+  } else if (globalLineDefaults.fontSize !== undefined) {
+    resolvedDefaults.fontSize = globalLineDefaults.fontSize
+  }
+
+  if (sourceDefaults?.fontWeight !== undefined) {
+    resolvedDefaults.fontWeight = sourceDefaults.fontWeight
+  } else if (globalLineDefaults.fontWeight !== undefined) {
+    resolvedDefaults.fontWeight = globalLineDefaults.fontWeight
+  }
+
+  if (sourceDefaults?.fontStyle !== undefined) {
+    resolvedDefaults.fontStyle = sourceDefaults.fontStyle
+  } else if (globalLineDefaults.fontStyle !== undefined) {
+    resolvedDefaults.fontStyle = globalLineDefaults.fontStyle
+  }
+
+  if (sourceDefaults?.underline !== undefined) {
+    resolvedDefaults.underline = sourceDefaults.underline
+  } else if (globalLineDefaults.underline !== undefined) {
+    resolvedDefaults.underline = globalLineDefaults.underline
+  }
+
+  if (sourceDefaults?.linethrough !== undefined) {
+    resolvedDefaults.linethrough = sourceDefaults.linethrough
+  } else if (globalLineDefaults.linethrough !== undefined) {
+    resolvedDefaults.linethrough = globalLineDefaults.linethrough
+  }
+
+  if (sourceDefaults?.fill !== undefined) {
+    resolvedDefaults.fill = sourceDefaults.fill
+  } else if (globalLineDefaults.fill !== undefined) {
+    resolvedDefaults.fill = globalLineDefaults.fill
+  }
+
+  if (sourceDefaults?.stroke !== undefined) {
+    resolvedDefaults.stroke = sourceDefaults.stroke
+  } else if (globalLineDefaults.stroke !== undefined) {
+    resolvedDefaults.stroke = globalLineDefaults.stroke
+  }
+
+  if (sourceDefaults?.strokeWidth !== undefined) {
+    resolvedDefaults.strokeWidth = sourceDefaults.strokeWidth
+  } else if (resolvedDefaults.stroke !== undefined && globalLineDefaults.strokeWidth !== undefined) {
+    resolvedDefaults.strokeWidth = globalLineDefaults.strokeWidth
+  }
+
+  return resolvedDefaults
+}
+
+/**
  * Синхронизирует inline-стили строки с lineFontDefaults, заполняя пропуски.
  */
 export const syncLineDefaultStyles = ({
@@ -279,7 +653,7 @@ export const syncLineDefaultStyles = ({
   }
 
   const defaultStyles = createLineDefaultStyle({ lineDefaults })
-  const defaultStyleKeys = Object.keys(defaultStyles) as Array<keyof TextboxProps>
+  const defaultStyleKeys = Object.keys(defaultStyles) as Array<keyof TextboxLineStyle>
 
   if (!defaultStyleKeys.length) {
     return { lineStyles, changed: false }
@@ -359,6 +733,174 @@ export const syncLineDefaultStyles = ({
   return {
     lineStyles: nextLineStyles,
     changed: stylesChanged
+  }
+}
+
+/**
+ * Синхронизирует lineFontDefaults и inline styles с текущим набором строк текста.
+ */
+const syncLineFontDefaultsWithCurrentLines = ({
+  deletedLineDefaultsCleanup,
+  globalLineDefaults,
+  lineFontDefaults,
+  lines,
+  styles
+}: {
+  deletedLineDefaultsCleanup?: DeletedLineDefaultsCleanup
+  globalLineDefaults: LineFontDefault
+  lineFontDefaults?: LineFontDefaults
+  lines: string[]
+  styles?: TextboxStyles
+}): LineFontDefaultsSyncResult => {
+  let nextLineDefaults = lineFontDefaults
+  let lineDefaultsChanged = false
+  let lineDefaultsCloned = false
+  let nextStyles = styles
+  let stylesChanged = false
+  let stylesCloned = false
+  let lastLineDefaults: LineFontDefault | undefined
+
+  const cleanupResult = removeDeletedLineDefaultStyles({
+    styles: nextStyles ?? {},
+    lineCount: lines.length,
+    cleanup: deletedLineDefaultsCleanup
+  })
+  if (cleanupResult.changed) {
+    nextStyles = cleanupResult.styles
+    stylesChanged = true
+    stylesCloned = true
+  }
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const lineText = lines[lineIndex] ?? ''
+    const storedLineDefaults = nextLineDefaults ? nextLineDefaults[lineIndex] : undefined
+
+    if (storedLineDefaults) {
+      lastLineDefaults = storedLineDefaults
+    }
+
+    const hasLineText = lineText.length !== 0
+    if (hasLineText) {
+      if (storedLineDefaults) {
+        const syncResult = syncLineDefaultStyles({
+          lineText,
+          lineStyles: nextStyles ? nextStyles[lineIndex] : undefined,
+          lineDefaults: storedLineDefaults
+        })
+
+        if (syncResult.changed) {
+          if (!nextStyles) {
+            nextStyles = {}
+            stylesCloned = true
+          }
+
+          if (!stylesCloned) {
+            nextStyles = { ...nextStyles }
+            stylesCloned = true
+          }
+
+          if (syncResult.lineStyles) {
+            nextStyles[lineIndex] = syncResult.lineStyles
+          }
+
+          if (!syncResult.lineStyles && nextStyles[lineIndex]) {
+            delete nextStyles[lineIndex]
+          }
+
+          stylesChanged = true
+        }
+      }
+
+      continue
+    }
+
+    const sourceDefaults = storedLineDefaults ?? lastLineDefaults
+    const resolvedDefaults = createEmptyLineDefaults({
+      sourceDefaults,
+      globalLineDefaults
+    })
+
+    if (!storedLineDefaults && Object.keys(resolvedDefaults).length) {
+      if (!nextLineDefaults) {
+        nextLineDefaults = {}
+        lineDefaultsCloned = true
+      }
+
+      if (!lineDefaultsCloned) {
+        nextLineDefaults = { ...nextLineDefaults }
+        lineDefaultsCloned = true
+      }
+
+      nextLineDefaults[lineIndex] = resolvedDefaults
+      lineDefaultsChanged = true
+      lastLineDefaults = resolvedDefaults
+    }
+
+    if (storedLineDefaults) {
+      lastLineDefaults = storedLineDefaults
+    }
+
+    const allowedStyles = createLineDefaultStyle({ lineDefaults: resolvedDefaults })
+    const hasAllowedStyles = Object.keys(allowedStyles).length > 0
+    if (hasAllowedStyles || (nextStyles && nextStyles[lineIndex])) {
+      if (!nextStyles) {
+        nextStyles = {}
+        stylesCloned = true
+      }
+
+      if (!stylesCloned) {
+        nextStyles = { ...nextStyles }
+        stylesCloned = true
+      }
+
+      if (hasAllowedStyles) {
+        nextStyles[lineIndex] = { 0: allowedStyles }
+      }
+
+      if (!hasAllowedStyles && nextStyles[lineIndex]) {
+        delete nextStyles[lineIndex]
+      }
+
+      stylesChanged = true
+    }
+  }
+
+  return {
+    lineFontDefaults: nextLineDefaults,
+    lineFontDefaultsChanged: lineDefaultsChanged,
+    styles: nextStyles ?? {},
+    stylesChanged
+  }
+}
+
+/**
+ * Возвращает следующие lineFontDefaults и Fabric styles после изменения текста, не мутируя textbox.
+ */
+export const syncLineFontDefaultsAfterTextChange = ({
+  currentText,
+  previousText,
+  textbox
+}: {
+  currentText: string
+  previousText: string
+  textbox: EditorTextbox
+}): LineFontDefaultsSyncResult => {
+  const lineDefaultsChange = resolveLineFontDefaultsAfterTextChange({
+    lineFontDefaults: textbox.lineFontDefaults,
+    previousText,
+    currentText
+  })
+  const currentLinesSync = syncLineFontDefaultsWithCurrentLines({
+    lines: currentText.split('\n'),
+    styles: textbox.styles,
+    lineFontDefaults: lineDefaultsChange.lineFontDefaults,
+    deletedLineDefaultsCleanup: lineDefaultsChange.deletedLineDefaultsCleanup,
+    globalLineDefaults: createGlobalLineDefaults({ textbox })
+  })
+
+  return {
+    ...currentLinesSync,
+    lineFontDefaultsChanged: lineDefaultsChange.changed || currentLinesSync.lineFontDefaultsChanged
   }
 }
 

--- a/src/editor/text-manager/line-defaults.ts
+++ b/src/editor/text-manager/line-defaults.ts
@@ -12,6 +12,58 @@ import {
   MIN_TEXTBOX_FONT_SIZE
 } from './constants'
 
+type TextboxLineStyle = Partial<TextboxProps>
+type TextboxLineStyles = Record<string, TextboxLineStyle>
+
+/**
+ * Создаёт Fabric style-объект из lineFontDefaults.
+ */
+export const createLineDefaultStyle = ({
+  lineDefaults
+}: {
+  lineDefaults: LineFontDefault
+}): TextboxLineStyle => {
+  const styles: TextboxLineStyle = {}
+
+  if (lineDefaults.fontFamily !== undefined) {
+    styles.fontFamily = lineDefaults.fontFamily
+  }
+
+  if (lineDefaults.fontSize !== undefined) {
+    styles.fontSize = lineDefaults.fontSize
+  }
+
+  if (lineDefaults.fontWeight !== undefined) {
+    styles.fontWeight = lineDefaults.fontWeight
+  }
+
+  if (lineDefaults.fontStyle !== undefined) {
+    styles.fontStyle = lineDefaults.fontStyle
+  }
+
+  if (lineDefaults.underline !== undefined) {
+    styles.underline = lineDefaults.underline
+  }
+
+  if (lineDefaults.linethrough !== undefined) {
+    styles.linethrough = lineDefaults.linethrough
+  }
+
+  if (lineDefaults.fill !== undefined) {
+    styles.fill = lineDefaults.fill
+  }
+
+  if (lineDefaults.stroke !== undefined) {
+    styles.stroke = lineDefaults.stroke
+  }
+
+  if (lineDefaults.strokeWidth !== undefined) {
+    styles.strokeWidth = lineDefaults.strokeWidth
+  }
+
+  return styles
+}
+
 /**
  * Обновляет lineFontDefaults для указанных строк, изменяя только заданные поля.
  */
@@ -27,15 +79,25 @@ export const applyLineDefaultUpdates = ({
   if (!lineIndices.length) return false
 
   const {
+    fill,
     fontFamily,
     fontSize,
-    fill,
-    stroke
+    fontStyle,
+    fontWeight,
+    linethrough,
+    stroke,
+    strokeWidth,
+    underline
   } = updates
-  const hasUpdates = fontFamily !== undefined
+  const hasUpdates = fill !== undefined
+    || fontFamily !== undefined
     || fontSize !== undefined
-    || fill !== undefined
+    || fontStyle !== undefined
+    || fontWeight !== undefined
+    || linethrough !== undefined
     || stroke !== undefined
+    || strokeWidth !== undefined
+    || underline !== undefined
   if (!hasUpdates) return false
 
   const { lineFontDefaults } = textbox
@@ -65,6 +127,26 @@ export const applyLineDefaultUpdates = ({
       lineChanged = true
     }
 
+    if (fontWeight !== undefined && currentLineDefaults?.fontWeight !== fontWeight) {
+      nextLineDefault.fontWeight = fontWeight
+      lineChanged = true
+    }
+
+    if (fontStyle !== undefined && currentLineDefaults?.fontStyle !== fontStyle) {
+      nextLineDefault.fontStyle = fontStyle
+      lineChanged = true
+    }
+
+    if (underline !== undefined && currentLineDefaults?.underline !== underline) {
+      nextLineDefault.underline = underline
+      lineChanged = true
+    }
+
+    if (linethrough !== undefined && currentLineDefaults?.linethrough !== linethrough) {
+      nextLineDefault.linethrough = linethrough
+      lineChanged = true
+    }
+
     if (fill !== undefined && currentLineDefaults?.fill !== fill) {
       nextLineDefault.fill = fill
       lineChanged = true
@@ -82,6 +164,11 @@ export const applyLineDefaultUpdates = ({
         nextLineDefault.stroke = stroke
         lineChanged = true
       }
+    }
+
+    if (strokeWidth !== undefined && currentLineDefaults?.strokeWidth !== strokeWidth) {
+      nextLineDefault.strokeWidth = strokeWidth
+      lineChanged = true
     }
 
     if (!lineChanged) {
@@ -113,43 +200,19 @@ export const syncLineDefaultStyles = ({
   lineDefaults
 }: {
   lineText: string
-  lineStyles?: Record<string, TextboxProps>
+  lineStyles?: TextboxLineStyles
   lineDefaults: LineFontDefault
-}): { lineStyles?: Record<string, TextboxProps>; changed: boolean } => {
+}): { lineStyles?: TextboxLineStyles; changed: boolean } => {
   const lineLength = lineText.length
   if (lineLength === 0) {
     return { lineStyles, changed: false }
   }
 
-  const {
-    fontFamily,
-    fontSize,
-    fill,
-    stroke
-  } = lineDefaults
-  const hasDefaults = fontFamily !== undefined
-    || fontSize !== undefined
-    || fill !== undefined
-    || stroke !== undefined
-  if (!hasDefaults) {
+  const defaultStyles = createLineDefaultStyle({ lineDefaults })
+  const defaultStyleKeys = Object.keys(defaultStyles) as Array<keyof TextboxProps>
+
+  if (!defaultStyleKeys.length) {
     return { lineStyles, changed: false }
-  }
-
-  const defaultStyles: Partial<TextboxProps> = {}
-  if (fontFamily !== undefined) {
-    defaultStyles.fontFamily = fontFamily
-  }
-
-  if (fontSize !== undefined) {
-    defaultStyles.fontSize = fontSize
-  }
-
-  if (fill !== undefined) {
-    defaultStyles.fill = fill
-  }
-
-  if (stroke !== undefined) {
-    defaultStyles.stroke = stroke
   }
 
   let nextLineStyles = lineStyles
@@ -200,35 +263,9 @@ export const syncLineDefaultStyles = ({
       continue
     }
 
-    let nextCharStyles: TextboxProps | null = null
-
-    if (fontFamily !== undefined && currentStyle.fontFamily === undefined) {
-      nextCharStyles = { ...currentStyle }
-      nextCharStyles.fontFamily = fontFamily
-    }
-
-    if (fontSize !== undefined && currentStyle.fontSize === undefined) {
-      if (!nextCharStyles) {
-        nextCharStyles = { ...currentStyle }
-      }
-      nextCharStyles.fontSize = fontSize
-    }
-
-    if (fill !== undefined && currentStyle.fill === undefined) {
-      if (!nextCharStyles) {
-        nextCharStyles = { ...currentStyle }
-      }
-      nextCharStyles.fill = fill
-    }
-
-    if (stroke !== undefined && currentStyle.stroke === undefined) {
-      if (!nextCharStyles) {
-        nextCharStyles = { ...currentStyle }
-      }
-      nextCharStyles.stroke = stroke
-    }
-
-    if (!nextCharStyles) {
+    const hasMissingDefaultStyle = defaultStyleKeys
+      .some((property) => currentStyle[property] === undefined)
+    if (!hasMissingDefaultStyle) {
       continue
     }
 
@@ -242,7 +279,10 @@ export const syncLineDefaultStyles = ({
       stylesCloned = true
     }
 
-    nextLineStyles[charIndex] = nextCharStyles
+    nextLineStyles[charIndex] = {
+      ...defaultStyles,
+      ...currentStyle
+    }
     stylesChanged = true
   }
 

--- a/src/editor/text-manager/line-defaults.ts
+++ b/src/editor/text-manager/line-defaults.ts
@@ -192,6 +192,76 @@ export const applyLineDefaultUpdates = ({
 }
 
 /**
+ * Убирает из inline-стилей свойства, которые были перенесены из удалённого line default.
+ */
+export const removeLineDefaultStyles = ({
+  lineStyles,
+  lineDefaults
+}: {
+  lineDefaults: LineFontDefault
+  lineStyles?: TextboxLineStyles
+}): { lineStyles?: TextboxLineStyles; changed: boolean } => {
+  if (!lineStyles) return { lineStyles, changed: false }
+
+  const defaultStyles = createLineDefaultStyle({ lineDefaults })
+  const defaultStyleKeys = Object.keys(defaultStyles) as Array<keyof TextboxProps>
+  if (!defaultStyleKeys.length) return { lineStyles, changed: false }
+
+  let nextLineStyles = lineStyles
+  let lineStylesCloned = false
+  let stylesChanged = false
+
+  for (const key in lineStyles) {
+    if (!Object.prototype.hasOwnProperty.call(lineStyles, key)) continue
+
+    const currentStyle = lineStyles[key]
+    if (!currentStyle) continue
+
+    let nextStyle = currentStyle
+    let styleChanged = false
+
+    for (let index = 0; index < defaultStyleKeys.length; index += 1) {
+      const property = defaultStyleKeys[index]
+      if (!property) continue
+      if (currentStyle[property] !== defaultStyles[property]) continue
+
+      if (!styleChanged) {
+        nextStyle = { ...currentStyle }
+        styleChanged = true
+      }
+
+      delete nextStyle[property]
+    }
+
+    if (!styleChanged) continue
+
+    if (!lineStylesCloned) {
+      nextLineStyles = { ...lineStyles }
+      lineStylesCloned = true
+    }
+
+    if (Object.keys(nextStyle).length) {
+      nextLineStyles[key] = nextStyle
+    } else {
+      delete nextLineStyles[key]
+    }
+
+    stylesChanged = true
+  }
+
+  if (!stylesChanged) {
+    return { lineStyles, changed: false }
+  }
+
+  const hasStyles = Object.keys(nextLineStyles).length > 0
+
+  return {
+    lineStyles: hasStyles ? nextLineStyles : undefined,
+    changed: true
+  }
+}
+
+/**
  * Синхронизирует inline-стили строки с lineFontDefaults, заполняя пропуски.
  */
 export const syncLineDefaultStyles = ({

--- a/src/editor/text-manager/types.ts
+++ b/src/editor/text-manager/types.ts
@@ -145,7 +145,12 @@ export type LineFontDefaultUpdate = {
   fill?: string
   fontFamily?: string
   fontSize?: number
+  fontStyle?: TextboxProps['fontStyle']
+  fontWeight?: TextboxProps['fontWeight']
+  linethrough?: boolean
   stroke?: string | null
+  strokeWidth?: number
+  underline?: boolean
 }
 
 export type TextScaleBaseState = {


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить текстовый объект с двумя строками "TEST \n TEST TEXT" с общим размером шрифта 48px
2. Выделить текст первой строки, а затем задать шрифт Exo 2, жирное начертание, наклонный текст, зачеркнутый текст, подчеркнутый текст, обводка 1 px, и размер шрифта 36px, оранжевый цвет текста
3. Выделить текст второй строки, а затем задать шрифт Oswald, жирное начертание, наклонный текст, зачеркнутый текст, подчеркнутый текст, обводка 1 px, и размер текста 24px, оранжевый цвет текста (скрин 1)

<img width="339" height="260" alt="image" src="https://github.com/user-attachments/assets/f3d82d79-7bc5-4169-a0e1-822c2af889a1" />


4. Стерть первую строку, и написать вместо неё что-то другое, например, строку "FIRST LINE". Стерть вторую строку, и написать вместо неё что-то другое, например, строку "SECOND LINE".

Ожидаемое поведение.

Новый текст в первой строке сохранит все стилизации, шрифт, цвет, и размер текста.
Новый текст во второй строке сохранит все стилизации, шрифт, цвет, и размер текста.

Фактический результат.

Новый текст в обеих строках теряет стиллизации, потому что они не заданы для всего объекта (скрин 2)

<img width="509" height="272" alt="image" src="https://github.com/user-attachments/assets/aa2a5f7f-6de5-42c9-bfff-3339a9eac4ca" />

Список стиллизаций которые пропадают после стирания строки и ввода текста:
- Жирный шрифт
- Наклонный текст
- Подчеркивание
- Зачеркивание
- Обводка

---

FIXED