### PR TITLE
ShapeManager. Правим прыгающую высоту при скейлинге нескольких шейпов. Убираем возможность флипать шейпы и тексты путём скейлинга.

### DIFF
--- a/e2e/fixtures/data/customized-controls.data.ts
+++ b/e2e/fixtures/data/customized-controls.data.ts
@@ -1,0 +1,51 @@
+import type {
+  ShapeAddAtBoundsParams,
+  TextAddParams
+} from '../../types'
+
+export const ACTIVE_SELECTION_MINIMUM_SIZE = 1
+export const ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE = 1.5
+
+export const ACTIVE_SELECTION_FLIP_TEXT_LEFT_OPTIONS = {
+  id: 'active-selection-flip-text-left',
+  left: 120,
+  top: 120,
+  width: 140,
+  text: 'TEST',
+  fontSize: 36,
+  autoExpand: false
+} satisfies TextAddParams
+
+export const ACTIVE_SELECTION_FLIP_TEXT_RIGHT_OPTIONS = {
+  id: 'active-selection-flip-text-right',
+  left: 360,
+  top: 120,
+  width: 140,
+  text: 'TEST',
+  fontSize: 36,
+  autoExpand: false
+} satisfies TextAddParams
+
+export const ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS = {
+  id: 'active-selection-flip-shape-left',
+  left: 120,
+  top: 120,
+  width: 160,
+  height: 160,
+  text: 'TEST',
+  textStyle: {
+    fontSize: 36
+  }
+} satisfies ShapeAddAtBoundsParams['options']
+
+export const ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS = {
+  id: 'active-selection-flip-shape-right',
+  left: 360,
+  top: 120,
+  width: 160,
+  height: 160,
+  text: 'TEST',
+  textStyle: {
+    fontSize: 36
+  }
+} satisfies ShapeAddAtBoundsParams['options']

--- a/e2e/fixtures/data/shape-multi-scaling.data.ts
+++ b/e2e/fixtures/data/shape-multi-scaling.data.ts
@@ -24,6 +24,8 @@ export const SHAPE_MULTI_SCALING_RIGHT_OPTIONS = {
 
 export const SHAPE_MULTI_SCALING_SCALE_X = 0.55
 
+export const SHAPE_MULTI_SCALING_EXPAND_SCALE_X = 1.85
+
 export const SHAPE_MULTI_SCALING_SCALE_Y = 0.55
 
 export const SHAPE_MULTI_SCALING_EDITED_TEXT = 'Active text Active text Active text Active text'

--- a/e2e/fixtures/editor.fixture.ts
+++ b/e2e/fixtures/editor.fixture.ts
@@ -13,6 +13,7 @@ import { BackgroundModel } from '../models/background.model'
 import { InteractionBlockerModel } from '../models/interaction-blocker.model'
 import { ImageModel } from '../models/image.model'
 import { ToolbarModel } from '../models/toolbar.model'
+import { SelectionModel } from '../models/selection.model'
 import { bypassCertificateWarning } from '../helpers/certificate.helper'
 import { injectEditorBrowserHelpers } from '../helpers/editor-browser-helpers.helper'
 import { resolveHeadedBrowserHoldMs } from '../helpers/headed-browser-hold.helper'
@@ -34,6 +35,7 @@ interface EditorFixtures {
   interactionBlocker: InteractionBlockerModel
   images: ImageModel
   toolbar: ToolbarModel
+  selection: SelectionModel
 }
 
 interface EditorInternalFixtures {
@@ -138,6 +140,10 @@ export const test = base.extend<EditorFixtures & EditorInternalFixtures>({
 
   toolbar: async({ editorModel }, use) => {
     await use(editorModel.toolbar)
+  },
+
+  selection: async({ editorModel }, use) => {
+    await use(editorModel.selection)
   }
 })
 

--- a/e2e/models/editor.model.ts
+++ b/e2e/models/editor.model.ts
@@ -22,6 +22,7 @@ import { BackgroundModel } from './background.model'
 import { InteractionBlockerModel } from './interaction-blocker.model'
 import { ImageModel } from './image.model'
 import { ToolbarModel } from './toolbar.model'
+import { SelectionModel } from './selection.model'
 
 export class EditorModel {
   readonly shapes: ShapeModel
@@ -46,6 +47,8 @@ export class EditorModel {
 
   readonly toolbar: ToolbarModel
 
+  readonly selection: SelectionModel
+
   constructor(readonly page: Page) {
     this.shapes = new ShapeModel(page)
     this.canvas = new CanvasModel(page)
@@ -58,6 +61,7 @@ export class EditorModel {
     this.interactionBlocker = new InteractionBlockerModel(page)
     this.images = new ImageModel(page)
     this.toolbar = new ToolbarModel(page)
+    this.selection = new SelectionModel(page)
   }
 
   /** Ожидает финальное состояние редактора после завершения init(), а не раннее появление window.editor. */

--- a/e2e/models/selection.model.ts
+++ b/e2e/models/selection.model.ts
@@ -1,0 +1,300 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { type Page, expect } from '@playwright/test'
+import type { SnappingObjectSnapshot } from '../types'
+import { waitForCanvasRender } from '../helpers/canvas-render.helper'
+
+type SelectionControlKey = 'tl' | 'tr' | 'bl' | 'br' | 'ml' | 'mr' | 'mt' | 'mb'
+
+type SelectionScaleInteraction = {
+  point: {
+    x: number
+    y: number
+  }
+  control: SelectionControlKey
+}
+
+type ScaleSelectionFromControlParams = {
+  startControl: SelectionControlKey
+  oppositeControl: SelectionControlKey
+  scaleX?: number
+  scaleY?: number
+  minimumWidth?: number
+  minimumHeight?: number
+}
+
+type SelectionMinimumSizeParams = {
+  minimumSize: number
+}
+
+export class SelectionModel {
+  private readonly page: Page
+
+  private activeScaleInteraction: SelectionScaleInteraction | null
+
+  constructor(page: Page) {
+    this.page = page
+    this.activeScaleInteraction = null
+  }
+
+  /** Возвращает состояние текущего общего выделения. */
+  async getSnapshot(): Promise<SnappingObjectSnapshot> {
+    const snapshot = await this.page.evaluate(() => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+      const target = editor.canvas.getActiveObject()
+      if (!target) return null
+
+      return helpers.serializeSnappingObjectSnapshot(target)
+    })
+
+    expect(snapshot, 'должно существовать текущее общее выделение').not.toBeNull()
+
+    return snapshot as SnappingObjectSnapshot
+  }
+
+  /** Масштабирует текущее общее выделение справа и возвращает live-состояние. */
+  async scaleHorizontallyFromRight(
+    params: {
+      scaleX: number
+    }
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'mr',
+      oppositeControl: 'ml',
+      scaleX: params.scaleX
+    })
+  }
+
+  /** Масштабирует текущее общее выделение снизу и возвращает live-состояние. */
+  async scaleVerticallyFromBottom(
+    params: {
+      scaleY: number
+    }
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'mb',
+      oppositeControl: 'mt',
+      scaleY: params.scaleY
+    })
+  }
+
+  /** Сжимает текущее общее выделение справа до минимальной ширины и возвращает live-состояние. */
+  async shrinkHorizontallyFromRightToMinimum(
+    params: SelectionMinimumSizeParams
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'mr',
+      oppositeControl: 'ml',
+      minimumWidth: params.minimumSize
+    })
+  }
+
+  /** Сжимает текущее общее выделение снизу до минимальной высоты и возвращает live-состояние. */
+  async shrinkVerticallyFromBottomToMinimum(
+    params: SelectionMinimumSizeParams
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'mb',
+      oppositeControl: 'mt',
+      minimumHeight: params.minimumSize
+    })
+  }
+
+  /** Сжимает текущее общее выделение из правого нижнего угла до минимальных ширины и высоты и возвращает live-состояние. */
+  async shrinkDiagonallyFromBottomRightToMinimum(
+    params: SelectionMinimumSizeParams
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'br',
+      oppositeControl: 'tl',
+      minimumWidth: params.minimumSize,
+      minimumHeight: params.minimumSize
+    })
+  }
+
+  /** Завершает активное масштабирование общего выделения через настоящий mouseup. */
+  async finishScale(): Promise<SnappingObjectSnapshot> {
+    expect(
+      this.activeScaleInteraction,
+      'должна существовать активная drag-сессия масштабирования общего выделения'
+    ).not.toBeNull()
+
+    if (!this.activeScaleInteraction) {
+      throw new Error('должна существовать активная drag-сессия масштабирования общего выделения')
+    }
+
+    const snapshot = await this.page.evaluate((payload) => {
+      const {
+        point: interactionPoint,
+        control
+      } = payload
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+      const target = editor.canvas.getActiveObject()
+      if (!target) return null
+
+      target.setCoords()
+
+      const currentControl = target.oCoords?.[control]
+      const rect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+      let releasePoint = interactionPoint
+
+      if (
+        currentControl
+        && typeof currentControl.x === 'number'
+        && typeof currentControl.y === 'number'
+      ) {
+        releasePoint = {
+          x: rect.left + currentControl.x,
+          y: rect.top + currentControl.y
+        }
+      }
+
+      editor.canvas.__onMouseUp(new MouseEvent('mouseup', {
+        bubbles: true,
+        button: 0,
+        buttons: 0,
+        clientX: releasePoint.x,
+        clientY: releasePoint.y
+      }))
+
+      target.setCoords()
+
+      return helpers.serializeSnappingObjectSnapshot(target)
+    }, this.activeScaleInteraction)
+
+    this.activeScaleInteraction = null
+
+    expect(snapshot, 'должно существовать состояние общего выделения после mouseup').not.toBeNull()
+
+    await waitForCanvasRender({ page: this.page })
+
+    return snapshot as SnappingObjectSnapshot
+  }
+
+  private async _scaleFromControl(
+    params: ScaleSelectionFromControlParams
+  ): Promise<SnappingObjectSnapshot> {
+    expect(
+      this.activeScaleInteraction,
+      'нельзя начинать новое масштабирование общего выделения, пока предыдущий drag не завершён'
+    ).toBeNull()
+
+    const result = await this.page.evaluate(({
+      startControl: startControlName,
+      oppositeControl: oppositeControlName,
+      scaleX,
+      scaleY,
+      minimumWidth,
+      minimumHeight
+    }) => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+      const target = editor.canvas.getActiveObject()
+      if (!target) return null
+
+      target.setCoords()
+
+      const startControl = target.oCoords?.[startControlName]
+      const oppositeControl = target.oCoords?.[oppositeControlName]
+      if (
+        !startControl
+        || !oppositeControl
+        || typeof startControl.x !== 'number'
+        || typeof startControl.y !== 'number'
+        || typeof oppositeControl.x !== 'number'
+        || typeof oppositeControl.y !== 'number'
+      ) {
+        return null
+      }
+
+      const rect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+      const startPoint = {
+        x: rect.left + startControl.x,
+        y: rect.top + startControl.y
+      }
+
+      editor.canvas.__onMouseDown(new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: startPoint.x,
+        clientY: startPoint.y
+      }))
+
+      const transform = editor.canvas._currentTransform
+      if (!transform || transform.target !== target) return null
+
+      const controlWidth = startControl.x - oppositeControl.x
+      const controlHeight = startControl.y - oppositeControl.y
+      const widthSign = Math.sign(controlWidth) || 1
+      const heightSign = Math.sign(controlHeight) || 1
+      const targetWidth = typeof minimumWidth === 'number'
+        ? minimumWidth
+        : Math.abs(controlWidth) * (scaleX ?? 1)
+      const targetHeight = typeof minimumHeight === 'number'
+        ? minimumHeight
+        : Math.abs(controlHeight) * (scaleY ?? 1)
+      const movePoint = {
+        x: rect.left + oppositeControl.x + (widthSign * targetWidth),
+        y: rect.top + oppositeControl.y + (heightSign * targetHeight)
+      }
+
+      editor.canvas.__onMouseMove(new MouseEvent('mousemove', {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: movePoint.x,
+        clientY: movePoint.y
+      }))
+
+      target.setCoords()
+      const currentControl = target.oCoords?.[startControlName]
+      let currentPoint = movePoint
+
+      if (
+        currentControl
+        && typeof currentControl.x === 'number'
+        && typeof currentControl.y === 'number'
+      ) {
+        currentPoint = {
+          x: rect.left + currentControl.x,
+          y: rect.top + currentControl.y
+        }
+      }
+
+      return {
+        point: currentPoint,
+        snapshot: helpers.serializeSnappingObjectSnapshot(target)
+      }
+    }, params)
+
+    expect(result, 'должно существовать live-состояние общего выделения после масштабирования').not.toBeNull()
+
+    await waitForCanvasRender({ page: this.page })
+
+    const {
+      point,
+      snapshot
+    } = result as {
+      point: {
+        x: number
+        y: number
+      }
+      snapshot: SnappingObjectSnapshot
+    }
+
+    this.activeScaleInteraction = {
+      point,
+      control: params.startControl
+    }
+
+    return snapshot
+  }
+}

--- a/e2e/tests/customized-controls/index.spec.ts
+++ b/e2e/tests/customized-controls/index.spec.ts
@@ -1,0 +1,284 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  ACTIVE_SELECTION_MINIMUM_SIZE,
+  ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE,
+  ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS,
+  ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS,
+  ACTIVE_SELECTION_FLIP_TEXT_LEFT_OPTIONS,
+  ACTIVE_SELECTION_FLIP_TEXT_RIGHT_OPTIONS
+} from '../../fixtures/data/customized-controls.data'
+
+test.describe('Масштабирование общего выделения', () => {
+  test.describe('Выделение с текстом', () => {
+    test.beforeEach(async({ editorModel, text }) => {
+      const leftText = await text.add(ACTIVE_SELECTION_FLIP_TEXT_LEFT_OPTIONS)
+      const rightText = await text.add(ACTIVE_SELECTION_FLIP_TEXT_RIGHT_OPTIONS)
+
+      text.checkCreation({ textObject: leftText })
+      text.checkCreation({ textObject: rightText })
+
+      await editorModel.selectAllObjects()
+    })
+
+    test('нельзя перевернуть при максимальном сжатии по горизонтали', async({
+      editorModel,
+      selection
+    }) => {
+      const liveSelection = await test.step('Сузить выделение справа до минимальной ширины', () => {
+        return selection.shrinkHorizontallyFromRightToMinimum({
+          minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
+        })
+      })
+      const finalSelection = await test.step('Отпустить мышь и получить итоговое состояние выделения', () => {
+        return selection.finishScale()
+      })
+      const finalLeftText = await test.step('Получить положение левого текста после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_TEXT_LEFT_OPTIONS.id })
+      })
+      const finalRightText = await test.step('Получить положение правого текста после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_TEXT_RIGHT_OPTIONS.id })
+      })
+
+      await test.step('Проверить что выделение сжалось до минимума и тексты не перевернулись', () => {
+        expect(liveSelection.flipX).toBe(false)
+        expect(finalSelection.flipX).toBe(false)
+        expect(liveSelection.boundsWidth).toBeGreaterThan(0)
+        expect(finalSelection.boundsWidth).toBeGreaterThan(0)
+        expect(liveSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalLeftText.flipX).toBe(false)
+        expect(finalRightText.flipX).toBe(false)
+        expect(finalLeftText.centerX).toBeLessThanOrEqual(finalRightText.centerX)
+      })
+    })
+
+    test('нельзя перевернуть при максимальном сжатии по диагонали', async({
+      editorModel,
+      selection
+    }) => {
+      const liveSelection = await test.step('Сузить выделение из правого нижнего угла до минимального размера', () => {
+        return selection.shrinkDiagonallyFromBottomRightToMinimum({
+          minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
+        })
+      })
+      const finalSelection = await test.step('Отпустить мышь и получить итоговое состояние выделения', () => {
+        return selection.finishScale()
+      })
+      const finalLeftText = await test.step('Получить положение левого текста после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_TEXT_LEFT_OPTIONS.id })
+      })
+      const finalRightText = await test.step('Получить положение правого текста после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_TEXT_RIGHT_OPTIONS.id })
+      })
+
+      await test.step('Проверить что выделение сжалось до минимума и тексты не перевернулись', () => {
+        expect(liveSelection.flipX).toBe(false)
+        expect(liveSelection.flipY).toBe(false)
+        expect(finalSelection.flipX).toBe(false)
+        expect(finalSelection.flipY).toBe(false)
+        expect(liveSelection.boundsWidth).toBeGreaterThan(0)
+        expect(liveSelection.boundsHeight).toBeGreaterThan(0)
+        expect(finalSelection.boundsWidth).toBeGreaterThan(0)
+        expect(finalSelection.boundsHeight).toBeGreaterThan(0)
+        expect(liveSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(liveSelection.boundsHeight)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalSelection.boundsHeight)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalLeftText.flipX).toBe(false)
+        expect(finalLeftText.flipY).toBe(false)
+        expect(finalRightText.flipX).toBe(false)
+        expect(finalRightText.flipY).toBe(false)
+        expect(finalLeftText.centerX).toBeLessThanOrEqual(finalRightText.centerX)
+      })
+    })
+  })
+
+  test.describe('Выделение с шейпом', () => {
+    test.beforeEach(async({ editorModel, shapes }) => {
+      const leftShape = await shapes.addAtBounds({
+        presetKey: 'square',
+        options: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS
+      })
+      const rightShape = await shapes.addAtBounds({
+        presetKey: 'square',
+        options: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS
+      })
+
+      shapes.checkCreation({
+        shape: leftShape,
+        presetKey: 'square'
+      })
+      shapes.checkCreation({
+        shape: rightShape,
+        presetKey: 'square'
+      })
+
+      await editorModel.selectAllObjects()
+    })
+
+    test('нельзя перевернуть при максимальном сжатии по горизонтали', async({
+      editorModel,
+      selection,
+      shapes
+    }) => {
+      const liveSelection = await test.step('Сузить выделение справа до минимальной ширины', () => {
+        return selection.shrinkHorizontallyFromRightToMinimum({
+          minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
+        })
+      })
+      const finalSelection = await test.step('Отпустить мышь и получить итоговое состояние выделения', () => {
+        return selection.finishScale()
+      })
+      const finalLeftShape = await test.step('Получить положение левого шейпа после максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS.id })
+      })
+      const finalRightShape = await test.step('Получить положение правого шейпа после максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS.id })
+      })
+      const finalLeftObject = await test.step('Получить состояние левого шейпа после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS.id })
+      })
+      const finalRightObject = await test.step('Получить состояние правого шейпа после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS.id })
+      })
+
+      await test.step('Проверить что выделение сжалось до минимума и шейпы не перевернулись', () => {
+        expect(liveSelection.flipX).toBe(false)
+        expect(finalSelection.flipX).toBe(false)
+        expect(liveSelection.boundsWidth).toBeGreaterThan(0)
+        expect(finalSelection.boundsWidth).toBeGreaterThan(0)
+        expect(liveSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalLeftObject.flipX).toBe(false)
+        expect(finalRightObject.flipX).toBe(false)
+        expect(finalLeftShape.groupBoundsLeft).toBeLessThanOrEqual(finalRightShape.groupBoundsLeft)
+      })
+    })
+
+    test('нельзя перевернуть при максимальном сжатии по вертикали', async({
+      editorModel,
+      selection,
+      shapes
+    }) => {
+      const liveSelection = await test.step('Сузить выделение снизу до минимальной высоты', () => {
+        return selection.shrinkVerticallyFromBottomToMinimum({
+          minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
+        })
+      })
+      const liveLeftShape = await test.step('Получить положение левого шейпа во время максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS.id })
+      })
+      const liveRightShape = await test.step('Получить положение правого шейпа во время максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS.id })
+      })
+      const finalSelection = await test.step('Отпустить мышь и получить итоговое состояние выделения', () => {
+        return selection.finishScale()
+      })
+      const finalLeftShape = await test.step('Получить положение левого шейпа после максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS.id })
+      })
+      const finalRightShape = await test.step('Получить положение правого шейпа после максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS.id })
+      })
+      const finalLeftObject = await test.step('Получить состояние левого шейпа после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS.id })
+      })
+      const finalRightObject = await test.step('Получить состояние правого шейпа после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS.id })
+      })
+
+      await test.step('Проверить что выделение сжалось до минимума, шейпы не перевернулись, а текст остался внутри', () => {
+        expect(liveSelection.flipY).toBe(false)
+        expect(finalSelection.flipY).toBe(false)
+        expect(liveSelection.boundsHeight).toBeGreaterThan(0)
+        expect(finalSelection.boundsHeight).toBeGreaterThan(0)
+        expect(liveSelection.boundsHeight)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalSelection.boundsHeight)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalLeftObject.flipY).toBe(false)
+        expect(finalRightObject.flipY).toBe(false)
+        expect(finalLeftShape.groupBoundsHeight).toBeGreaterThan(0)
+        expect(finalRightShape.groupBoundsHeight).toBeGreaterThan(0)
+
+        shapes.checkNodeInsideGroup({
+          snapshot: liveLeftShape,
+          kind: 'text'
+        })
+        shapes.checkNodeInsideGroup({
+          snapshot: liveRightShape,
+          kind: 'text'
+        })
+        shapes.checkNodeInsideGroup({
+          snapshot: finalLeftShape,
+          kind: 'text'
+        })
+        shapes.checkNodeInsideGroup({
+          snapshot: finalRightShape,
+          kind: 'text'
+        })
+      })
+    })
+
+    test('нельзя перевернуть при максимальном сжатии по диагонали', async({
+      editorModel,
+      selection,
+      shapes
+    }) => {
+      const liveSelection = await test.step('Сузить выделение из правого нижнего угла до минимального размера', () => {
+        return selection.shrinkDiagonallyFromBottomRightToMinimum({
+          minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
+        })
+      })
+      const finalSelection = await test.step('Отпустить мышь и получить итоговое состояние выделения', () => {
+        return selection.finishScale()
+      })
+      const finalLeftShape = await test.step('Получить положение левого шейпа после максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS.id })
+      })
+      const finalRightShape = await test.step('Получить положение правого шейпа после максимального сжатия', () => {
+        return shapes.getScaleSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS.id })
+      })
+      const finalLeftObject = await test.step('Получить состояние левого шейпа после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_LEFT_OPTIONS.id })
+      })
+      const finalRightObject = await test.step('Получить состояние правого шейпа после максимального сжатия', () => {
+        return editorModel.getObjectSnapshot({ id: ACTIVE_SELECTION_FLIP_SHAPE_RIGHT_OPTIONS.id })
+      })
+
+      await test.step('Проверить что выделение сжалось до минимума и шейпы не перевернулись', () => {
+        expect(liveSelection.flipX).toBe(false)
+        expect(liveSelection.flipY).toBe(false)
+        expect(finalSelection.flipX).toBe(false)
+        expect(finalSelection.flipY).toBe(false)
+        expect(liveSelection.boundsWidth).toBeGreaterThan(0)
+        expect(liveSelection.boundsHeight).toBeGreaterThan(0)
+        expect(finalSelection.boundsWidth).toBeGreaterThan(0)
+        expect(finalSelection.boundsHeight).toBeGreaterThan(0)
+        expect(liveSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(liveSelection.boundsHeight)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalSelection.boundsWidth)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalSelection.boundsHeight)
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(finalLeftObject.flipX).toBe(false)
+        expect(finalLeftObject.flipY).toBe(false)
+        expect(finalRightObject.flipX).toBe(false)
+        expect(finalRightObject.flipY).toBe(false)
+        expect(finalLeftShape.groupBoundsLeft).toBeLessThanOrEqual(finalRightShape.groupBoundsLeft)
+        expect(finalLeftShape.groupBoundsHeight).toBeGreaterThan(0)
+        expect(finalRightShape.groupBoundsHeight).toBeGreaterThan(0)
+      })
+    })
+  })
+})

--- a/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
+++ b/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../fixtures/editor.fixture'
 import {
   SHAPE_MULTI_SCALING_EDITED_TEXT,
+  SHAPE_MULTI_SCALING_EXPAND_SCALE_X,
   SHAPE_MULTI_SCALING_LEFT_OPTIONS,
   SHAPE_MULTI_SCALING_RIGHT_OPTIONS,
   SHAPE_MULTI_SCALING_SCALE_X,
@@ -31,9 +32,12 @@ test.describe('Изменение размера нескольких шейпо
     await editorModel.selectAllObjects()
   })
 
-  test('при сужении нескольких шейпов справа текст в них переносится уже во время drag', async({ shapes }) => {
+  test('при сужении нескольких шейпов справа текст в них переносится уже во время drag', async({
+    selection,
+    shapes
+  }) => {
     const initialSelectionSnapshot = await test.step('Получить исходную ширину общего выделения', () => {
-      return shapes.getScaleSnapshot()
+      return selection.getSnapshot()
     })
     const initialLeftText = await test.step('Получить исходное состояние текста в левом шейпе', () => {
       return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
@@ -43,7 +47,7 @@ test.describe('Изменение размера нескольких шейпо
     })
 
     const liveSelectionSnapshot = await test.step('Сузить общее выделение справа во время drag', () => {
-      return shapes.scaleHorizontallyFromRight({
+      return selection.scaleHorizontallyFromRight({
         scaleX: SHAPE_MULTI_SCALING_SCALE_X
       })
     })
@@ -70,8 +74,8 @@ test.describe('Изменение размера нескольких шейпо
         throw new Error('текст в обоих шейпах должен существовать до и во время drag')
       }
 
-      expect(liveSelectionSnapshot.groupBoundsWidth)
-        .toBeLessThan(initialSelectionSnapshot.groupBoundsWidth - SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(liveSelectionSnapshot.boundsWidth)
+        .toBeLessThan(initialSelectionSnapshot.boundsWidth - SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
       expect(initialLeftText.lineCount).toBe(1)
       expect(initialRightText.lineCount).toBe(1)
       expect(liveLeftText.lineCount).toBeGreaterThan(initialLeftText.lineCount)
@@ -90,9 +94,12 @@ test.describe('Изменение размера нескольких шейпо
     })
   })
 
-  test('после сужения нескольких шейпов справа их размер не дёргается после отпускания мыши', async({ shapes }) => {
+  test('после сужения нескольких шейпов справа их размер не дёргается после отпускания мыши', async({
+    selection,
+    shapes
+  }) => {
     const liveSelectionSnapshot = await test.step('Сузить общее выделение справа во время drag', () => {
-      return shapes.scaleHorizontallyFromRight({
+      return selection.scaleHorizontallyFromRight({
         scaleX: SHAPE_MULTI_SCALING_SCALE_X
       })
     })
@@ -109,12 +116,8 @@ test.describe('Изменение размера нескольких шейпо
       return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
     })
 
-    await test.step('Отпустить мышь и завершить общее изменение размера', async() => {
-      await shapes.finishScale()
-    })
-
-    const finalSelectionSnapshot = await test.step('Получить итоговую ширину общего выделения', () => {
-      return shapes.getScaleSnapshot()
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговую ширину общего выделения', () => {
+      return selection.finishScale()
     })
     const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
       return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
@@ -139,7 +142,7 @@ test.describe('Изменение размера нескольких шейпо
         throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
       }
 
-      const selectionWidthJump = Math.abs(finalSelectionSnapshot.groupBoundsWidth - liveSelectionSnapshot.groupBoundsWidth)
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.boundsWidth - liveSelectionSnapshot.boundsWidth)
       const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
       const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
 
@@ -162,9 +165,136 @@ test.describe('Изменение размера нескольких шейпо
     })
   })
 
-  test('при уменьшении нескольких шейпов снизу их высота меняется без деформации текста и без рывка после mouseup', async({ shapes }) => {
+  test('после сужения и обратного расширения нескольких шейпов высота не дёргается после mouseup', async({
+    editorModel,
+    selection,
+    shapes
+  }) => {
+    await test.step('Сузить несколько шейпов справа и завершить изменение размера', async() => {
+      await selection.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+      await selection.finishScale()
+    })
+
+    await test.step('Заново выделить оба шейпа перед обратным расширением', async() => {
+      await editorModel.selectAllObjects()
+    })
+
+    const narrowedSelectionSnapshot = await test.step('Получить ширину выделения после сужения', () => {
+      return selection.getSnapshot()
+    })
+    const narrowedLeftText = await test.step('Получить текст в левом шейпе после сужения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const narrowedRightText = await test.step('Получить текст в правом шейпе после сужения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    const liveSelectionSnapshot = await test.step('Расширить общее выделение справа во время drag', () => {
+      return selection.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_EXPAND_SCALE_X
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние левого шейпа во время обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightShape = await test.step('Получить состояние правого шейпа во время обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const liveLeftText = await test.step('Получить текст в левом шейпе во время обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightText = await test.step('Получить текст в правом шейпе во время обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что во время обратного расширения текст вернулся в одну строку и остался внутри шейпов', () => {
+      expect(narrowedLeftText, 'текст в левом шейпе после сужения должен существовать').not.toBeNull()
+      expect(narrowedRightText, 'текст в правом шейпе после сужения должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в левом шейпе во время обратного расширения должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время обратного расширения должен существовать').not.toBeNull()
+
+      if (!narrowedLeftText || !narrowedRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать после сужения и во время обратного расширения')
+      }
+
+      expect(liveSelectionSnapshot.boundsWidth)
+        .toBeGreaterThan(narrowedSelectionSnapshot.boundsWidth + SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(narrowedLeftText.lineCount).toBeGreaterThan(1)
+      expect(narrowedRightText.lineCount).toBeGreaterThan(1)
+      expect(liveLeftText.lineCount).toBe(1)
+      expect(liveRightText.lineCount).toBe(1)
+      expect(liveLeftText.fontSize).toBe(narrowedLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(narrowedRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', async() => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа после обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа после обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в левом шейпе после обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в правом шейпе после обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что после mouseup размер не дёрнулся и переносы строк сохранились', () => {
+      expect(finalLeftText, 'итоговый текст в левом шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в правом шейпе должен существовать').not.toBeNull()
+
+      if (!finalLeftText || !finalRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
+      }
+
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.boundsWidth - liveSelectionSnapshot.boundsWidth)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('при уменьшении нескольких шейпов снизу их высота меняется без деформации текста и без рывка после mouseup', async({
+    selection,
+    shapes
+  }) => {
     const initialSelectionSnapshot = await test.step('Получить исходную высоту общего выделения', () => {
-      return shapes.getScaleSnapshot()
+      return selection.getSnapshot()
     })
     const initialLeftText = await test.step('Получить исходное состояние текста в левом шейпе', () => {
       return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
@@ -174,7 +304,7 @@ test.describe('Изменение размера нескольких шейпо
     })
 
     const liveSelectionSnapshot = await test.step('Уменьшить общее выделение снизу во время drag', () => {
-      return shapes.scaleVerticallyFromBottom({
+      return selection.scaleVerticallyFromBottom({
         scaleY: SHAPE_MULTI_SCALING_SCALE_Y
       })
     })
@@ -201,9 +331,9 @@ test.describe('Изменение размера нескольких шейпо
         throw new Error('текст в обоих шейпах должен существовать до и во время drag')
       }
 
-      expect(liveSelectionSnapshot.groupBoundsHeight)
-        .toBeLessThan(initialSelectionSnapshot.groupBoundsHeight - SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
-      expect(Math.abs(liveSelectionSnapshot.groupBoundsWidth - initialSelectionSnapshot.groupBoundsWidth))
+      expect(liveSelectionSnapshot.boundsHeight)
+        .toBeLessThan(initialSelectionSnapshot.boundsHeight - SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(liveSelectionSnapshot.boundsWidth - initialSelectionSnapshot.boundsWidth))
         .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
       expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
       expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
@@ -221,9 +351,7 @@ test.describe('Изменение размера нескольких шейпо
     })
 
     const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', async() => {
-      await shapes.finishScale()
-
-      return shapes.getScaleSnapshot()
+      return selection.finishScale()
     })
     const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
       return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
@@ -246,7 +374,7 @@ test.describe('Изменение размера нескольких шейпо
         throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
       }
 
-      const selectionHeightJump = Math.abs(finalSelectionSnapshot.groupBoundsHeight - liveSelectionSnapshot.groupBoundsHeight)
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.boundsHeight - liveSelectionSnapshot.boundsHeight)
       const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
       const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
 
@@ -271,13 +399,14 @@ test.describe('Изменение размера нескольких шейпо
 
   test('после undo и redo несколько шейпов сохраняют тот же размер и те же переносы строк', async({
     history,
+    selection,
     shapes
   }) => {
     await test.step('Сузить несколько шейпов справа и завершить изменение размера', async() => {
-      await shapes.scaleHorizontallyFromRight({
+      await selection.scaleHorizontallyFromRight({
         scaleX: SHAPE_MULTI_SCALING_SCALE_X
       })
-      await shapes.finishScale()
+      await selection.finishScale()
       await history.flushPendingSave()
     })
 
@@ -342,12 +471,15 @@ test.describe('Изменение размера нескольких шейпо
     })
   })
 
-  test('после массового сужения можно редактировать текст внутри одного шейпа без возврата старой ширины', async({ shapes }) => {
+  test('после массового сужения можно редактировать текст внутри одного шейпа без возврата старой ширины', async({
+    selection,
+    shapes
+  }) => {
     await test.step('Сузить несколько шейпов справа и завершить изменение размера', async() => {
-      await shapes.scaleHorizontallyFromRight({
+      await selection.scaleHorizontallyFromRight({
         scaleX: SHAPE_MULTI_SCALING_SCALE_X
       })
-      await shapes.finishScale()
+      await selection.finishScale()
     })
 
     const resizedLeftShape = await test.step('Получить состояние левого шейпа после изменения размера', () => {

--- a/specs/src/editor/customized-controls/index.spec.ts
+++ b/specs/src/editor/customized-controls/index.spec.ts
@@ -1,4 +1,7 @@
-import { createControlsCustomizerTestSetup } from '../../../test-utils/customized-controls-helpers'
+import {
+  createActiveSelectionScalingRulesTestSetup,
+  createControlsCustomizerTestSetup
+} from '../../../test-utils/customized-controls-helpers'
 
 describe('customized-controls', () => {
   beforeEach(() => {
@@ -66,5 +69,62 @@ describe('customized-controls', () => {
     }, 0, 0)
 
     expect(setCursor).not.toHaveBeenCalled()
+  })
+
+  it('выделение с текстом нельзя перевернуть при масштабировании', () => {
+    const {
+      selection,
+      recalculateBounds
+    } = createActiveSelectionScalingRulesTestSetup({
+      objectKinds: ['text']
+    })
+
+    recalculateBounds()
+
+    expect(selection.lockScalingFlip).toBe(true)
+    expect(selection.setControlsVisibility).toHaveBeenCalledWith({
+      mt: false,
+      mb: false,
+      ml: true,
+      mr: true
+    })
+  })
+
+  it('выделение с шейпом нельзя перевернуть при масштабировании', () => {
+    const {
+      selection,
+      recalculateBounds
+    } = createActiveSelectionScalingRulesTestSetup({
+      objectKinds: ['shape']
+    })
+
+    recalculateBounds()
+
+    expect(selection.lockScalingFlip).toBe(true)
+    expect(selection.setControlsVisibility).toHaveBeenCalledWith({
+      mt: true,
+      mb: true,
+      ml: true,
+      mr: true
+    })
+  })
+
+  it('выделение обычных объектов не блокирует flip', () => {
+    const {
+      selection,
+      recalculateBounds
+    } = createActiveSelectionScalingRulesTestSetup({
+      objectKinds: ['object']
+    })
+
+    recalculateBounds()
+
+    expect(selection.lockScalingFlip).toBe(false)
+    expect(selection.setControlsVisibility).toHaveBeenCalledWith({
+      mt: true,
+      mb: true,
+      ml: true,
+      mr: true
+    })
   })
 })

--- a/specs/src/editor/shape-manager/shape-manager-events.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-events.spec.ts
@@ -294,7 +294,7 @@ describe('shape-manager events', () => {
     }))
   })
 
-  it('после изменения размера нескольких шейпов запекает каждую фигуру и собирает выделение обратно', async() => {
+  it('после изменения размера нескольких шейпов фиксирует resize каждой фигуры и собирает выделение обратно', async() => {
     const editor = createShapeManagerEditorStub()
     const manager = new ShapeManager({
       editor: editor as never
@@ -323,6 +323,7 @@ describe('shape-manager events', () => {
     }).lifecycleController
     const scalingController = (manager as unknown as {
       scalingController: {
+        commitActiveSelectionGroupScaling: (payload: unknown) => boolean
         clearState: (payload: unknown) => void
       }
     }).scalingController
@@ -336,26 +337,76 @@ describe('shape-manager events', () => {
       scaleX?: number
       scaleY?: number
     }
-    const commitRehydratedShapeLayoutSpy = jest.spyOn(manager, 'commitRehydratedShapeLayout').mockReturnValue(true)
+    const scalingTransform = {
+      action: 'scaleX',
+      corner: 'mr',
+      target: selection,
+      original: {
+        scaleX: 1,
+        scaleY: 1,
+        left: 0,
+        top: 0,
+        originX: 'center',
+        originY: 'center'
+      }
+    } as never
+    const commitActiveSelectionGroupScalingSpy = jest
+      .spyOn(scalingController, 'commitActiveSelectionGroupScaling')
+      .mockReturnValue(true)
+    const commitRehydratedShapeLayoutSpy = jest
+      .spyOn(manager, 'commitRehydratedShapeLayout')
+      .mockReturnValue(true)
     const clearStateSpy = jest.spyOn(scalingController, 'clearState').mockImplementation(() => {})
     const finishResizeSpy = jest.spyOn(lifecycleController, 'finishResize').mockImplementation(() => {})
+    const getObjectPlacementMock = editor.canvasManager.getObjectPlacement as jest.Mock
+    const applyObjectPlacementMock = editor.canvasManager.applyObjectPlacement as jest.Mock
 
     selection.scaleX = 0.75
     selection.scaleY = 1.2
 
     objectModifiedHandler({
-      target: selection
+      target: selection,
+      transform: scalingTransform
     })
 
-    expect(commitRehydratedShapeLayoutSpy).toHaveBeenCalledTimes(2)
-    expect(commitRehydratedShapeLayoutSpy).toHaveBeenNthCalledWith(1, {
-      target: firstShape,
-      shapeTextAutoExpand: false
+    expect(commitActiveSelectionGroupScalingSpy).toHaveBeenCalledTimes(2)
+    expect(commitActiveSelectionGroupScalingSpy).toHaveBeenNthCalledWith(1, {
+      group: firstShape,
+      scaleX: 0.75,
+      scaleY: 1.2,
+      transform: scalingTransform
     })
-    expect(commitRehydratedShapeLayoutSpy).toHaveBeenNthCalledWith(2, {
-      target: secondShape,
-      shapeTextAutoExpand: false
+    expect(commitActiveSelectionGroupScalingSpy).toHaveBeenNthCalledWith(2, {
+      group: secondShape,
+      scaleX: 0.75,
+      scaleY: 1.2,
+      transform: scalingTransform
     })
+
+    expect(commitRehydratedShapeLayoutSpy).not.toHaveBeenCalled()
+    expect(getObjectPlacementMock).toHaveBeenCalledTimes(2)
+    expect(getObjectPlacementMock).toHaveBeenNthCalledWith(1, {
+      object: firstShape
+    })
+    expect(getObjectPlacementMock).toHaveBeenNthCalledWith(2, {
+      object: secondShape
+    })
+    expect(applyObjectPlacementMock).toHaveBeenCalledTimes(2)
+    expect(applyObjectPlacementMock).toHaveBeenNthCalledWith(1, {
+      object: firstShape,
+      placement: getObjectPlacementMock.mock.results[0].value
+    })
+    expect(applyObjectPlacementMock).toHaveBeenNthCalledWith(2, {
+      object: secondShape,
+      placement: getObjectPlacementMock.mock.results[1].value
+    })
+    expect(getObjectPlacementMock.mock.invocationCallOrder[0]).toBeLessThan(
+      commitActiveSelectionGroupScalingSpy.mock.invocationCallOrder[0]
+    )
+    expect(commitActiveSelectionGroupScalingSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      applyObjectPlacementMock.mock.invocationCallOrder[0]
+    )
+
     expect(clearStateSpy).toHaveBeenCalledTimes(2)
     expect(clearStateSpy).toHaveBeenNthCalledWith(1, {
       group: firstShape

--- a/specs/src/editor/shape-manager/shape-scaling.spec.ts
+++ b/specs/src/editor/shape-manager/shape-scaling.spec.ts
@@ -774,6 +774,141 @@ describe('shape-scaling', () => {
     expect(nonShapeObject.setCoords).not.toHaveBeenCalled()
   })
 
+  it('после горизонтального изменения размера нескольких шейпов не увеличивает высоту после завершения drag', () => {
+    const {
+      controller,
+      groups,
+      selection
+    } = createActiveSelectionShapeScalingSetup()
+
+    isShapeTextFrameFilledMock.mockReturnValue(false)
+    resolveRequiredShapeHeightForTextMock.mockImplementation(({ width, height }: {
+      width: number
+      height: number
+    }) => {
+      if (width >= 200 && height === 100) return 80
+
+      return height
+    })
+
+    groups.forEach((group) => {
+      group.width = 100
+      group.height = 180
+      group.shapeBaseWidth = 100
+      group.shapeBaseHeight = 180
+      group.shapeManualBaseWidth = 100
+      group.shapeManualBaseHeight = 100
+    })
+
+    selection.scaleX = 2
+    selection.scaleY = 1
+
+    const transform = createShapeScalingTransform({
+      target: selection,
+      action: 'scaleX',
+      corner: 'mr',
+      originX: 'left',
+      originY: 'center'
+    }) as never
+
+    controller.handleObjectScaling({
+      target: selection,
+      transform
+    })
+
+    const liveHeights = groups.map(({ height }) => height)
+
+    applyShapeTextLayoutMock.mockClear()
+
+    groups.forEach((group) => {
+      const didCommit = controller.commitActiveSelectionGroupScaling({
+        group,
+        scaleX: 2,
+        scaleY: 1,
+        transform
+      })
+
+      expect(didCommit).toBe(true)
+    })
+
+    expect(liveHeights).toEqual([100, 100])
+    expect(applyShapeTextLayoutMock).toHaveBeenCalledTimes(2)
+    expect(applyShapeTextLayoutMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      width: 200,
+      height: 100
+    }))
+    expect(applyShapeTextLayoutMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      width: 200,
+      height: 100
+    }))
+    expect(groups[0].height).toBe(100)
+    expect(groups[1].height).toBe(100)
+  })
+
+  it('после сужения нескольких шейпов фиксирует высоту, достаточную для текста', () => {
+    const {
+      controller,
+      groups,
+      selection
+    } = createActiveSelectionShapeScalingSetup()
+
+    isShapeTextFrameFilledMock.mockReturnValue(false)
+    resolveRequiredShapeHeightForTextMock.mockImplementation(({ width, height }: {
+      width: number
+      height: number
+    }) => {
+      if (width <= 100) return 260
+
+      return height
+    })
+
+    selection.scaleX = 0.5
+    selection.scaleY = 1
+
+    const transform = createShapeScalingTransform({
+      target: selection,
+      action: 'scaleX',
+      corner: 'mr',
+      originX: 'left',
+      originY: 'center'
+    }) as never
+
+    controller.handleObjectScaling({
+      target: selection,
+      transform
+    })
+
+    const liveHeights = groups.map(({ height }) => height)
+
+    applyShapeTextLayoutMock.mockClear()
+
+    groups.forEach((group) => {
+      const didCommit = controller.commitActiveSelectionGroupScaling({
+        group,
+        scaleX: 0.5,
+        scaleY: 1,
+        transform
+      })
+
+      expect(didCommit).toBe(true)
+    })
+
+    expect(liveHeights).toEqual([260, 260])
+    expect(applyShapeTextLayoutMock).toHaveBeenCalledTimes(2)
+    expect(applyShapeTextLayoutMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      width: 100,
+      height: 260
+    }))
+    expect(applyShapeTextLayoutMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      width: 100,
+      height: 260
+    }))
+    expect(groups[0].height).toBe(260)
+    expect(groups[1].height).toBe(260)
+    expect(groups[0].shapeManualBaseHeight).toBe(200)
+    expect(groups[1].shapeManualBaseHeight).toBe(200)
+  })
+
   it('на object:modified запекает vertical shrink в minimum height текста, даже если lastAllowedScaleY устарел', () => {
     const {
       controller,

--- a/specs/test-utils/customized-controls-helpers.ts
+++ b/specs/test-utils/customized-controls-helpers.ts
@@ -1,4 +1,5 @@
 import {
+  ActiveSelection,
   Control,
   InteractiveFabricObject,
   Textbox,
@@ -12,26 +13,77 @@ type RotateControl = Control & {
 }
 
 type ControlCollection = Record<string, RotateControl>
+type ActiveSelectionObjectKind = 'object' | 'shape' | 'text'
+type ActiveSelectionScalingRulesSelection = ActiveSelection & {
+  lockScalingFlip?: boolean
+  setControlsVisibility: jest.Mock
+  setCoords: jest.Mock
+  setPositionByOrigin: jest.Mock
+  _calcBoundsFromObjects?: () => unknown
+}
 
 export type ControlsCustomizerTestSetup = {
   objectRotateControl: RotateControl
 }
 
+export type ActiveSelectionScalingRulesTestSetup = {
+  selection: ActiveSelectionScalingRulesSelection
+  recalculateBounds: () => void
+}
+
 const createControlCollection = (): ControlCollection => ({
-  tl: new Control(),
-  tr: new Control(),
-  bl: new Control(),
-  br: new Control(),
+  tl: new Control() as RotateControl,
+  tr: new Control() as RotateControl,
+  bl: new Control() as RotateControl,
+  br: new Control() as RotateControl,
   ml: new Control({
     actionHandler: jest.fn(() => true)
   }) as RotateControl,
   mr: new Control({
     actionHandler: jest.fn(() => true)
   }) as RotateControl,
-  mt: new Control(),
-  mb: new Control(),
+  mt: new Control() as RotateControl,
+  mb: new Control() as RotateControl,
   mtr: new Control() as RotateControl
 })
+
+const createBoundingObject = ({
+  left,
+  shapeComposite = false
+}: {
+  left: number
+  shapeComposite?: boolean
+}) => ({
+  shapeComposite,
+  getBoundingRect: jest.fn(() => ({
+    left,
+    top: 0,
+    width: 100,
+    height: 50
+  }))
+})
+
+const createActiveSelectionObject = ({
+  kind,
+  index
+}: {
+  kind: ActiveSelectionObjectKind
+  index: number
+}) => {
+  const left = index * 120
+
+  return kind === 'text'
+    ? new Textbox('Text', {
+      left,
+      top: 0,
+      width: 100,
+      height: 50
+    })
+    : createBoundingObject({
+      left,
+      shapeComposite: kind === 'shape'
+    })
+}
 
 /**
  * Регистрирует отдельный набор object/textbox controls и применяет кастомизацию редактора.
@@ -51,5 +103,33 @@ export const createControlsCustomizerTestSetup = (): ControlsCustomizerTestSetup
 
   return {
     objectRotateControl: objectControls.mtr
+  }
+}
+
+/**
+ * Создаёт ActiveSelection и запускает кастомный пересчёт его границ.
+ */
+export const createActiveSelectionScalingRulesTestSetup = ({
+  objectKinds
+}: {
+  objectKinds: ActiveSelectionObjectKind[]
+}): ActiveSelectionScalingRulesTestSetup => {
+  createControlsCustomizerTestSetup()
+
+  const objects = objectKinds.map((kind, index) => createActiveSelectionObject({
+    kind,
+    index
+  }))
+  const selection = new ActiveSelection(objects as never[], {}) as ActiveSelectionScalingRulesSelection
+
+  selection.setControlsVisibility = jest.fn()
+  selection.setCoords = jest.fn()
+  selection.setPositionByOrigin = jest.fn()
+
+  return {
+    selection,
+    recalculateBounds: () => {
+      selection._calcBoundsFromObjects?.()
+    }
   }
 }

--- a/src/editor/customized-controls/index.ts
+++ b/src/editor/customized-controls/index.ts
@@ -111,7 +111,7 @@ export default class ControlsCustomizer {
 
     activeSelectionPrototype._calcBoundsFromObjects = function(this: ActiveSelection, ...args: unknown[]) {
       const objects = this.getObjects?.() ?? []
-      ControlsCustomizer.applyTextSelectionScalingLock({
+      ControlsCustomizer.applyActiveSelectionScalingRules({
         selection: this,
         objects
       })
@@ -140,7 +140,7 @@ export default class ControlsCustomizer {
     activeSelectionPrototype._onAfterObjectsChange = function(this: ActiveSelection, type: unknown, options: unknown) {
       const result = originalAfterChange ? originalAfterChange.call(this, type, options) : undefined
       const objects = this.getObjects?.() ?? []
-      ControlsCustomizer.applyTextSelectionScalingLock({
+      ControlsCustomizer.applyActiveSelectionScalingRules({
         selection: this,
         objects
       })
@@ -168,16 +168,16 @@ export default class ControlsCustomizer {
       objects: FabricObject[],
       context: StrictLayoutContext
     ) {
-      const { target, type, overrides } = context
-      if (type === 'imperative' && overrides) {
-        return overrides
+      const { target, type } = context
+      if (type === 'imperative' && context.overrides) {
+        return context.overrides
       }
 
       if (!(target instanceof ActiveSelection)) {
         return originalCalcBoundingBox.call(this, objects, context)
       }
 
-      ControlsCustomizer.applyTextSelectionScalingLock({
+      ControlsCustomizer.applyActiveSelectionScalingRules({
         selection: target,
         objects
       })
@@ -232,9 +232,9 @@ export default class ControlsCustomizer {
   }
 
   /**
-   * Блокирует горизонтальное масштабирование ActiveSelection, если в выделении есть текстовые объекты.
+   * Применяет ограничения масштабирования ActiveSelection для объектов с собственным text/layout контрактом.
    */
-  private static applyTextSelectionScalingLock(
+  private static applyActiveSelectionScalingRules(
     {
       selection,
       objects
@@ -244,9 +244,15 @@ export default class ControlsCustomizer {
     }
   ): void {
     const hasText = objects.some((object) => object instanceof Textbox)
+    const hasShape = objects.some((object) => object.shapeComposite === true)
+    const shouldLockScalingFlip = hasText || hasShape
 
-    // Разрешаем горизонтальное масштабирование для групп с текстом,
-    // так как TextManager теперь умеет корректно обрабатывать изменение ширины (reflow).
+    selection.set({
+      lockScalingFlip: shouldLockScalingFlip
+    })
+
+    // Для текстовых объектов скрываем вертикальные хэндлы, но оставляем горизонтальное масштабирование:
+    // TextManager корректно обрабатывает изменение ширины.
     selection.setControlsVisibility({
       mt: !hasText,
       mb: !hasText,

--- a/src/editor/shape-manager/index.ts
+++ b/src/editor/shape-manager/index.ts
@@ -1455,7 +1455,8 @@ export default class ShapeManager {
 
     if (target instanceof ActiveSelection) {
       this._commitActiveSelectionShapeScaling({
-        selection: target
+        selection: target,
+        transform: event.transform
       })
 
       groups.forEach((group) => {
@@ -1475,13 +1476,15 @@ export default class ShapeManager {
   }
 
   /**
-   * Материализует transient-scale ActiveSelection в дочерние shape-группы
-   * через общий rehydration/layout pipeline и восстанавливает выделение.
+   * Материализует временный scale ActiveSelection в дочерние shape-группы
+   * через общий путь фиксации resize и восстанавливает выделение.
    */
   private _commitActiveSelectionShapeScaling({
-    selection
+    selection,
+    transform
   }: {
     selection: ActiveSelection
+    transform?: ShapeCanvasEvent['transform']
   }): void {
     const objects = selection.getObjects()
     const shapeGroups = objects.filter((object): object is ShapeGroup => {
@@ -1497,19 +1500,30 @@ export default class ShapeManager {
 
     if (!hasScaleChange) return
 
-    const { canvas } = this.editor
-    const hasWidthChange = Math.abs(scaleX - 1) > ACTIVE_SELECTION_SCALE_EPSILON
+    const {
+      canvas,
+      canvasManager
+    } = this.editor
 
     canvas.discardActiveObject()
 
     shapeGroups.forEach((group) => {
-      this.commitRehydratedShapeLayout({
-        target: group,
-        shapeTextAutoExpand: hasWidthChange
-          ? false
-          : undefined
+      const placement = canvasManager.getObjectPlacement({
+        object: group
+      })
+      const didCommitScaling = this.scalingController.commitActiveSelectionGroupScaling({
+        group,
+        scaleX,
+        scaleY,
+        transform
       })
 
+      if (!didCommitScaling) return
+
+      canvasManager.applyObjectPlacement({
+        object: group,
+        placement
+      })
       group.setCoords()
     })
 

--- a/src/editor/shape-manager/scaling/shape-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling.ts
@@ -21,10 +21,12 @@ import {
 import { resizeShapeNode } from '../shape-factory'
 import {
   ShapeGroup,
+  ShapeHorizontalAlign,
   ShapePadding,
   ShapeScalingState,
   ShapeNode,
-  ShapeTextNode
+  ShapeTextNode,
+  ShapeVerticalAlign
 } from '../types'
 import {
   getShapeNodes,
@@ -103,6 +105,28 @@ type ShapeScalingStartDimensions = {
 type ShapeScalingManualBaseDimensions = {
   width: number
   height: number
+}
+
+type ShapeScalingCommitDimensions = {
+  width: number
+  height: number
+  hasWidthChange: boolean
+  hasDimensionChange: boolean
+}
+
+type ShapeScalingLayoutCommit = {
+  group: ShapeGroup
+  shape: ShapeNode
+  text: ShapeTextNode
+  width: number
+  height: number
+  alignH: ShapeHorizontalAlign
+  alignV: ShapeVerticalAlign
+  startManualBaseWidth: number
+  startManualBaseHeight: number
+  canScaleWidth: boolean
+  canScaleHeight: boolean
+  hasWidthChange: boolean
 }
 
 type CanvasWithCurrentTransform = Canvas & {
@@ -313,7 +337,7 @@ export default class ShapeScalingController {
       group,
       text,
       constraintPadding,
-      state,
+      startDimensions: state,
       appliedScaleX,
       appliedScaleY,
       minimumHeight: shouldReuseResolvedMinimumHeight ? constraintState.resolvedMinimumHeight : null
@@ -432,7 +456,7 @@ export default class ShapeScalingController {
     group,
     text,
     constraintPadding,
-    state,
+    startDimensions,
     appliedScaleX,
     appliedScaleY,
     minimumHeight
@@ -440,17 +464,17 @@ export default class ShapeScalingController {
     group: ShapeGroup
     text: ShapeTextNode
     constraintPadding: ShapePadding
-    state: ShapeScalingState
+    startDimensions: ShapeScalingStartDimensions
     appliedScaleX: number
     appliedScaleY: number
     minimumHeight?: number | null
   }): ShapePreviewDimensions {
-    const previewWidth = state.canScaleWidth
-      ? Math.max(MIN_SIZE, state.startWidth * appliedScaleX)
-      : state.startWidth
-    const scaledPreviewHeight = state.canScaleHeight
-      ? Math.max(MIN_SIZE, state.startHeight * appliedScaleY)
-      : state.startManualBaseHeight
+    const previewWidth = startDimensions.canScaleWidth
+      ? Math.max(MIN_SIZE, startDimensions.startWidth * appliedScaleX)
+      : startDimensions.startWidth
+    const scaledPreviewHeight = startDimensions.canScaleHeight
+      ? Math.max(MIN_SIZE, startDimensions.startHeight * appliedScaleY)
+      : startDimensions.startManualBaseHeight
     const resolvedMinimumHeight = minimumHeight ?? resolveRequiredShapeHeightForText({
       text,
       width: previewWidth,
@@ -665,7 +689,7 @@ export default class ShapeScalingController {
       group,
       text,
       constraintPadding,
-      state,
+      startDimensions: state,
       appliedScaleX: nextScaleX,
       appliedScaleY: nextScaleY,
       minimumHeight: didClampWidth ? null : resolvedMinimumHeight
@@ -766,7 +790,7 @@ export default class ShapeScalingController {
         group,
         text,
         constraintPadding,
-        state,
+        startDimensions: state,
         appliedScaleX: scaleX,
         appliedScaleY: scaleY
       })
@@ -949,18 +973,26 @@ export default class ShapeScalingController {
       }
     }
 
-    const widthByAllowedScale = canScaleWidth
-      ? Math.max(MIN_SIZE, startWidth * allowedScaleX)
-      : startWidth
-    const heightByAllowedScale = canScaleHeight
-      ? Math.max(MIN_SIZE, startHeight * allowedScaleY)
-      : startManualBaseHeight
-    const hasWidthChange = Math.abs(widthByAllowedScale - startWidth) > SIZE_EPSILON
-    const hasHeightChange = Math.abs(heightByAllowedScale - startHeight) > SIZE_EPSILON
-    const hasDimensionChange = hasWidthChange || hasHeightChange
-
-    const width = widthByAllowedScale
-    const height = heightByAllowedScale
+    const {
+      width,
+      height,
+      hasWidthChange,
+      hasDimensionChange
+    } = this._resolveScalingCommitDimensions({
+      group,
+      text,
+      constraintPadding,
+      startDimensions: {
+        startWidth,
+        startHeight,
+        startManualBaseWidth,
+        startManualBaseHeight,
+        canScaleWidth,
+        canScaleHeight
+      },
+      scaleX: allowedScaleX,
+      scaleY: allowedScaleY
+    })
 
     if (!hasDimensionChange && state) {
       this._restoreShapeStateWithoutResize({
@@ -987,32 +1019,7 @@ export default class ShapeScalingController {
       })
     }
 
-    const nextManualBaseDimensions = this._resolveNextManualBaseDimensionsAfterScaling({
-      startManualBaseWidth,
-      startManualBaseHeight,
-      canScaleWidth,
-      canScaleHeight,
-      finalWidth: width,
-      finalHeight: height
-    })
-
-    group.shapeManualBaseWidth = nextManualBaseDimensions.width
-    group.shapeManualBaseHeight = nextManualBaseDimensions.height
-
-    if (canScaleWidth && hasWidthChange) {
-      // Ручной resize по ширине фиксирует новую ширину как пользовательский контракт.
-      group.shapeTextAutoExpand = false
-    }
-
-    const userPadding = ShapeScalingController._resolveUserPadding({ group })
-    const internalShapeTextInset = ShapeScalingController._resolveInternalShapeTextInset({
-      group,
-      width,
-      height
-    })
-    const expandShapeHeightToFitText = !canScaleHeight
-
-    applyShapeTextLayout({
+    this._commitResolvedShapeScalingLayout({
       group,
       shape,
       text,
@@ -1020,30 +1027,11 @@ export default class ShapeScalingController {
       height,
       alignH,
       alignV,
-      padding: userPadding,
-      shapeTextAutoExpandEnabled: group.shapeTextAutoExpand !== false,
-      internalShapeTextInset,
-      expandShapeHeightToFitText,
-      resolveInternalShapeTextInset: ({ width: nextWidth, height: nextHeight }) => {
-        return ShapeScalingController._resolveInternalShapeTextInset({
-          group,
-          width: nextWidth,
-          height: nextHeight
-        })
-      }
-    })
-
-    group.shapeReplaceBoxWidth = Math.max(1, group.shapeBaseWidth ?? width)
-    group.shapeReplaceBoxHeight = Math.max(1, group.shapeBaseHeight ?? height)
-
-    text.set({
-      scaleX: 1,
-      scaleY: 1
-    })
-
-    group.set({
-      scaleX: 1,
-      scaleY: 1
+      startManualBaseWidth,
+      startManualBaseHeight,
+      canScaleWidth,
+      canScaleHeight,
+      hasWidthChange
     })
 
     if (state) {
@@ -1061,6 +1049,94 @@ export default class ShapeScalingController {
     group.shapeScalingNoopTransform = false
 
     this.canvas.requestRenderAll()
+  }
+
+  /**
+   * Фиксирует resize дочерней shape-группы после масштабирования ActiveSelection.
+   */
+  public commitActiveSelectionGroupScaling({
+    group,
+    scaleX,
+    scaleY,
+    transform
+  }: {
+    group: ShapeGroup
+    scaleX: number
+    scaleY: number
+    transform?: Transform | null
+  }): boolean {
+    const {
+      shape,
+      text
+    } = getShapeNodes({ group })
+
+    if (!shape || !text) {
+      this.scalingState.delete(group)
+      return false
+    }
+
+    const state = this.scalingState.get(group)
+    const startDimensions = state ?? this._resolveScalingStartDimensions({
+      group,
+      transform
+    })
+    const resolvedAxes = transform
+      ? resolveShapeScaleActionAxes({
+        transform
+      })
+      : null
+    const canScaleWidth = state?.canScaleWidth
+      ?? resolvedAxes?.canScaleWidth
+      ?? (Math.abs(scaleX - 1) > SCALE_EPSILON)
+    const canScaleHeight = state?.canScaleHeight
+      ?? resolvedAxes?.canScaleHeight
+      ?? (Math.abs(scaleY - 1) > SCALE_EPSILON)
+    const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
+    const alignV = group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN
+    const constraintPadding = ShapeScalingController._resolveScalingConstraintPadding({ group })
+    const {
+      width,
+      height,
+      hasWidthChange,
+      hasDimensionChange
+    } = this._resolveScalingCommitDimensions({
+      group,
+      text,
+      constraintPadding,
+      startDimensions: {
+        ...startDimensions,
+        canScaleWidth,
+        canScaleHeight
+      },
+      scaleX,
+      scaleY
+    })
+
+    if (!hasDimensionChange) {
+      this.scalingState.delete(group)
+      group.shapeScalingNoopTransform = false
+      return false
+    }
+
+    this._commitResolvedShapeScalingLayout({
+      group,
+      shape,
+      text,
+      width,
+      height,
+      alignH,
+      alignV,
+      startManualBaseWidth: startDimensions.startManualBaseWidth,
+      startManualBaseHeight: startDimensions.startManualBaseHeight,
+      canScaleWidth,
+      canScaleHeight,
+      hasWidthChange
+    })
+
+    this.scalingState.delete(group)
+    group.shapeScalingNoopTransform = false
+
+    return true
   }
 
   /**
@@ -1630,5 +1706,130 @@ export default class ShapeScalingController {
       width: nextManualBaseWidth,
       height: nextManualBaseHeight
     }
+  }
+
+  /**
+   * Возвращает итоговые размеры шага фиксации с учетом осей, которые реально скейлились.
+   */
+  private _resolveScalingCommitDimensions({
+    group,
+    text,
+    constraintPadding,
+    startDimensions,
+    scaleX,
+    scaleY
+  }: {
+    group: ShapeGroup
+    text: ShapeTextNode
+    constraintPadding: ShapePadding
+    startDimensions: ShapeScalingStartDimensions
+    scaleX: number
+    scaleY: number
+  }): ShapeScalingCommitDimensions {
+    const {
+      previewWidth,
+      previewHeight
+    } = this._resolvePreviewDimensions({
+      group,
+      text,
+      constraintPadding,
+      startDimensions,
+      appliedScaleX: scaleX,
+      appliedScaleY: scaleY
+    })
+    const {
+      startWidth,
+      startHeight
+    } = startDimensions
+    const hasWidthChange = Math.abs(previewWidth - startWidth) > SIZE_EPSILON
+    const hasHeightChange = Math.abs(previewHeight - startHeight) > SIZE_EPSILON
+
+    return {
+      width: previewWidth,
+      height: previewHeight,
+      hasWidthChange,
+      hasDimensionChange: hasWidthChange || hasHeightChange
+    }
+  }
+
+  /**
+   * Применяет уже выбранные resize-размеры к layout шейпа и сбрасывает временный scale.
+   */
+  private _commitResolvedShapeScalingLayout({
+    group,
+    shape,
+    text,
+    width,
+    height,
+    alignH,
+    alignV,
+    startManualBaseWidth,
+    startManualBaseHeight,
+    canScaleWidth,
+    canScaleHeight,
+    hasWidthChange
+  }: ShapeScalingLayoutCommit): void {
+    const nextManualBaseDimensions = this._resolveNextManualBaseDimensionsAfterScaling({
+      startManualBaseWidth,
+      startManualBaseHeight,
+      canScaleWidth,
+      canScaleHeight,
+      finalWidth: width,
+      finalHeight: height
+    })
+
+    group.shapeManualBaseWidth = nextManualBaseDimensions.width
+    group.shapeManualBaseHeight = nextManualBaseDimensions.height
+
+    if (canScaleWidth && hasWidthChange) {
+      // Ручной resize по ширине фиксирует новую ширину как пользовательский контракт.
+      group.shapeTextAutoExpand = false
+    }
+
+    const userPadding = ShapeScalingController._resolveUserPadding({ group })
+    const internalShapeTextInset = ShapeScalingController._resolveInternalShapeTextInset({
+      group,
+      width,
+      height
+    })
+    const expandShapeHeightToFitText = !canScaleHeight
+
+    applyShapeTextLayout({
+      group,
+      shape,
+      text,
+      width,
+      height,
+      alignH,
+      alignV,
+      padding: userPadding,
+      shapeTextAutoExpandEnabled: group.shapeTextAutoExpand !== false,
+      internalShapeTextInset,
+      expandShapeHeightToFitText,
+      resolveInternalShapeTextInset: ({ width: nextWidth, height: nextHeight }) => {
+        return ShapeScalingController._resolveInternalShapeTextInset({
+          group,
+          width: nextWidth,
+          height: nextHeight
+        })
+      }
+    })
+
+    group.shapeReplaceBoxWidth = Math.max(1, group.shapeBaseWidth ?? width)
+    group.shapeReplaceBoxHeight = Math.max(1, group.shapeBaseHeight ?? height)
+
+    text.set({
+      scaleX: 1,
+      scaleY: 1
+    })
+
+    group.set({
+      scaleX: 1,
+      scaleY: 1
+    })
+
+    group.setCoords()
+    text.setCoords()
+    shape.setCoords()
   }
 }


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавляем 2 одинаковых шейпа с текстом "TEST" (скрин 1)

<img width="472" height="462" alt="image" src="https://github.com/user-attachments/assets/ef3aeb4c-3d29-42ba-b4dd-f8d8f1af4968" />

2. Выделяем оба шейпа и уменьшаем их как одно массовое выделение (activeselection) (Скрин 2)

<img width="469" height="492" alt="image" src="https://github.com/user-attachments/assets/78ef38a4-6d8e-4f79-973a-6bba52c63f91" />

3. Далее увеличиваем ширину шейпов путём скейлинга массвого выделения по горизонтали

Ожидаемый результат.

В процессе увеличения ширины путём скейлинга ширина объектов увеличивается, однострочный текст перестраивается в одну строку. После отпускания размеры остаются такими же как они были во время лайв скейлинга.

Фактический результат.

В процессе увеличения ширины путём скейлинга ширина объектов увеличивается, однострочный текст перестраивается в одну строку. После отпускания высота шейпов увеличивается.

<img width="563" height="510" alt="image" src="https://github.com/user-attachments/assets/30d1582b-8a0a-4eba-a737-a815be63bbfd" />

<img width="595" height="456" alt="image" src="https://github.com/user-attachments/assets/c04fd7fa-3769-4e63-8c25-561e45c0a54a" />

--- 

FIXED
