### PR TITLE
ShapeManager. Правим некоректный массовый скейлинг шейпов

### DIFF
--- a/e2e/fixtures/data/shape-multi-scaling.data.ts
+++ b/e2e/fixtures/data/shape-multi-scaling.data.ts
@@ -1,0 +1,33 @@
+export const SHAPE_MULTI_SCALING_LEFT_OPTIONS = {
+  id: 'shape-multi-scaling-left',
+  left: 120,
+  top: 120,
+  width: 220,
+  height: 220,
+  text: 'Active text',
+  textStyle: {
+    fontSize: 48
+  }
+}
+
+export const SHAPE_MULTI_SCALING_RIGHT_OPTIONS = {
+  id: 'shape-multi-scaling-right',
+  left: 420,
+  top: 120,
+  width: 220,
+  height: 220,
+  text: 'Active text',
+  textStyle: {
+    fontSize: 48
+  }
+}
+
+export const SHAPE_MULTI_SCALING_SCALE_X = 0.55
+
+export const SHAPE_MULTI_SCALING_SCALE_Y = 0.55
+
+export const SHAPE_MULTI_SCALING_EDITED_TEXT = 'Active text Active text Active text Active text'
+
+export const SHAPE_MULTI_SCALING_TOLERANCE = {
+  mouseupJump: 1.5
+}

--- a/e2e/helpers/browser/editor-browser-helpers.installer.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.installer.ts
@@ -113,6 +113,11 @@ export function installEditorBrowserHelpers(): void {
    */
   function getBoundingRect({ target }: { target: unknown }): BrowserObject | null {
     const canvasObject = toBrowserObject({ value: target }) as BrowserBoundedObject
+
+    if (typeof canvasObject.getBoundingRect !== 'function') {
+      return null
+    }
+
     const bounds = canvasObject.getBoundingRect()
 
     return toBrowserObject({ value: bounds })
@@ -459,6 +464,20 @@ export function installEditorBrowserHelpers(): void {
     if (objectIndex === undefined) return undefined
 
     return objects[objectIndex]
+  }
+
+  /**
+   * Возвращает canvas-объект по индексу или id, а при их отсутствии — target текущего transform или active object.
+   */
+  function resolveCanvasObjectOrActive({ objectIndex, id }: { objectIndex?: number, id?: string }): unknown {
+    const target = resolveCanvasObject({ objectIndex, id })
+
+    if (target !== undefined) return target
+
+    const transformTarget = browserWindow.editor.canvas._currentTransform?.target
+    if (transformTarget) return transformTarget
+
+    return browserWindow.editor.canvas.getActiveObject()
   }
 
   /**
@@ -991,6 +1010,9 @@ export function installEditorBrowserHelpers(): void {
       },
       resolveCanvasObject(objectIndex?: number, id?: string) {
         return resolveCanvasObject({ objectIndex, id })
+      },
+      resolveCanvasObjectOrActive(objectIndex?: number, id?: string) {
+        return resolveCanvasObjectOrActive({ objectIndex, id })
       },
       getSnappingGuideState() {
         return {

--- a/e2e/helpers/browser/editor-browser-helpers.types.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.types.ts
@@ -139,6 +139,7 @@ export interface BrowserEditorHelpers {
   resolveShapeNode: (group: unknown) => BrowserObject | null
   resolveTarget: (objectIndex?: number, id?: string) => unknown
   resolveCanvasObject: (objectIndex?: number, id?: string) => unknown
+  resolveCanvasObjectOrActive: (objectIndex?: number, id?: string) => unknown
   getSnappingGuideState: () => BrowserSnappingGuideState
   getTextSelectionStyles: (params: BrowserTextSelectionStyleParams) => BrowserTextSelectionStyleInfo | null
   getShapeTextSelectionStyles: (params: BrowserTextSelectionStyleParams) => BrowserTextSelectionStyleInfo | null
@@ -163,6 +164,10 @@ export interface NullableBoundsInfo {
 export interface BrowserEditorWindow extends Window {
   editor: {
     canvas: {
+      _currentTransform?: {
+        target?: unknown
+      } | null
+      getActiveObject: () => unknown
       upperCanvasEl: {
         style: {
           pointerEvents: string

--- a/e2e/models/shape.model.ts
+++ b/e2e/models/shape.model.ts
@@ -57,7 +57,7 @@ export class ShapeModel {
         __editorHelpers: helpers
       } = window as any
 
-      const target = helpers.resolveCanvasObject(objectIndex, id)
+      const target = helpers.resolveCanvasObjectOrActive(objectIndex, id)
       if (!target) return null
 
       target.setCoords()
@@ -450,7 +450,7 @@ export class ShapeModel {
     return snapshot
   }
 
-  /** Масштабирует shape по горизонтали за правую ручку и возвращает live snapshot. */
+  /** Масштабирует текущий target на canvas по горизонтали за правую ручку и возвращает live snapshot. */
   async scaleHorizontallyFromRight(
     params: { scaleX: number, ctrlKey?: boolean } & ObjectTargetParams
   ): Promise<ShapeScaleSnapshot> {
@@ -558,7 +558,7 @@ export class ShapeModel {
     return states
   }
 
-  /** Масштабирует shape по вертикали за нижнюю ручку и возвращает live snapshot. */
+  /** Масштабирует текущий target на canvas по вертикали за нижнюю ручку и возвращает live snapshot. */
   async scaleVerticallyFromBottom(
     params: { scaleY: number, ctrlKey?: boolean } & ObjectTargetParams
   ): Promise<ShapeScaleSnapshot> {
@@ -703,7 +703,7 @@ export class ShapeModel {
         __editorHelpers: helpers
       } = window as any
 
-      const target = helpers.resolveCanvasObject(objectIndex, id)
+      const target = helpers.resolveCanvasObjectOrActive(objectIndex, id)
       if (!target) return null
 
       const transform = editor.canvas._currentTransform
@@ -891,7 +891,7 @@ export class ShapeModel {
         __editorHelpers: helpers
       } = window as any
 
-      const target = helpers.resolveCanvasObject(objectIndex, id)
+      const target = helpers.resolveCanvasObjectOrActive(objectIndex, id)
       if (!target) return null
 
       const left = typeof target.left === 'number' ? target.left : 0
@@ -1156,7 +1156,7 @@ export class ShapeModel {
           __editorHelpers: helpers
         } = window as any
 
-        const target = helpers.resolveCanvasObject(targetObjectIndex, targetId)
+        const target = helpers.resolveCanvasObjectOrActive(targetObjectIndex, targetId)
         if (!target) return null
 
         target.setCoords()
@@ -1277,7 +1277,7 @@ export class ShapeModel {
         __editorHelpers: helpers
       } = window as any
 
-      const target = helpers.resolveCanvasObject(targetObjectIndex, targetId)
+      const target = helpers.resolveCanvasObjectOrActive(targetObjectIndex, targetId)
       if (!target) return null
 
       editor.canvas.setActiveObject(target)
@@ -1354,18 +1354,18 @@ export class ShapeModel {
     return true
   }
 
-  /** Возвращает текущий snapshot состояния shape-группы, fail-fast проверяет его наличие. */
+  /** Возвращает текущий snapshot масштабируемого target, fail-fast проверяет его наличие. */
   async getScaleSnapshot(params: ObjectTargetParams = {}): Promise<ShapeScaleSnapshot> {
     const snapshot = await this.page.evaluate(({ objectIndex, id }) => {
       const { __editorHelpers: helpers } = window as any
 
-      const target = helpers.resolveCanvasObject(objectIndex, id)
+      const target = helpers.resolveCanvasObjectOrActive(objectIndex, id)
       if (!target) return null
 
       return helpers.serializeShapeScaleSnapshot(target)
     }, params)
 
-    expect(snapshot, 'должен существовать текущий snapshot масштабируемого shape').not.toBeNull()
+    expect(snapshot, 'должен существовать текущий snapshot масштабируемого target').not.toBeNull()
 
     return snapshot as ShapeScaleSnapshot
   }
@@ -1471,7 +1471,7 @@ export class ShapeModel {
         __editorHelpers: helpers
       } = window as any
 
-      const target = helpers.resolveCanvasObject(objectIndex, id)
+      const target = helpers.resolveCanvasObjectOrActive(objectIndex, id)
       if (!target) return null
 
       const shapeNode = helpers.resolveShapeNode(target)
@@ -1497,7 +1497,7 @@ export class ShapeModel {
         __editorHelpers: helpers
       } = window as any
 
-      const target = helpers.resolveCanvasObject(objectIndex, id)
+      const target = helpers.resolveCanvasObjectOrActive(objectIndex, id)
       if (!target) return null
 
       editor.canvas.setActiveObject(target)
@@ -1556,7 +1556,12 @@ export class ShapeModel {
 
     expect(point, 'для клика по фигуре должны существовать координаты на canvas').not.toBeNull()
 
-    await this.page.mouse.click(point.x, point.y)
+    const resolvedPoint = point as {
+      x: number
+      y: number
+    }
+
+    await this.page.mouse.click(resolvedPoint.x, resolvedPoint.y)
     await waitForCanvasRender({ page: this.page })
   }
 

--- a/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
+++ b/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
@@ -1,0 +1,408 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  SHAPE_MULTI_SCALING_EDITED_TEXT,
+  SHAPE_MULTI_SCALING_LEFT_OPTIONS,
+  SHAPE_MULTI_SCALING_RIGHT_OPTIONS,
+  SHAPE_MULTI_SCALING_SCALE_X,
+  SHAPE_MULTI_SCALING_SCALE_Y,
+  SHAPE_MULTI_SCALING_TOLERANCE
+} from '../../fixtures/data/shape-multi-scaling.data'
+
+test.describe('Изменение размера нескольких шейпов', () => {
+  test.beforeEach(async({ editorModel, shapes }) => {
+    const leftShape = await shapes.addAtBounds({
+      presetKey: 'square',
+      options: SHAPE_MULTI_SCALING_LEFT_OPTIONS
+    })
+    const rightShape = await shapes.addAtBounds({
+      presetKey: 'square',
+      options: SHAPE_MULTI_SCALING_RIGHT_OPTIONS
+    })
+
+    shapes.checkCreation({
+      shape: leftShape,
+      presetKey: 'square'
+    })
+    shapes.checkCreation({
+      shape: rightShape,
+      presetKey: 'square'
+    })
+
+    await editorModel.selectAllObjects()
+  })
+
+  test('при сужении нескольких шейпов справа текст в них переносится уже во время drag', async({ shapes }) => {
+    const initialSelectionSnapshot = await test.step('Получить исходную ширину общего выделения', () => {
+      return shapes.getScaleSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в левом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в правом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    const liveSelectionSnapshot = await test.step('Сузить общее выделение справа во время drag', () => {
+      return shapes.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+    })
+    const liveLeftText = await test.step('Получить текст в левом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightText = await test.step('Получить текст в правом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const liveLeftShape = await test.step('Получить состояние левого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightShape = await test.step('Получить состояние правого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что текст уже переносится во время drag и не выходит за границы своих шейпов', () => {
+      expect(initialLeftText, 'текст в левом шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в правом шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.groupBoundsWidth)
+        .toBeLessThan(initialSelectionSnapshot.groupBoundsWidth - SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(initialLeftText.lineCount).toBe(1)
+      expect(initialRightText.lineCount).toBe(1)
+      expect(liveLeftText.lineCount).toBeGreaterThan(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBeGreaterThan(initialRightText.lineCount)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('после сужения нескольких шейпов справа их размер не дёргается после отпускания мыши', async({ shapes }) => {
+    const liveSelectionSnapshot = await test.step('Сузить общее выделение справа во время drag', () => {
+      return shapes.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние левого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightShape = await test.step('Получить состояние правого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const liveLeftText = await test.step('Получить текст в левом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightText = await test.step('Получить текст в правом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Отпустить мышь и завершить общее изменение размера', async() => {
+      await shapes.finishScale()
+    })
+
+    const finalSelectionSnapshot = await test.step('Получить итоговую ширину общего выделения', () => {
+      return shapes.getScaleSnapshot()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в левом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в правом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что после mouseup ширина не дёрнулась и переносы строк сохранились', () => {
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+      expect(finalLeftText, 'итоговый текст в левом шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в правом шейпе должен существовать').not.toBeNull()
+
+      if (!liveLeftText || !liveRightText || !finalLeftText || !finalRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
+      }
+
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.groupBoundsWidth - liveSelectionSnapshot.groupBoundsWidth)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+
+      expect(selectionWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('при уменьшении нескольких шейпов снизу их высота меняется без деформации текста и без рывка после mouseup', async({ shapes }) => {
+    const initialSelectionSnapshot = await test.step('Получить исходную высоту общего выделения', () => {
+      return shapes.getScaleSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в левом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в правом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    const liveSelectionSnapshot = await test.step('Уменьшить общее выделение снизу во время drag', () => {
+      return shapes.scaleVerticallyFromBottom({
+        scaleY: SHAPE_MULTI_SCALING_SCALE_Y
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние левого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightShape = await test.step('Получить состояние правого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const liveLeftText = await test.step('Получить текст в левом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightText = await test.step('Получить текст в правом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что во время drag уменьшается только высота, а текст не деформируется', () => {
+      expect(initialLeftText, 'текст в левом шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в правом шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.groupBoundsHeight)
+        .toBeLessThan(initialSelectionSnapshot.groupBoundsHeight - SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(liveSelectionSnapshot.groupBoundsWidth - initialSelectionSnapshot.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+      expect(liveLeftText.lineCount).toBe(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBe(initialRightText.lineCount)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', async() => {
+      await shapes.finishScale()
+
+      return shapes.getScaleSnapshot()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в левом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в правом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что после mouseup высота не дёрнулась и текст остался тем же', () => {
+      expect(finalLeftText, 'итоговый текст в левом шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в правом шейпе должен существовать').not.toBeNull()
+
+      if (!finalLeftText || !finalRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
+      }
+
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.groupBoundsHeight - liveSelectionSnapshot.groupBoundsHeight)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('после undo и redo несколько шейпов сохраняют тот же размер и те же переносы строк', async({
+    history,
+    shapes
+  }) => {
+    await test.step('Сузить несколько шейпов справа и завершить изменение размера', async() => {
+      await shapes.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+      await shapes.finishScale()
+      await history.flushPendingSave()
+    })
+
+    const resizedLeftShape = await test.step('Получить состояние левого шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const resizedRightShape = await test.step('Получить состояние правого шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const resizedLeftText = await test.step('Получить текст в левом шейпе после изменения размера', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const resizedRightText = await test.step('Получить текст в правом шейпе после изменения размера', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Сделать undo и redo', async() => {
+      await history.undo()
+      await history.redo()
+    })
+
+    const restoredLeftShape = await test.step('Получить состояние левого шейпа после redo', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const restoredRightShape = await test.step('Получить состояние правого шейпа после redo', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const restoredLeftText = await test.step('Получить текст в левом шейпе после redo', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const restoredRightText = await test.step('Получить текст в правом шейпе после redo', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что redo вернул тот же размер и те же переносы строк', () => {
+      expect(resizedLeftText, 'текст в левом шейпе после resize должен существовать').not.toBeNull()
+      expect(resizedRightText, 'текст в правом шейпе после resize должен существовать').not.toBeNull()
+      expect(restoredLeftText, 'текст в левом шейпе после redo должен существовать').not.toBeNull()
+      expect(restoredRightText, 'текст в правом шейпе после redo должен существовать').not.toBeNull()
+
+      if (!resizedLeftText || !resizedRightText || !restoredLeftText || !restoredRightText) {
+        throw new Error('текст в обоих шейпах должен существовать после resize и после redo')
+      }
+
+      expect(Math.abs(restoredLeftShape.groupBoundsWidth - resizedLeftShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(restoredRightShape.groupBoundsWidth - resizedRightShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(restoredLeftText.lineCount).toBe(resizedLeftText.lineCount)
+      expect(restoredRightText.lineCount).toBe(resizedRightText.lineCount)
+      expect(restoredLeftText.fontSize).toBe(resizedLeftText.fontSize)
+      expect(restoredRightText.fontSize).toBe(resizedRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: restoredLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: restoredRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('после массового сужения можно редактировать текст внутри одного шейпа без возврата старой ширины', async({ shapes }) => {
+    await test.step('Сузить несколько шейпов справа и завершить изменение размера', async() => {
+      await shapes.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+      await shapes.finishScale()
+    })
+
+    const resizedLeftShape = await test.step('Получить состояние левого шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const resizedLeftText = await test.step('Получить текст в левом шейпе после изменения размера', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const resizedRightShape = await test.step('Получить состояние правого шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Изменить текст только в левом шейпе после массового resize', async() => {
+      await shapes.enterTextEditing({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+      await shapes.updateEditingText({
+        id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id,
+        text: SHAPE_MULTI_SCALING_EDITED_TEXT
+      })
+      await shapes.exitTextEditing({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа после редактирования текста', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа после редактирования текста', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в левом шейпе после редактирования', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что левый шейп сохранил текущую ширину, а текст просто перенёсся внутри неё', () => {
+      expect(resizedLeftText, 'текст в левом шейпе после resize должен существовать').not.toBeNull()
+      expect(finalLeftText, 'итоговый текст в левом шейпе должен существовать').not.toBeNull()
+
+      if (!resizedLeftText || !finalLeftText) {
+        throw new Error('текст в левом шейпе должен существовать до и после редактирования')
+      }
+
+      expect(finalLeftText.text).toBe(SHAPE_MULTI_SCALING_EDITED_TEXT)
+      expect(finalLeftText.fontSize).toBe(resizedLeftText.fontSize)
+      expect(finalLeftText.lineCount).toBeGreaterThan(resizedLeftText.lineCount)
+      expect(Math.abs(finalLeftShape.groupBoundsWidth - resizedLeftShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalRightShape.groupBoundsWidth - resizedRightShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+})

--- a/specs/src/editor/shape-manager/shape-manager-events.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-events.spec.ts
@@ -1,4 +1,5 @@
 import '../../../test-utils/shape-manager-module-mocks'
+import { ActiveSelection } from 'fabric'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import {
   createShapeManagerEditorStub,
@@ -215,5 +216,166 @@ describe('shape-manager events', () => {
       canvas: editor.canvas,
       eventName: 'editor:shape-updated'
     })).toHaveLength(0)
+  })
+
+  it('при начале изменения размера нескольких шейпов запускает resize lifecycle для каждой фигуры', async() => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const firstShape = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'first'
+      }
+    })
+    const secondShape = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'second'
+      }
+    })
+
+    if (!firstShape || !secondShape) {
+      throw new Error('shape groups should be created')
+    }
+
+    const lifecycleController = (manager as unknown as {
+      lifecycleController: {
+        beginResize: (payload: unknown) => void
+      }
+    }).lifecycleController
+    const scalingController = (manager as unknown as {
+      scalingController: {
+        handleObjectScaling: (event: unknown) => void
+      }
+    }).scalingController
+    const objectScalingHandler = getRequiredCanvasHandler({
+      canvas: editor.canvas,
+      eventName: 'object:scaling'
+    })
+    const selection = new ActiveSelection([firstShape, secondShape] as never[], {
+      canvas: editor.canvas as never
+    }) as ActiveSelection & {
+      scaleX?: number
+      scaleY?: number
+    }
+    const scalingTransform = {
+      action: 'scaleX',
+      corner: 'mr',
+      target: selection,
+      original: {
+        scaleX: 1,
+        scaleY: 1,
+        left: 0,
+        top: 0,
+        originX: 'center',
+        originY: 'center'
+      }
+    } as never
+    const beginResizeSpy = jest.spyOn(lifecycleController, 'beginResize').mockImplementation(() => {})
+    const handleObjectScalingSpy = jest.spyOn(scalingController, 'handleObjectScaling').mockImplementation(() => {})
+
+    objectScalingHandler({
+      target: selection,
+      transform: scalingTransform
+    })
+
+    expect(beginResizeSpy).toHaveBeenCalledTimes(2)
+    expect(beginResizeSpy).toHaveBeenNthCalledWith(1, {
+      group: firstShape
+    })
+    expect(beginResizeSpy).toHaveBeenNthCalledWith(2, {
+      group: secondShape
+    })
+    expect(handleObjectScalingSpy).toHaveBeenCalledWith(expect.objectContaining({
+      target: selection,
+      transform: scalingTransform
+    }))
+  })
+
+  it('после изменения размера нескольких шейпов запекает каждую фигуру и собирает выделение обратно', async() => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const firstShape = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'first'
+      }
+    })
+    const secondShape = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'second'
+      }
+    })
+
+    if (!firstShape || !secondShape) {
+      throw new Error('shape groups should be created')
+    }
+
+    const lifecycleController = (manager as unknown as {
+      lifecycleController: {
+        finishResize: (payload: unknown) => void
+      }
+    }).lifecycleController
+    const scalingController = (manager as unknown as {
+      scalingController: {
+        clearState: (payload: unknown) => void
+      }
+    }).scalingController
+    const objectModifiedHandler = getRequiredCanvasHandler({
+      canvas: editor.canvas,
+      eventName: 'object:modified'
+    })
+    const selection = new ActiveSelection([firstShape, secondShape] as never[], {
+      canvas: editor.canvas as never
+    }) as ActiveSelection & {
+      scaleX?: number
+      scaleY?: number
+    }
+    const commitRehydratedShapeLayoutSpy = jest.spyOn(manager, 'commitRehydratedShapeLayout').mockReturnValue(true)
+    const clearStateSpy = jest.spyOn(scalingController, 'clearState').mockImplementation(() => {})
+    const finishResizeSpy = jest.spyOn(lifecycleController, 'finishResize').mockImplementation(() => {})
+
+    selection.scaleX = 0.75
+    selection.scaleY = 1.2
+
+    objectModifiedHandler({
+      target: selection
+    })
+
+    expect(commitRehydratedShapeLayoutSpy).toHaveBeenCalledTimes(2)
+    expect(commitRehydratedShapeLayoutSpy).toHaveBeenNthCalledWith(1, {
+      target: firstShape,
+      shapeTextAutoExpand: false
+    })
+    expect(commitRehydratedShapeLayoutSpy).toHaveBeenNthCalledWith(2, {
+      target: secondShape,
+      shapeTextAutoExpand: false
+    })
+    expect(clearStateSpy).toHaveBeenCalledTimes(2)
+    expect(clearStateSpy).toHaveBeenNthCalledWith(1, {
+      group: firstShape
+    })
+    expect(clearStateSpy).toHaveBeenNthCalledWith(2, {
+      group: secondShape
+    })
+    expect(finishResizeSpy).toHaveBeenCalledTimes(2)
+    expect(finishResizeSpy).toHaveBeenNthCalledWith(1, {
+      group: firstShape
+    })
+    expect(finishResizeSpy).toHaveBeenNthCalledWith(2, {
+      group: secondShape
+    })
+    expect(editor.canvas.discardActiveObject).toHaveBeenCalledTimes(1)
+
+    const setActiveObjectCalls = (editor.canvas.setActiveObject as jest.Mock).mock.calls
+    const restoredSelection = setActiveObjectCalls[setActiveObjectCalls.length - 1]?.[0]
+
+    expect(restoredSelection).toBeInstanceOf(ActiveSelection)
+    expect(restoredSelection?.getObjects()).toEqual([firstShape, secondShape])
   })
 })

--- a/specs/src/editor/shape-manager/shape-manager-rehydration.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-rehydration.spec.ts
@@ -34,7 +34,8 @@ describe('восстановленная фигура', () => {
     const result = manager.commitRehydratedShapeLayout({
       target: group
     })
-    const layoutCall = applyShapeTextLayoutMock.mock.calls.at(-1)?.[0]
+    const layoutCallCalls = applyShapeTextLayoutMock.mock.calls
+    const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
 
     expect(result).toBe(true)
     expect(layoutCall).toEqual(expect.objectContaining({
@@ -124,7 +125,8 @@ describe('восстановленная фигура', () => {
     const result = manager.commitRehydratedShapeLayout({
       target: group
     })
-    const layoutCall = applyShapeTextLayoutMock.mock.calls.at(-1)?.[0]
+    const layoutCallCalls = applyShapeTextLayoutMock.mock.calls
+    const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
 
     expect(result).toBe(true)
     expect(layoutCall).toEqual(expect.objectContaining({
@@ -135,5 +137,64 @@ describe('восстановленная фигура', () => {
     expect(text.paddingTop).toBe(3)
     expect(text.radiusTopLeft).toBe(5)
     expect(group.shapePaddingTop).toBe(7)
+  })
+
+  it('при явном отключении авторасширения передаёт этот режим в layout во время materialization', () => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const { group } = createShapeRehydrationTarget({
+      width: 200,
+      height: 100,
+      scaleX: 1.25,
+      scaleY: 1.5
+    })
+
+    group.shapeTextAutoExpand = true
+
+    const result = manager.commitRehydratedShapeLayout({
+      target: group,
+      shapeTextAutoExpand: false
+    })
+    const layoutCallCalls = applyShapeTextLayoutMock.mock.calls
+    const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
+
+    expect(result).toBe(true)
+    expect(layoutCall).toEqual(expect.objectContaining({
+      width: 250,
+      height: 150,
+      shapeTextAutoExpandEnabled: false
+    }))
+    expect(group.shapeTextAutoExpand).toBe(false)
+  })
+
+  it('без override сохраняет текущий режим авторасширения при materialization', () => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const { group } = createShapeRehydrationTarget({
+      width: 200,
+      height: 100,
+      scaleX: 1.25,
+      scaleY: 1.5
+    })
+
+    group.shapeTextAutoExpand = true
+
+    const result = manager.commitRehydratedShapeLayout({
+      target: group
+    })
+    const layoutCallCalls = applyShapeTextLayoutMock.mock.calls
+    const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
+
+    expect(result).toBe(true)
+    expect(layoutCall).toEqual(expect.objectContaining({
+      width: 250,
+      height: 150,
+      shapeTextAutoExpandEnabled: true
+    }))
+    expect(group.shapeTextAutoExpand).toBe(true)
   })
 })

--- a/specs/src/editor/shape-manager/shape-scaling.spec.ts
+++ b/specs/src/editor/shape-manager/shape-scaling.spec.ts
@@ -11,6 +11,7 @@ import {
   isShapeGroup
 } from '../../../../src/editor/shape-manager/shape-utils'
 import {
+  createActiveSelectionShapeScalingSetup,
   createShapeScalingSetup,
   createShapeScalingTransform,
   mockShapeScalingLocalPointer,
@@ -653,6 +654,124 @@ describe('shape-scaling', () => {
 
     expect(text.scaleX).toBeCloseTo(1, 4)
     expect(text.scaleY).toBeCloseTo(2, 4)
+  })
+
+  it('при изменении размера нескольких шейпов в лайве не уменьшает текст пропорционально выделению', () => {
+    const {
+      controller,
+      groups,
+      texts,
+      selection
+    } = createActiveSelectionShapeScalingSetup()
+
+    isShapeTextFrameFilledMock.mockReturnValue(false)
+    selection.scaleX = 0.5
+    selection.scaleY = 1
+
+    controller.handleObjectScaling({
+      target: selection,
+      transform: createShapeScalingTransform({
+        target: selection,
+        action: 'scaleX',
+        corner: 'mr',
+        originX: 'left',
+        originY: 'center'
+      }) as never
+    })
+
+    expect(resolveShapeTextFixedWidthLayoutMock).toHaveBeenCalledTimes(2)
+    expect(resolveShapeTextFixedWidthLayoutMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      width: 100,
+      height: 200
+    }))
+    expect(resolveShapeTextFixedWidthLayoutMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      width: 100,
+      height: 200
+    }))
+    expect(texts[0].scaleX).toBeCloseTo(2, 4)
+    expect(texts[0].scaleY).toBeCloseTo(1, 4)
+    expect(texts[1].scaleX).toBeCloseTo(2, 4)
+    expect(texts[1].scaleY).toBeCloseTo(1, 4)
+    expect(groups[0].width).toBe(200)
+    expect(groups[1].width).toBe(200)
+  })
+
+  it('если Fabric пропустил scaling-кадр, продолжает лайв-перерасчёт текста для нескольких шейпов', () => {
+    const {
+      controller,
+      canvas,
+      texts,
+      selection
+    } = createActiveSelectionShapeScalingSetup()
+
+    isShapeTextFrameFilledMock.mockReturnValue(false)
+
+    controller.handleObjectScaling({
+      target: selection,
+      transform: createShapeScalingTransform({
+        target: selection,
+        action: 'scaleX',
+        corner: 'mr',
+        originX: 'left',
+        originY: 'center'
+      }) as never
+    })
+
+    resolveShapeTextFixedWidthLayoutMock.mockClear()
+    selection.scaleX = 0.5
+    selection.scaleY = 1
+
+    const canvasWithTransform = canvas as typeof canvas & {
+      _currentTransform?: unknown
+    }
+
+    canvasWithTransform._currentTransform = createShapeScalingTransform({
+      target: selection,
+      action: 'scaleX',
+      corner: 'mr',
+      originX: 'left',
+      originY: 'center'
+    })
+
+    controller.handleCanvasMouseMove({
+      e: {} as PointerEvent
+    })
+
+    expect(resolveShapeTextFixedWidthLayoutMock).toHaveBeenCalledTimes(2)
+    expect(texts[0].scaleX).toBeCloseTo(2, 4)
+    expect(texts[1].scaleX).toBeCloseTo(2, 4)
+  })
+
+  it('в лайве с несколькими объектами перерасчитывает только шейпы из выделения', () => {
+    const {
+      controller,
+      nonShapeObject,
+      selection
+    } = createActiveSelectionShapeScalingSetup({
+      includeNonShapeObject: true
+    })
+
+    if (!nonShapeObject) {
+      throw new Error('non-shape object should be created')
+    }
+
+    isShapeTextFrameFilledMock.mockReturnValue(false)
+    selection.scaleX = 0.5
+    selection.scaleY = 1
+
+    controller.handleObjectScaling({
+      target: selection,
+      transform: createShapeScalingTransform({
+        target: selection,
+        action: 'scaleX',
+        corner: 'mr',
+        originX: 'left',
+        originY: 'center'
+      }) as never
+    })
+
+    expect(resolveShapeTextFixedWidthLayoutMock).toHaveBeenCalledTimes(2)
+    expect(nonShapeObject.setCoords).not.toHaveBeenCalled()
   })
 
   it('на object:modified запекает vertical shrink в minimum height текста, даже если lastAllowedScaleY устарел', () => {

--- a/specs/test-utils/shape-helpers.ts
+++ b/specs/test-utils/shape-helpers.ts
@@ -14,6 +14,7 @@ type MockCanvas = {
   findTarget: jest.Mock
   requestRenderAll: jest.Mock
   setActiveObject: jest.Mock
+  discardActiveObject: jest.Mock
   getActiveObject: jest.Mock
   getObjects: jest.Mock
   getCenterPoint: jest.Mock
@@ -38,6 +39,15 @@ type MockShapeTextbox = Textbox & {
   dynamicMinWidth: number
   autoExpand: boolean
   splitByGrapheme: boolean
+  lineFontDefaults?: Record<number, Record<string, unknown>>
+  paddingTop?: number
+  paddingRight?: number
+  paddingBottom?: number
+  paddingLeft?: number
+  radiusTopLeft?: number
+  radiusTopRight?: number
+  radiusBottomRight?: number
+  radiusBottomLeft?: number
   set: jest.Mock
   initDimensions: jest.Mock
   calcTextHeight: jest.Mock
@@ -103,6 +113,9 @@ export const createMockCanvas = (): MockCanvas => {
     requestRenderAll: jest.fn(),
     setActiveObject: jest.fn((object: unknown) => {
       activeObject = object
+    }),
+    discardActiveObject: jest.fn(() => {
+      activeObject = null
     }),
     getActiveObject: jest.fn(() => activeObject),
     getObjects: jest.fn(() => [...objects]),
@@ -468,7 +481,7 @@ export const createMockShapeGroup = ({
   height?: number
   presetKey?: string
 }): MockShapeGroup => {
-  const group = new Group([shape, text], {
+  const group = new Group([shape, text] as never[], {
     left,
     top,
     width,

--- a/specs/test-utils/shape-scaling-helpers.ts
+++ b/specs/test-utils/shape-scaling-helpers.ts
@@ -1,4 +1,4 @@
-import { Point } from 'fabric'
+import { ActiveSelection, Point } from 'fabric'
 import ShapeScalingController from '../../src/editor/shape-manager/scaling/shape-scaling'
 import { getShapeNodes } from '../../src/editor/shape-manager/shape-utils'
 import {
@@ -11,6 +11,7 @@ import {
 type GroupOriginX = 'left' | 'center' | 'right'
 type GroupOriginY = 'top' | 'center' | 'bottom'
 type ShapeScalingTestGroup = ReturnType<typeof createMockShapeGroup>
+type ShapeScalingTransformTarget = ShapeScalingTestGroup | ActiveSelection
 
 type ShapeScalingTransformOptions = {
   scaleX?: number
@@ -23,7 +24,7 @@ type ShapeScalingTransformOptions = {
   action?: string
   signX?: number
   signY?: number
-  target?: ShapeScalingTestGroup
+  target?: ShapeScalingTransformTarget
 }
 
 export type ShapeScalingTransformStub = {
@@ -39,7 +40,7 @@ export type ShapeScalingTransformStub = {
   action?: string
   signX?: number
   signY?: number
-  target?: ShapeScalingTestGroup
+  target?: ShapeScalingTransformTarget
 }
 
 export type ShapeGroupPositionByOriginMock = jest.Mock<
@@ -53,6 +54,22 @@ export type ShapeScalingTestSetup = {
   group: ShapeScalingTestGroup
   shape: ReturnType<typeof createMockShapeNode>
   text: ReturnType<typeof createMockShapeTextbox>
+}
+
+export type ActiveSelectionShapeScalingTestSetup = {
+  controller: ShapeScalingController
+  canvas: ReturnType<typeof createMockCanvas>
+  groups: ShapeScalingTestGroup[]
+  shapes: Array<ReturnType<typeof createMockShapeNode>>
+  texts: Array<ReturnType<typeof createMockShapeTextbox>>
+  selection: ActiveSelection & {
+    scaleX?: number
+    scaleY?: number
+  }
+  nonShapeObject: {
+    setCoords: jest.Mock
+    shapeComposite?: boolean
+  } | null
 }
 
 /**
@@ -92,6 +109,89 @@ export const createShapeScalingSetup = (): ShapeScalingTestSetup => {
     group,
     shape,
     text
+  }
+}
+
+/**
+ * Создаёт setup для ActiveSelection c несколькими shape-группами.
+ */
+export const createActiveSelectionShapeScalingSetup = ({
+  includeNonShapeObject = false
+}: {
+  includeNonShapeObject?: boolean
+} = {}): ActiveSelectionShapeScalingTestSetup => {
+  const canvas = createMockCanvas()
+  const controller = new ShapeScalingController({
+    canvas: canvas as never
+  })
+  const groups: ShapeScalingTestGroup[] = []
+  const shapes: Array<ReturnType<typeof createMockShapeNode>> = []
+  const texts: Array<ReturnType<typeof createMockShapeTextbox>> = []
+  const groupNodes = new Map<ShapeScalingTestGroup, {
+    shape: ReturnType<typeof createMockShapeNode>
+    text: ReturnType<typeof createMockShapeTextbox>
+  }>()
+
+  for (let index = 0; index < 2; index += 1) {
+    const shape = createMockShapeNode({
+      width: 200,
+      height: 200
+    })
+    const text = createMockShapeTextbox({
+      text: `test text ${index + 1}`,
+      width: 200,
+      fontSize: 30
+    })
+    const group = createMockShapeGroup({
+      shape,
+      text,
+      left: 480 + (index * 140),
+      top: 420,
+      width: 200,
+      height: 200
+    })
+
+    groups.push(group)
+    shapes.push(shape)
+    texts.push(text)
+    groupNodes.set(group, {
+      shape,
+      text
+    })
+  }
+
+  const nonShapeObject = includeNonShapeObject
+    ? {
+      setCoords: jest.fn(),
+      shapeComposite: false
+    }
+    : null
+  const selectionObjects = includeNonShapeObject && nonShapeObject
+    ? [groups[0], nonShapeObject, groups[1]]
+    : groups
+  const selection = new ActiveSelection(selectionObjects as never[], {
+    canvas: canvas as never
+  }) as ActiveSelection & {
+    scaleX?: number
+    scaleY?: number
+  }
+  const getShapeNodesMock = getShapeNodes as jest.Mock
+
+  getShapeNodesMock.mockImplementation(({ group }: { group: ShapeScalingTestGroup }) => {
+    return groupNodes.get(group) ?? {
+      shape: null,
+      text: null
+    }
+  })
+
+  return {
+    controller,
+    canvas,
+    groups,
+    shapes,
+    texts,
+    selection,
+    nonShapeObject
   }
 }
 

--- a/src/editor/shape-manager/index.ts
+++ b/src/editor/shape-manager/index.ts
@@ -95,6 +95,8 @@ type ShapeGroupDimensions = {
   height: number
 }
 
+const ACTIVE_SELECTION_SCALE_EPSILON = 0.0001
+
 /**
  * Менеджер фигур и композитных объектов "фигура + текст".
  */
@@ -1290,10 +1292,12 @@ export default class ShapeManager {
    */
   public commitRehydratedShapeLayout({
     target,
-    textScale = 1
+    textScale = 1,
+    shapeTextAutoExpand
   }: {
     target?: ShapeReference
     textScale?: number
+    shapeTextAutoExpand?: boolean
   }): boolean {
     const group = this._resolveShapeGroup({ target })
     if (!group) return false
@@ -1362,6 +1366,10 @@ export default class ShapeManager {
       group
     })
 
+    if (shapeTextAutoExpand !== undefined) {
+      group.shapeTextAutoExpand = shapeTextAutoExpand
+    }
+
     group.shapeManualBaseWidth = manualDimensions.width
     group.shapeManualBaseHeight = manualDimensions.height
 
@@ -1417,39 +1425,98 @@ export default class ShapeManager {
   }
 
   /**
-   * Обработчик live-resize shape-групп.
+   * Обработчик live-resize shape-групп, включая shape внутри ActiveSelection.
    */
   private _handleObjectScaling = (
     event: ShapeCanvasEvent
   ): void => {
-    const group = event.target && isShapeGroup(event.target)
-      ? event.target
-      : null
+    const groups = this._collectShapeGroupsFromTarget({
+      target: event.target,
+      subTargets: event.subTargets
+    })
 
-    if (group) {
+    groups.forEach((group) => {
       this.lifecycleController.beginResize({
         group
       })
-    }
+    })
 
     this.scalingController.handleObjectScaling(event)
   }
 
   /**
-   * Обработчик commit ресайза shape после завершения transform.
+   * Обработчик commit ресайза shape после завершения transform, включая ActiveSelection.
    */
   private _handleObjectModified = (
     event: ShapeCanvasEvent
   ): void => {
-    this.scalingController.handleObjectModified(event)
-    const group = event.target && isShapeGroup(event.target)
-      ? event.target
-      : null
-    if (!group) return
+    const { target } = event
+    const groups = this._collectShapeGroupsFromTarget({ target })
 
-    this.lifecycleController.finishResize({
-      group
+    if (target instanceof ActiveSelection) {
+      this._commitActiveSelectionShapeScaling({
+        selection: target
+      })
+
+      groups.forEach((group) => {
+        this.scalingController.clearState({
+          group
+        })
+      })
+    } else {
+      this.scalingController.handleObjectModified(event)
+    }
+
+    groups.forEach((group) => {
+      this.lifecycleController.finishResize({
+        group
+      })
     })
+  }
+
+  /**
+   * Материализует transient-scale ActiveSelection в дочерние shape-группы
+   * через общий rehydration/layout pipeline и восстанавливает выделение.
+   */
+  private _commitActiveSelectionShapeScaling({
+    selection
+  }: {
+    selection: ActiveSelection
+  }): void {
+    const objects = selection.getObjects()
+    const shapeGroups = objects.filter((object): object is ShapeGroup => {
+      return isShapeGroup(object)
+    })
+
+    if (!shapeGroups.length) return
+
+    const scaleX = Math.abs(selection.scaleX ?? 1)
+    const scaleY = Math.abs(selection.scaleY ?? 1)
+    const hasScaleChange = Math.abs(scaleX - 1) > ACTIVE_SELECTION_SCALE_EPSILON
+      || Math.abs(scaleY - 1) > ACTIVE_SELECTION_SCALE_EPSILON
+
+    if (!hasScaleChange) return
+
+    const { canvas } = this.editor
+    const hasWidthChange = Math.abs(scaleX - 1) > ACTIVE_SELECTION_SCALE_EPSILON
+
+    canvas.discardActiveObject()
+
+    shapeGroups.forEach((group) => {
+      this.commitRehydratedShapeLayout({
+        target: group,
+        shapeTextAutoExpand: hasWidthChange
+          ? false
+          : undefined
+      })
+
+      group.setCoords()
+    })
+
+    const nextSelection = new ActiveSelection(objects, { canvas })
+
+    canvas.setActiveObject(nextSelection)
+    canvas.requestRenderAll()
   }
 
   /**

--- a/src/editor/shape-manager/scaling/shape-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling.ts
@@ -1,4 +1,5 @@
 import {
+  ActiveSelection,
   Canvas,
   FabricObject,
   Point,
@@ -137,6 +138,14 @@ export default class ShapeScalingController {
       target,
       transform
     } = event
+    if (target instanceof ActiveSelection) {
+      this._applyActiveSelectionScalingPreview({
+        selection: target,
+        transform
+      })
+      return
+    }
+
     if (!isShapeGroup(target)) return
 
     const group = target
@@ -564,6 +573,14 @@ export default class ShapeScalingController {
     if (!transform) return
 
     const { target } = transform
+    if (target instanceof ActiveSelection) {
+      this._applyActiveSelectionScalingPreview({
+        selection: target,
+        transform
+      })
+      return
+    }
+
     if (!isShapeGroup(target)) return
 
     const {
@@ -696,6 +713,85 @@ export default class ShapeScalingController {
       currentTop: state.lastAllowedTop,
       currentFlipX: state.lastAllowedFlipX,
       currentFlipY: state.lastAllowedFlipY
+    })
+
+    this.canvas.requestRenderAll()
+  }
+
+  /**
+   * Применяет shape-specific live preview для shape-групп внутри ActiveSelection,
+   * чтобы текст перераскладывался по shape-layout контракту, а не скейлился пропорционально с selection.
+   */
+  private _applyActiveSelectionScalingPreview({
+    selection,
+    transform
+  }: {
+    selection: ActiveSelection
+    transform?: Transform | null
+  }): void {
+    if (!transform) return
+
+    const {
+      canScaleWidth,
+      canScaleHeight
+    } = resolveShapeScaleActionAxes({
+      transform
+    })
+    if (!canScaleWidth && !canScaleHeight) return
+
+    const scaleX = Math.abs(selection.scaleX ?? 1) || 1
+    const scaleY = Math.abs(selection.scaleY ?? 1) || 1
+    const shapeGroups = selection.getObjects().filter((object): object is ShapeGroup => {
+      return isShapeGroup(object)
+    })
+
+    if (!shapeGroups.length) return
+
+    shapeGroups.forEach((group) => {
+      const {
+        shape,
+        text
+      } = getShapeNodes({ group })
+
+      if (!shape || !text) return
+
+      const constraintPadding = ShapeScalingController._resolveScalingConstraintPadding({ group })
+      const state = this._ensureScalingState({
+        group,
+        text,
+        constraintPadding,
+        transform
+      })
+      const previewDimensions = this._resolvePreviewDimensions({
+        group,
+        text,
+        constraintPadding,
+        state,
+        appliedScaleX: scaleX,
+        appliedScaleY: scaleY
+      })
+      const previewLayout = this._resolvePreviewLayout({
+        group,
+        text,
+        state,
+        appliedScaleX: scaleX,
+        appliedScaleY: scaleY,
+        minimumHeight: previewDimensions.previewHeight
+      })
+
+      applyShapeScalingPreviewLayout({
+        group,
+        shape,
+        text,
+        layout: previewLayout,
+        alignH: group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN,
+        scaleX,
+        scaleY,
+        minSize: MIN_SIZE,
+        scaleEpsilon: SCALE_EPSILON
+      })
+
+      group.setCoords()
     })
 
     this.canvas.requestRenderAll()


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавляем 2 одинаковых шейпа с текстом "TEST" (скрин 1)

<img width="472" height="462" alt="image" src="https://github.com/user-attachments/assets/97caa444-1362-4f41-8c33-d44288df9100" />

2. Выделяем оба шейпа и уменьшаем их как одно массовое выделение (activeselection) (Скрин 2)

<img width="547" height="476" alt="image" src="https://github.com/user-attachments/assets/114bf4d1-bfe4-4e98-aa1f-5a2880bd6688" />

3. Выделяем 1 из шейпов, переходим в режим редактирования текста и пишем пробел, или делаем любую стилизацию для текста, например, жирный шрифт

Ожидаемый результат.

При редактировании текста шейп не увеличивается обратно до прежних размеров.

Фактический результат.

При редактировании текст шейп увеличивается в размерах до исходных (скрин 3)

<img width="537" height="524" alt="image" src="https://github.com/user-attachments/assets/d2cbe714-0e92-4a7c-95b4-c124c1c97a2f" />

Кроме того, если сделать undo/redo, то текстовые объекты останутся тех же размеров что и были, после ресайза, но текст внутри них увеличится до исходных из пункта 1 (скрин 4)

<img width="525" height="478" alt="image" src="https://github.com/user-attachments/assets/0cc2e3fb-68db-4b8c-9ddd-a507f9046816" />

При этом, если начать редактировать текст, то объект ещё и схлопнется (скрин 5)

<img width="530" height="492" alt="image" src="https://github.com/user-attachments/assets/a9660769-3786-4da9-8edb-30fd2b1f1628" />

---

FIXED.