### PR TITLE
ShapeManager. Правим баг когда при массовом скейлинге шейпов область выделения не учитывает минимальные размеры объектов + отключаем флип шейпов и текстов при скейлинге

### DIFF
--- a/e2e/models/selection.model.ts
+++ b/e2e/models/selection.model.ts
@@ -13,6 +13,11 @@ type SelectionScaleInteraction = {
   control: SelectionControlKey
 }
 
+type DragActiveScaleHandleParams = {
+  deltaX: number
+  deltaY: number
+}
+
 type ScaleSelectionFromControlParams = {
   startControl: SelectionControlKey
   oppositeControl: SelectionControlKey
@@ -76,6 +81,21 @@ export class SelectionModel {
     return this._scaleFromControl({
       startControl: 'mb',
       oppositeControl: 'mt',
+      scaleY: params.scaleY
+    })
+  }
+
+  /** Масштабирует текущее общее выделение из правого нижнего угла и возвращает live-состояние. */
+  async scaleDiagonallyFromBottomRight(
+    params: {
+      scaleX: number
+      scaleY: number
+    }
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'br',
+      oppositeControl: 'tl',
+      scaleX: params.scaleX,
       scaleY: params.scaleY
     })
   }
@@ -162,9 +182,10 @@ export class SelectionModel {
         clientY: releasePoint.y
       }))
 
-      target.setCoords()
+      const snapshotTarget = editor.canvas.getActiveObject() ?? target
+      snapshotTarget.setCoords()
 
-      return helpers.serializeSnappingObjectSnapshot(target)
+      return helpers.serializeSnappingObjectSnapshot(snapshotTarget)
     }, this.activeScaleInteraction)
 
     this.activeScaleInteraction = null
@@ -174,6 +195,92 @@ export class SelectionModel {
     await waitForCanvasRender({ page: this.page })
 
     return snapshot as SnappingObjectSnapshot
+  }
+
+  /** Продолжает текущий drag хэндла общего выделения и возвращает live-состояние. */
+  async dragActiveScaleHandleBy(
+    params: DragActiveScaleHandleParams
+  ): Promise<SnappingObjectSnapshot> {
+    expect(
+      this.activeScaleInteraction,
+      'должна существовать активная drag-сессия масштабирования общего выделения'
+    ).not.toBeNull()
+
+    if (!this.activeScaleInteraction) {
+      throw new Error('должна существовать активная drag-сессия масштабирования общего выделения')
+    }
+
+    const result = await this.page.evaluate((payload) => {
+      const {
+        point,
+        control,
+        deltaX,
+        deltaY
+      } = payload
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+      const target = editor.canvas.getActiveObject()
+      if (!target) return null
+
+      const movePoint = {
+        x: point.x + deltaX,
+        y: point.y + deltaY
+      }
+
+      editor.canvas.__onMouseMove(new MouseEvent('mousemove', {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: movePoint.x,
+        clientY: movePoint.y
+      }))
+
+      const snapshotTarget = editor.canvas.getActiveObject() ?? target
+      snapshotTarget.setCoords()
+
+      const currentControl = snapshotTarget.oCoords?.[control]
+      const rect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+      const currentPoint = currentControl
+        && typeof currentControl.x === 'number'
+        && typeof currentControl.y === 'number'
+        ? {
+          x: rect.left + currentControl.x,
+          y: rect.top + currentControl.y
+        }
+        : movePoint
+
+      return {
+        point: currentPoint,
+        snapshot: helpers.serializeSnappingObjectSnapshot(snapshotTarget)
+      }
+    }, {
+      ...this.activeScaleInteraction,
+      ...params
+    })
+
+    expect(result, 'должно существовать live-состояние общего выделения после продолжения drag').not.toBeNull()
+
+    await waitForCanvasRender({ page: this.page })
+
+    const {
+      point,
+      snapshot
+    } = result as {
+      point: {
+        x: number
+        y: number
+      }
+      snapshot: SnappingObjectSnapshot
+    }
+
+    this.activeScaleInteraction = {
+      ...this.activeScaleInteraction,
+      point
+    }
+
+    return snapshot
   }
 
   private async _scaleFromControl(

--- a/e2e/tests/customized-controls/index.spec.ts
+++ b/e2e/tests/customized-controls/index.spec.ts
@@ -46,8 +46,6 @@ test.describe('Масштабирование общего выделения', 
         expect(finalSelection.boundsWidth).toBeGreaterThan(0)
         expect(liveSelection.boundsWidth)
           .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
-        expect(finalSelection.boundsWidth)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalLeftText.flipX).toBe(false)
         expect(finalRightText.flipX).toBe(false)
         expect(finalLeftText.centerX).toBeLessThanOrEqual(finalRightText.centerX)
@@ -86,10 +84,6 @@ test.describe('Масштабирование общего выделения', 
           .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(liveSelection.boundsHeight)
           .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
-        expect(finalSelection.boundsWidth)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
-        expect(finalSelection.boundsHeight)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalLeftText.flipX).toBe(false)
         expect(finalLeftText.flipY).toBe(false)
         expect(finalRightText.flipX).toBe(false)
@@ -122,11 +116,14 @@ test.describe('Масштабирование общего выделения', 
       await editorModel.selectAllObjects()
     })
 
-    test('нельзя перевернуть при максимальном сжатии по горизонтали', async({
+    test('при максимальном сжатии по горизонтали упирается в минимальную ширину шейпов и не переворачивает их', async({
       editorModel,
       selection,
       shapes
     }) => {
+      const initialSelection = await test.step('Получить исходную ширину выделения', () => {
+        return selection.getSnapshot()
+      })
       const liveSelection = await test.step('Сузить выделение справа до минимальной ширины', () => {
         return selection.shrinkHorizontallyFromRightToMinimum({
           minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
@@ -154,20 +151,27 @@ test.describe('Масштабирование общего выделения', 
         expect(liveSelection.boundsWidth).toBeGreaterThan(0)
         expect(finalSelection.boundsWidth).toBeGreaterThan(0)
         expect(liveSelection.boundsWidth)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeLessThan(initialSelection.boundsWidth - ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(liveSelection.boundsWidth)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalSelection.boundsWidth)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(Math.abs(finalSelection.boundsWidth - liveSelection.boundsWidth))
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalLeftObject.flipX).toBe(false)
         expect(finalRightObject.flipX).toBe(false)
         expect(finalLeftShape.groupBoundsLeft).toBeLessThanOrEqual(finalRightShape.groupBoundsLeft)
       })
     })
 
-    test('нельзя перевернуть при максимальном сжатии по вертикали', async({
+    test('при максимальном сжатии по вертикали упирается в минимальную высоту шейпов и не переворачивает их', async({
       editorModel,
       selection,
       shapes
     }) => {
+      const initialSelection = await test.step('Получить исходную высоту выделения', () => {
+        return selection.getSnapshot()
+      })
       const liveSelection = await test.step('Сузить выделение снизу до минимальной высоты', () => {
         return selection.shrinkVerticallyFromBottomToMinimum({
           minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
@@ -201,9 +205,13 @@ test.describe('Масштабирование общего выделения', 
         expect(liveSelection.boundsHeight).toBeGreaterThan(0)
         expect(finalSelection.boundsHeight).toBeGreaterThan(0)
         expect(liveSelection.boundsHeight)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeLessThan(initialSelection.boundsHeight - ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(liveSelection.boundsHeight)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalSelection.boundsHeight)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(Math.abs(finalSelection.boundsHeight - liveSelection.boundsHeight))
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalLeftObject.flipY).toBe(false)
         expect(finalRightObject.flipY).toBe(false)
         expect(finalLeftShape.groupBoundsHeight).toBeGreaterThan(0)
@@ -228,11 +236,14 @@ test.describe('Масштабирование общего выделения', 
       })
     })
 
-    test('нельзя перевернуть при максимальном сжатии по диагонали', async({
+    test('при максимальном сжатии по диагонали не переворачивает шейпы и оставляет текст внутри', async({
       editorModel,
       selection,
       shapes
     }) => {
+      const initialSelection = await test.step('Получить исходный размер выделения', () => {
+        return selection.getSnapshot()
+      })
       const liveSelection = await test.step('Сузить выделение из правого нижнего угла до минимального размера', () => {
         return selection.shrinkDiagonallyFromBottomRightToMinimum({
           minimumSize: ACTIVE_SELECTION_MINIMUM_SIZE
@@ -264,13 +275,19 @@ test.describe('Масштабирование общего выделения', 
         expect(finalSelection.boundsWidth).toBeGreaterThan(0)
         expect(finalSelection.boundsHeight).toBeGreaterThan(0)
         expect(liveSelection.boundsWidth)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeLessThan(initialSelection.boundsWidth - ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(liveSelection.boundsWidth)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(liveSelection.boundsHeight)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalSelection.boundsWidth)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalSelection.boundsHeight)
-          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+          .toBeGreaterThan(ACTIVE_SELECTION_MINIMUM_SIZE + ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(Math.abs(finalSelection.boundsWidth - liveSelection.boundsWidth))
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
+        expect(Math.abs(finalSelection.boundsHeight - liveSelection.boundsHeight))
+          .toBeLessThanOrEqual(ACTIVE_SELECTION_MINIMUM_SIZE_TOLERANCE)
         expect(finalLeftObject.flipX).toBe(false)
         expect(finalLeftObject.flipY).toBe(false)
         expect(finalRightObject.flipX).toBe(false)

--- a/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
+++ b/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
@@ -9,6 +9,9 @@ import {
   SHAPE_MULTI_SCALING_TOLERANCE
 } from '../../fixtures/data/shape-multi-scaling.data'
 
+const SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE = 1
+const SHAPE_MULTI_SCALING_BEYOND_MINIMUM_DRAG_DELTA = -120
+
 test.describe('Изменение размера нескольких шейпов', () => {
   test.beforeEach(async({ editorModel, shapes }) => {
     const leftShape = await shapes.addAtBounds({
@@ -386,6 +389,208 @@ test.describe('Изменение размера нескольких шейпо
       expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
       expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
 
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('при сужении нескольких шейпов за угол текст переносится во время drag и размер не дёргается после mouseup', async({
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_RIGHT_OPTIONS
+    const { mouseupJump } = SHAPE_MULTI_SCALING_TOLERANCE
+
+    const initialSelectionSnapshot = await test.step('Получить исходный размер общего выделения', () => {
+      return selection.getSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в левом шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в правом шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const liveSelectionSnapshot = await test.step('Сузить общее выделение из правого нижнего угла во время drag', () => {
+      return selection.scaleDiagonallyFromBottomRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X,
+        scaleY: SHAPE_MULTI_SCALING_SCALE_Y
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние левого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const liveRightShape = await test.step('Получить состояние правого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const liveLeftText = await test.step('Получить текст в левом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const liveRightText = await test.step('Получить текст в правом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в левом шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в правом шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что во время drag изменяются обе оси и текст переносится внутри шейпов', () => {
+      expect(initialLeftText, 'текст в левом шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в правом шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.boundsWidth)
+        .toBeLessThan(initialSelectionSnapshot.boundsWidth - mouseupJump)
+      expect(liveSelectionSnapshot.boundsHeight)
+        .toBeLessThan(initialSelectionSnapshot.boundsHeight - mouseupJump)
+      expect(liveLeftText.lineCount).toBeGreaterThan(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBeGreaterThan(initialRightText.lineCount)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    await test.step('Проверить что после mouseup размер не дёрнулся и переносы строк сохранились', () => {
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+      expect(finalLeftText, 'итоговый текст в левом шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в правом шейпе должен существовать').not.toBeNull()
+
+      if (!liveLeftText || !liveRightText || !finalLeftText || !finalRightText) {
+        throw new Error('текст в обоих шейпах должен существовать во время drag и после mouseup')
+      }
+
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.boundsWidth - liveSelectionSnapshot.boundsWidth)
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.boundsHeight - liveSelectionSnapshot.boundsHeight)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(selectionHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('если продолжать тянуть угол после упора в минимальную ширину, выделение не расширяется по ширине рывком', async({
+    selection,
+    shapes
+  }) => {
+    const minimumSelectionSnapshot = await test.step('Сжать общее выделение из правого нижнего угла до минимального размера', () => {
+      return selection.shrinkDiagonallyFromBottomRightToMinimum({
+        minimumSize: SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE
+      })
+    })
+    const minimumLeftShape = await test.step('Получить состояние левого шейпа на минимальном размере', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const minimumRightShape = await test.step('Получить состояние правого шейпа на минимальном размере', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    const continuedSelectionSnapshot = await test.step('Продолжить тянуть угол дальше по диагонали', () => {
+      return selection.dragActiveScaleHandleBy({
+        deltaX: SHAPE_MULTI_SCALING_BEYOND_MINIMUM_DRAG_DELTA,
+        deltaY: SHAPE_MULTI_SCALING_BEYOND_MINIMUM_DRAG_DELTA
+      })
+    })
+    const continuedLeftShape = await test.step('Получить состояние левого шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const continuedRightShape = await test.step('Получить состояние правого шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что продолжение drag не расширило выделение по ширине и шейпы остались корректными', () => {
+      expect(continuedSelectionSnapshot.boundsWidth)
+        .toBeGreaterThan(SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE + SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(continuedSelectionSnapshot.boundsHeight)
+        .toBeGreaterThan(SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE + SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+
+      expect(Math.abs(continuedSelectionSnapshot.boundsWidth - minimumSelectionSnapshot.boundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalSelectionSnapshot.boundsWidth - continuedSelectionSnapshot.boundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+
+      expect(Math.abs(continuedLeftShape.groupBoundsWidth - minimumLeftShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(continuedRightShape.groupBoundsWidth - minimumRightShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalLeftShape.groupBoundsWidth - continuedLeftShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalRightShape.groupBoundsWidth - continuedRightShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalSelectionSnapshot.boundsHeight).toBeGreaterThan(0)
+      expect(finalLeftShape.groupBoundsHeight).toBeGreaterThan(0)
+      expect(finalRightShape.groupBoundsHeight).toBeGreaterThan(0)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedRightShape,
+        kind: 'text'
+      })
       shapes.checkNodeInsideGroup({
         snapshot: finalLeftShape,
         kind: 'text'

--- a/specs/__mocks__/fabric.ts
+++ b/specs/__mocks__/fabric.ts
@@ -60,7 +60,23 @@ export class Pattern {
   }
 }
 
-export class FitContentLayout {
+export class LayoutStrategy {}
+
+export class LayoutManager {
+  public strategy?: LayoutStrategy
+
+  public subscribeTargets = jest.fn()
+
+  public unsubscribeTargets = jest.fn()
+
+  public performLayout = jest.fn()
+
+  constructor(strategy?: LayoutStrategy) {
+    this.strategy = strategy
+  }
+}
+
+export class FitContentLayout extends LayoutStrategy {
   calcBoundingBox(_objects: unknown[], _context: unknown) {
     return undefined
   }
@@ -991,6 +1007,8 @@ export default {
   FabricImage,
   Gradient,
   Textbox,
+  LayoutManager,
+  LayoutStrategy,
   FitContentLayout,
   InteractiveFabricObject,
   controlsUtils,

--- a/specs/src/editor/customized-controls/index.spec.ts
+++ b/specs/src/editor/customized-controls/index.spec.ts
@@ -109,6 +109,32 @@ describe('customized-controls', () => {
     })
   })
 
+  it('выделение с шейпом получает контролы для свободного изменения размера за угол', () => {
+    const {
+      selection,
+      recalculateBounds
+    } = createActiveSelectionScalingRulesTestSetup({
+      objectKinds: ['shape']
+    })
+    const topLeftControl = selection.controls.tl
+    const topRightControl = selection.controls.tr
+    const bottomLeftControl = selection.controls.bl
+    const bottomRightControl = selection.controls.br
+    const middleLeftControl = selection.controls.ml
+
+    recalculateBounds()
+
+    expect(selection.controls.tl).not.toBe(topLeftControl)
+    expect(selection.controls.tr).not.toBe(topRightControl)
+    expect(selection.controls.bl).not.toBe(bottomLeftControl)
+    expect(selection.controls.br).not.toBe(bottomRightControl)
+    expect(selection.controls.ml).toBe(middleLeftControl)
+    expect(selection.controls.tl).toHaveProperty('shapeFreeScaleCornerControl', true)
+    expect(selection.controls.tr).toHaveProperty('shapeFreeScaleCornerControl', true)
+    expect(selection.controls.bl).toHaveProperty('shapeFreeScaleCornerControl', true)
+    expect(selection.controls.br).toHaveProperty('shapeFreeScaleCornerControl', true)
+  })
+
   it('выделение обычных объектов не блокирует flip', () => {
     const {
       selection,

--- a/specs/src/editor/shape-manager/shape-controls.spec.ts
+++ b/specs/src/editor/shape-manager/shape-controls.spec.ts
@@ -1,4 +1,10 @@
-import { Control, Point, controlsUtils } from 'fabric'
+import {
+  Control,
+  Point,
+  controlsUtils,
+  type Transform,
+  type TPointerEvent
+} from 'fabric'
 import { applyShapeCornerFreeScaleControls } from '../../../../src/editor/shape-manager/scaling/shape-controls'
 import {
   createMockShapeGroup,
@@ -50,7 +56,7 @@ describe('shape-controls', () => {
     } as never
 
     applyShapeCornerFreeScaleControls({
-      group
+      target: group
     })
 
     expect(group.controls.tl).not.toBe(topLeftControl)
@@ -80,14 +86,14 @@ describe('shape-controls', () => {
     } as never
 
     applyShapeCornerFreeScaleControls({
-      group
+      target: group
     })
 
     const wrappedTopLeftControl = group.controls.tl
     const wrappedTopRightControl = group.controls.tr
 
     applyShapeCornerFreeScaleControls({
-      group
+      target: group
     })
 
     expect(group.controls.tl).toBe(wrappedTopLeftControl)
@@ -122,7 +128,7 @@ describe('shape-controls', () => {
     } as never
 
     applyShapeCornerFreeScaleControls({
-      group
+      target: group
     })
 
     const actionHandler = (group.controls.tl as Control).actionHandler as NonNullable<Control['actionHandler']>
@@ -135,35 +141,29 @@ describe('shape-controls', () => {
         mode: 'proportional-scaling-result'
       }
     })
+    const eventData = {
+      shiftKey: true
+    } satisfies Pick<TPointerEvent, 'shiftKey'>
+    const transform = {
+      target,
+      originX: 'left',
+      originY: 'top'
+    } as unknown as Transform
 
     const result = actionHandler(
-      {
-        shiftKey: true
-      },
-      {
-        target,
-        originX: 'left',
-        originY: 'top'
-      },
+      eventData as TPointerEvent,
+      transform,
       10,
       20
     )
 
     expect(result).toEqual({
-      eventData: {
-        shiftKey: true
-      },
+      eventData,
       mode: 'proportional-scaling-result'
     })
     expect(scalingEquallyMock).toHaveBeenCalledWith(
-      {
-        shiftKey: true
-      },
-      {
-        target,
-        originX: 'left',
-        originY: 'top'
-      },
+      eventData,
+      transform,
       10,
       20
     )
@@ -202,20 +202,22 @@ describe('shape-controls', () => {
     } as never
 
     applyShapeCornerFreeScaleControls({
-      group
+      target: group
     })
 
     const actionHandler = (group.controls.tl as Control).actionHandler as NonNullable<Control['actionHandler']>
+    const eventData = {
+      shiftKey: false
+    } satisfies Pick<TPointerEvent, 'shiftKey'>
+    const transform = {
+      target,
+      originX: 'left',
+      originY: 'top'
+    } as unknown as Transform
 
     const result = actionHandler(
-      {
-        shiftKey: false
-      },
-      {
-        target,
-        originX: 'left',
-        originY: 'top'
-      },
+      eventData as TPointerEvent,
+      transform,
       50,
       25
     )
@@ -257,7 +259,7 @@ describe('shape-controls', () => {
     } as never
 
     applyShapeCornerFreeScaleControls({
-      group
+      target: group
     })
 
     const actionHandler = (group.controls.tl as Control).actionHandler as NonNullable<Control['actionHandler']>
@@ -265,21 +267,20 @@ describe('shape-controls', () => {
       target,
       originX: 'left',
       originY: 'top'
-    }
+    } as unknown as Transform
+    const eventData = {
+      shiftKey: false
+    } satisfies Pick<TPointerEvent, 'shiftKey'>
 
     actionHandler(
-      {
-        shiftKey: false
-      },
+      eventData as TPointerEvent,
       transform,
       50,
       50
     )
 
     const result = actionHandler(
-      {
-        shiftKey: false
-      },
+      eventData as TPointerEvent,
       transform,
       -50,
       25
@@ -320,7 +321,7 @@ describe('shape-controls', () => {
     } as never
 
     applyShapeCornerFreeScaleControls({
-      group
+      target: group
     })
 
     const actionHandler = (group.controls.tl as Control).actionHandler as NonNullable<Control['actionHandler']>
@@ -328,21 +329,20 @@ describe('shape-controls', () => {
       target,
       originX: 'left',
       originY: 'top'
-    }
+    } as unknown as Transform
+    const eventData = {
+      shiftKey: false
+    } satisfies Pick<TPointerEvent, 'shiftKey'>
 
     actionHandler(
-      {
-        shiftKey: false
-      },
+      eventData as TPointerEvent,
       transform,
       50,
       50
     )
 
     const result = actionHandler(
-      {
-        shiftKey: false
-      },
+      eventData as TPointerEvent,
       transform,
       25,
       -50

--- a/specs/src/editor/shape-manager/shape-manager-events.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-events.spec.ts
@@ -1,5 +1,5 @@
 import '../../../test-utils/shape-manager-module-mocks'
-import { ActiveSelection } from 'fabric'
+import { ActiveSelection, Point } from 'fabric'
 import ShapeManager from '../../../../src/editor/shape-manager'
 import {
   createShapeManagerEditorStub,
@@ -428,5 +428,114 @@ describe('shape-manager events', () => {
 
     expect(restoredSelection).toBeInstanceOf(ActiveSelection)
     expect(restoredSelection?.getObjects()).toEqual([firstShape, secondShape])
+  })
+
+  it('после изменения размера нескольких шейпов фиксирует размер по scale, применённому во время drag', async() => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const firstShape = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'first'
+      }
+    })
+    const secondShape = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'second'
+      }
+    })
+
+    if (!firstShape || !secondShape) {
+      throw new Error('shape groups should be created')
+    }
+
+    const minimumShapeWidth = 120
+    const rawSelectionScaleX = 0.2
+    const { shapeBaseWidth } = firstShape
+
+    if (typeof shapeBaseWidth !== 'number') {
+      throw new Error('у первого шейпа должна существовать базовая ширина')
+    }
+
+    const appliedSelectionScaleX = minimumShapeWidth / shapeBaseWidth
+    const scalingController = (manager as unknown as {
+      scalingController: {
+        commitActiveSelectionGroupScaling: (payload: unknown) => boolean
+      }
+    }).scalingController
+    const objectScalingHandler = getRequiredCanvasHandler({
+      canvas: editor.canvas,
+      eventName: 'object:scaling'
+    })
+    const objectModifiedHandler = getRequiredCanvasHandler({
+      canvas: editor.canvas,
+      eventName: 'object:modified'
+    })
+    const selection = new ActiveSelection([firstShape, secondShape] as never[], {
+      canvas: editor.canvas as never
+    }) as ActiveSelection & {
+      scaleX?: number
+      scaleY?: number
+      setCoords: jest.Mock
+      setPositionByOrigin: jest.Mock
+    }
+    const scalingTransform = {
+      action: 'scaleX',
+      corner: 'mr',
+      target: selection,
+      originX: 'left',
+      originY: 'center',
+      original: {
+        scaleX: 1,
+        scaleY: 1,
+        left: 0,
+        top: 0,
+        originX: 'left',
+        originY: 'center'
+      }
+    } as never
+    const commitActiveSelectionGroupScalingSpy = jest
+      .spyOn(scalingController, 'commitActiveSelectionGroupScaling')
+      .mockReturnValue(true)
+    const getPositionByOriginMock = jest.fn((
+      _originX: Parameters<ActiveSelection['getPositionByOrigin']>[0],
+      _originY: Parameters<ActiveSelection['getPositionByOrigin']>[1]
+    ) => new Point(0, 0))
+
+    mocks.resolveMinimumShapeWidthForTextMock.mockReturnValue(minimumShapeWidth)
+    selection.scaleX = rawSelectionScaleX
+    selection.scaleY = 1
+    selection.setCoords = jest.fn()
+    selection.getPositionByOrigin = getPositionByOriginMock
+    selection.setPositionByOrigin = jest.fn()
+
+    objectScalingHandler({
+      target: selection,
+      transform: scalingTransform
+    })
+
+    selection.scaleX = rawSelectionScaleX
+
+    objectModifiedHandler({
+      target: selection,
+      transform: scalingTransform
+    })
+
+    expect(commitActiveSelectionGroupScalingSpy).toHaveBeenCalledTimes(2)
+    expect(commitActiveSelectionGroupScalingSpy).toHaveBeenNthCalledWith(1, {
+      group: firstShape,
+      scaleX: appliedSelectionScaleX,
+      scaleY: 1,
+      transform: scalingTransform
+    })
+    expect(commitActiveSelectionGroupScalingSpy).toHaveBeenNthCalledWith(2, {
+      group: secondShape,
+      scaleX: appliedSelectionScaleX,
+      scaleY: 1,
+      transform: scalingTransform
+    })
   })
 })

--- a/specs/src/editor/shape-manager/shape-scaling.spec.ts
+++ b/specs/src/editor/shape-manager/shape-scaling.spec.ts
@@ -694,6 +694,7 @@ describe('shape-scaling', () => {
     expect(texts[1].scaleY).toBeCloseTo(1, 4)
     expect(groups[0].width).toBe(200)
     expect(groups[1].width).toBe(200)
+    expect(selection.setCoords).toHaveBeenCalled()
   })
 
   it('если Fabric пропустил scaling-кадр, продолжает лайв-перерасчёт текста для нескольких шейпов', () => {

--- a/specs/test-utils/customized-controls-helpers.ts
+++ b/specs/test-utils/customized-controls-helpers.ts
@@ -15,6 +15,7 @@ type RotateControl = Control & {
 type ControlCollection = Record<string, RotateControl>
 type ActiveSelectionObjectKind = 'object' | 'shape' | 'text'
 type ActiveSelectionScalingRulesSelection = ActiveSelection & {
+  controls: ControlCollection
   lockScalingFlip?: boolean
   setControlsVisibility: jest.Mock
   setCoords: jest.Mock
@@ -122,6 +123,7 @@ export const createActiveSelectionScalingRulesTestSetup = ({
   }))
   const selection = new ActiveSelection(objects as never[], {}) as ActiveSelectionScalingRulesSelection
 
+  selection.controls = createControlCollection()
   selection.setControlsVisibility = jest.fn()
   selection.setCoords = jest.fn()
   selection.setPositionByOrigin = jest.fn()

--- a/specs/test-utils/shape-group-helpers.ts
+++ b/specs/test-utils/shape-group-helpers.ts
@@ -1,5 +1,7 @@
 import {
   FabricObject,
+  LayoutManager,
+  LayoutStrategy,
   Textbox,
   classRegistry
 } from 'fabric'
@@ -13,21 +15,9 @@ class MockShapeObject extends FabricObject {
   }
 }
 
-export class MockLayoutStrategy {}
+export class MockLayoutStrategy extends LayoutStrategy {}
 
-export class MockLayoutManager {
-  public strategy?: object
-
-  public subscribeTargets = jest.fn()
-
-  public unsubscribeTargets = jest.fn()
-
-  public performLayout = jest.fn()
-
-  constructor(strategy?: object) {
-    this.strategy = strategy
-  }
-}
+export class MockLayoutManager extends LayoutManager {}
 
 /**
  * Регистрирует тестовые классы Fabric, нужные для десериализации shape-group.

--- a/specs/test-utils/shape-scaling-helpers.ts
+++ b/specs/test-utils/shape-scaling-helpers.ts
@@ -12,6 +12,11 @@ type GroupOriginX = 'left' | 'center' | 'right'
 type GroupOriginY = 'top' | 'center' | 'bottom'
 type ShapeScalingTestGroup = ReturnType<typeof createMockShapeGroup>
 type ShapeScalingTransformTarget = ShapeScalingTestGroup | ActiveSelection
+type ActiveSelectionShapeScalingSelection = ActiveSelection & {
+  scaleX?: number
+  scaleY?: number
+  setCoords: jest.Mock
+}
 
 type ShapeScalingTransformOptions = {
   scaleX?: number
@@ -62,10 +67,7 @@ export type ActiveSelectionShapeScalingTestSetup = {
   groups: ShapeScalingTestGroup[]
   shapes: Array<ReturnType<typeof createMockShapeNode>>
   texts: Array<ReturnType<typeof createMockShapeTextbox>>
-  selection: ActiveSelection & {
-    scaleX?: number
-    scaleY?: number
-  }
+  selection: ActiveSelectionShapeScalingSelection
   nonShapeObject: {
     setCoords: jest.Mock
     shapeComposite?: boolean
@@ -171,10 +173,9 @@ export const createActiveSelectionShapeScalingSetup = ({
     : groups
   const selection = new ActiveSelection(selectionObjects as never[], {
     canvas: canvas as never
-  }) as ActiveSelection & {
-    scaleX?: number
-    scaleY?: number
-  }
+  }) as ActiveSelectionShapeScalingSelection
+  selection.setCoords = jest.fn()
+
   const getShapeNodesMock = getShapeNodes as jest.Mock
 
   getShapeNodesMock.mockImplementation(({ group }: { group: ShapeScalingTestGroup }) => {

--- a/src/editor/customized-controls/index.ts
+++ b/src/editor/customized-controls/index.ts
@@ -10,6 +10,7 @@ import {
   type StrictLayoutContext
 } from 'fabric'
 import { DEFAULT_CONTROLS } from './default-controls'
+import { applyShapeCornerFreeScaleControls } from '../shape-manager/scaling/shape-controls'
 
 type BoundingBox = {
   height: number
@@ -232,7 +233,7 @@ export default class ControlsCustomizer {
   }
 
   /**
-   * Применяет ограничения масштабирования ActiveSelection для объектов с собственным text/layout контрактом.
+   * Применяет ограничения и контролы масштабирования ActiveSelection для объектов с собственным text/layout контрактом.
    */
   private static applyActiveSelectionScalingRules(
     {
@@ -250,6 +251,12 @@ export default class ControlsCustomizer {
     selection.set({
       lockScalingFlip: shouldLockScalingFlip
     })
+
+    if (hasShape) {
+      applyShapeCornerFreeScaleControls({
+        target: selection
+      })
+    }
 
     // Для текстовых объектов скрываем вертикальные хэндлы, но оставляем горизонтальное масштабирование:
     // TextManager корректно обрабатывает изменение ширины.

--- a/src/editor/shape-manager/index.ts
+++ b/src/editor/shape-manager/index.ts
@@ -1493,12 +1493,21 @@ export default class ShapeManager {
 
     if (!shapeGroups.length) return
 
-    const scaleX = Math.abs(selection.scaleX ?? 1)
-    const scaleY = Math.abs(selection.scaleY ?? 1)
+    const {
+      scaleX,
+      scaleY
+    } = this.scalingController.resolveActiveSelectionCommittedScale({
+      selection
+    })
     const hasScaleChange = Math.abs(scaleX - 1) > ACTIVE_SELECTION_SCALE_EPSILON
       || Math.abs(scaleY - 1) > ACTIVE_SELECTION_SCALE_EPSILON
 
-    if (!hasScaleChange) return
+    if (!hasScaleChange) {
+      this.scalingController.clearActiveSelectionState({
+        selection
+      })
+      return
+    }
 
     const {
       canvas,
@@ -1528,6 +1537,10 @@ export default class ShapeManager {
     })
 
     const nextSelection = new ActiveSelection(objects, { canvas })
+
+    this.scalingController.clearActiveSelectionState({
+      selection
+    })
 
     canvas.setActiveObject(nextSelection)
     canvas.requestRenderAll()

--- a/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
@@ -1,0 +1,546 @@
+import {
+  ActiveSelection,
+  Canvas,
+  Transform
+} from 'fabric'
+import {
+  resolveMinimumShapeWidthForText
+} from '../layout/shape-layout'
+import {
+  SHAPE_DEFAULT_HORIZONTAL_ALIGN,
+  SHAPE_DEFAULT_VERTICAL_ALIGN
+} from '../shape-presets'
+import {
+  getShapeNodes,
+  isShapeGroup
+} from '../shape-utils'
+import type {
+  ShapeGroup,
+  ShapeNode,
+  ShapePadding,
+  ShapeScalingState,
+  ShapeTextNode
+} from '../types'
+import { applyShapeScalingPreviewLayout } from './shape-scaling-preview'
+import {
+  resolveShapeScaleActionAxes,
+  resolveShapeTransformOriginXValue,
+  resolveShapeTransformOriginYValue
+} from './shape-scaling-transform'
+import {
+  commitResolvedShapeScalingLayout,
+  ensureShapeScalingState,
+  resolveMinimumTextFitHeight,
+  resolveShapeScalingCommitDimensions,
+  resolveShapeScalingConstraintPadding,
+  resolveShapeScalingPreviewDimensions,
+  resolveShapeScalingPreviewLayout,
+  resolveShapeScalingStartDimensions,
+  SHAPE_SCALING_MIN_SIZE as MIN_SIZE,
+  SHAPE_SCALING_SCALE_EPSILON as SCALE_EPSILON
+} from './shape-scaling-layout'
+import type {
+  ShapeScalingPointerEvent
+} from './shape-scaling-layout'
+
+type ActiveSelectionShapeScalingPreviewItem = {
+  group: ShapeGroup
+  shape: ShapeNode
+  text: ShapeTextNode
+  constraintPadding: ShapePadding
+  state: ShapeScalingState
+}
+
+export type ActiveSelectionAppliedScale = {
+  scaleX: number
+  scaleY: number
+}
+
+/**
+ * Контроллер масштабирования shape-групп внутри ActiveSelection.
+ */
+export default class ShapeActiveSelectionScalingController {
+  private canvas: Canvas
+
+  private shapeScalingState: WeakMap<ShapeGroup, ShapeScalingState>
+
+  private scalingState: WeakMap<ActiveSelection, ActiveSelectionAppliedScale>
+
+  constructor({
+    canvas,
+    shapeScalingState
+  }: {
+    canvas: Canvas
+    shapeScalingState: WeakMap<ShapeGroup, ShapeScalingState>
+  }) {
+    this.canvas = canvas
+    this.shapeScalingState = shapeScalingState
+    this.scalingState = new WeakMap()
+  }
+
+  /**
+   * Применяет live-preview по правилам шейпов внутри ActiveSelection.
+   */
+  public handleScalingPreview({
+    selection,
+    transform,
+    event
+  }: {
+    selection: ActiveSelection
+    transform?: Transform | null
+    event?: ShapeScalingPointerEvent
+  }): void {
+    if (!transform) return
+
+    const {
+      canScaleWidth,
+      canScaleHeight
+    } = resolveShapeScaleActionAxes({
+      transform
+    })
+    if (!canScaleWidth && !canScaleHeight) return
+
+    const items = this._collectPreviewItems({
+      selection,
+      transform
+    })
+
+    if (!items.length) return
+
+    const scaleX = Math.abs(selection.scaleX ?? 1) || 1
+    const scaleY = Math.abs(selection.scaleY ?? 1) || 1
+    const appliedScale = this._resolveAppliedScale({
+      items,
+      transform,
+      scaleX,
+      scaleY,
+      event
+    })
+
+    this._applySelectionScale({
+      selection,
+      transform,
+      scaleX: appliedScale.scaleX,
+      scaleY: appliedScale.scaleY
+    })
+    this.scalingState.set(selection, appliedScale)
+
+    items.forEach(({
+      group,
+      shape,
+      text,
+      constraintPadding,
+      state
+    }) => {
+      const previewDimensions = resolveShapeScalingPreviewDimensions({
+        group,
+        text,
+        constraintPadding,
+        startDimensions: state,
+        appliedScaleX: appliedScale.scaleX,
+        appliedScaleY: appliedScale.scaleY
+      })
+      const previewLayout = resolveShapeScalingPreviewLayout({
+        group,
+        text,
+        state,
+        appliedScaleX: appliedScale.scaleX,
+        appliedScaleY: appliedScale.scaleY,
+        minimumHeight: previewDimensions.previewHeight
+      })
+
+      applyShapeScalingPreviewLayout({
+        group,
+        shape,
+        text,
+        layout: previewLayout,
+        alignH: group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN,
+        scaleX: appliedScale.scaleX,
+        scaleY: appliedScale.scaleY,
+        minSize: MIN_SIZE,
+        scaleEpsilon: SCALE_EPSILON
+      })
+
+      group.setCoords()
+    })
+
+    selection.setCoords()
+    this.canvas.requestRenderAll()
+  }
+
+  /**
+   * Фиксирует resize дочерней shape-группы после масштабирования ActiveSelection.
+   */
+  public commitGroupScaling({
+    group,
+    scaleX,
+    scaleY,
+    transform
+  }: {
+    group: ShapeGroup
+    scaleX: number
+    scaleY: number
+    transform?: Transform | null
+  }): boolean {
+    const {
+      shape,
+      text
+    } = getShapeNodes({ group })
+
+    if (!shape || !text) {
+      this.shapeScalingState.delete(group)
+      return false
+    }
+
+    const state = this.shapeScalingState.get(group)
+    const startDimensions = state ?? resolveShapeScalingStartDimensions({
+      group,
+      transform
+    })
+    const resolvedAxes = transform
+      ? resolveShapeScaleActionAxes({
+        transform
+      })
+      : null
+    const canScaleWidth = state?.canScaleWidth
+      ?? resolvedAxes?.canScaleWidth
+      ?? (Math.abs(scaleX - 1) > SCALE_EPSILON)
+    const canScaleHeight = state?.canScaleHeight
+      ?? resolvedAxes?.canScaleHeight
+      ?? (Math.abs(scaleY - 1) > SCALE_EPSILON)
+    const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
+    const alignV = group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN
+    const constraintPadding = resolveShapeScalingConstraintPadding({ group })
+    const {
+      width,
+      height,
+      hasWidthChange,
+      hasDimensionChange
+    } = resolveShapeScalingCommitDimensions({
+      group,
+      text,
+      constraintPadding,
+      startDimensions: {
+        ...startDimensions,
+        canScaleWidth,
+        canScaleHeight
+      },
+      scaleX,
+      scaleY
+    })
+
+    if (!hasDimensionChange) {
+      this.shapeScalingState.delete(group)
+      group.shapeScalingNoopTransform = false
+      return false
+    }
+
+    commitResolvedShapeScalingLayout({
+      group,
+      shape,
+      text,
+      width,
+      height,
+      alignH,
+      alignV,
+      startManualBaseWidth: startDimensions.startManualBaseWidth,
+      startManualBaseHeight: startDimensions.startManualBaseHeight,
+      canScaleWidth,
+      canScaleHeight,
+      hasWidthChange
+    })
+
+    this.shapeScalingState.delete(group)
+    group.shapeScalingNoopTransform = false
+
+    return true
+  }
+
+  /**
+   * Возвращает scale ActiveSelection, который был реально применён в live-preview.
+   */
+  public resolveCommittedScale({
+    selection
+  }: {
+    selection: ActiveSelection
+  }): ActiveSelectionAppliedScale {
+    const appliedScale = this.scalingState.get(selection)
+
+    if (appliedScale) {
+      return {
+        scaleX: appliedScale.scaleX,
+        scaleY: appliedScale.scaleY
+      }
+    }
+
+    return {
+      scaleX: Math.abs(selection.scaleX ?? 1) || 1,
+      scaleY: Math.abs(selection.scaleY ?? 1) || 1
+    }
+  }
+
+  /**
+   * Очищает состояние масштабирования для переданного ActiveSelection.
+   */
+  public clearState({ selection }: { selection: ActiveSelection }): void {
+    this.scalingState.delete(selection)
+  }
+
+  /**
+   * Собирает shape-группы общего выделения вместе с их стартовым состоянием для текущего drag.
+   */
+  private _collectPreviewItems({
+    selection,
+    transform
+  }: {
+    selection: ActiveSelection
+    transform: Transform
+  }): ActiveSelectionShapeScalingPreviewItem[] {
+    const items: ActiveSelectionShapeScalingPreviewItem[] = []
+
+    for (const object of selection.getObjects()) {
+      if (!isShapeGroup(object)) continue
+
+      const {
+        shape,
+        text
+      } = getShapeNodes({ group: object })
+
+      if (!shape || !text) continue
+
+      const constraintPadding = resolveShapeScalingConstraintPadding({
+        group: object
+      })
+      const state = ensureShapeScalingState({
+        scalingState: this.shapeScalingState,
+        group: object,
+        text,
+        constraintPadding,
+        transform
+      })
+
+      items.push({
+        group: object,
+        shape,
+        text,
+        constraintPadding,
+        state
+      })
+    }
+
+    return items
+  }
+
+  /**
+   * Возвращает scale общего выделения, ограниченный минимальными размерами всех shape-групп.
+   */
+  private _resolveAppliedScale({
+    items,
+    transform,
+    scaleX,
+    scaleY,
+    event
+  }: {
+    items: ActiveSelectionShapeScalingPreviewItem[]
+    transform: Transform
+    scaleX: number
+    scaleY: number
+    event?: ShapeScalingPointerEvent
+  }): ActiveSelectionAppliedScale {
+    const {
+      canScaleWidth,
+      canScaleHeight,
+      isCornerScaleAction
+    } = resolveShapeScaleActionAxes({
+      transform
+    })
+    const isShiftPressed = Boolean(event && 'shiftKey' in event && event.shiftKey)
+    let appliedScaleX = scaleX
+    let appliedScaleY = scaleY
+
+    if (canScaleWidth) {
+      appliedScaleX = this._resolveMinimumScaleX({
+        items,
+        scaleX,
+        scaleY: appliedScaleY
+      })
+    }
+
+    if (canScaleHeight) {
+      appliedScaleY = this._resolveMinimumScaleY({
+        items,
+        scaleX: appliedScaleX,
+        scaleY,
+        isVerticalOnlyScale: canScaleHeight && !canScaleWidth
+      })
+    }
+
+    if (canScaleWidth && canScaleHeight) {
+      appliedScaleX = this._resolveMinimumScaleX({
+        items,
+        scaleX,
+        scaleY: appliedScaleY
+      })
+    }
+
+    const isProportionalCornerScale = isCornerScaleAction
+      && isShiftPressed
+
+    if (isProportionalCornerScale) {
+      const appliedScale = Math.max(appliedScaleX, appliedScaleY)
+
+      return {
+        scaleX: appliedScale,
+        scaleY: appliedScale
+      }
+    }
+
+    return {
+      scaleX: appliedScaleX,
+      scaleY: appliedScaleY
+    }
+  }
+
+  /**
+   * Возвращает общий scaleX, при котором каждый shape в выделении остаётся не уже своей минимальной ширины.
+   */
+  private _resolveMinimumScaleX({
+    items,
+    scaleX,
+    scaleY
+  }: {
+    items: ActiveSelectionShapeScalingPreviewItem[]
+    scaleX: number
+    scaleY: number
+  }): number {
+    let appliedScaleX = scaleX
+
+    for (const {
+      group,
+      text,
+      constraintPadding,
+      state
+    } of items) {
+      const attemptedWidth = Math.max(MIN_SIZE, state.startWidth * scaleX)
+      const isShrinkingX = scaleX < state.lastAllowedScaleX - SCALE_EPSILON
+
+      if (!isShrinkingX) continue
+
+      const attemptedHeight = Math.max(MIN_SIZE, state.startHeight * scaleY)
+      const minimumWidth = resolveMinimumShapeWidthForText({
+        text,
+        padding: constraintPadding,
+        resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
+          group,
+          width,
+          height: attemptedHeight
+        })
+      })
+
+      if (attemptedWidth >= minimumWidth + SCALE_EPSILON) continue
+
+      const minimumScaleX = Math.max(MIN_SIZE / state.startWidth, minimumWidth / state.startWidth)
+      appliedScaleX = Math.max(appliedScaleX, minimumScaleX)
+    }
+
+    return appliedScaleX
+  }
+
+  /**
+   * Возвращает общий scaleY, при котором каждый shape в выделении остаётся не ниже своей минимальной высоты.
+   */
+  private _resolveMinimumScaleY({
+    items,
+    scaleX,
+    scaleY,
+    isVerticalOnlyScale
+  }: {
+    items: ActiveSelectionShapeScalingPreviewItem[]
+    scaleX: number
+    scaleY: number
+    isVerticalOnlyScale: boolean
+  }): number {
+    let appliedScaleY = scaleY
+
+    for (const {
+      group,
+      text,
+      constraintPadding,
+      state
+    } of items) {
+      const isShrinkingY = scaleY < state.lastAllowedScaleY - SCALE_EPSILON
+
+      if (!isShrinkingY) continue
+
+      if (
+        isVerticalOnlyScale
+        && state.cannotScaleDownAtStart
+        && scaleY < state.startScaleY - SCALE_EPSILON
+      ) {
+        appliedScaleY = Math.max(appliedScaleY, state.startScaleY)
+        continue
+      }
+
+      const attemptedWidth = Math.max(MIN_SIZE, state.startWidth * scaleX)
+      const attemptedHeight = Math.max(MIN_SIZE, state.startHeight * scaleY)
+      const minimumHeight = resolveMinimumTextFitHeight({
+        group,
+        text,
+        width: attemptedWidth,
+        padding: constraintPadding
+      })
+
+      if (attemptedHeight >= minimumHeight + SCALE_EPSILON) continue
+
+      const minimumScaleY = Math.max(MIN_SIZE / state.startHeight, minimumHeight / state.startHeight)
+      appliedScaleY = Math.max(appliedScaleY, minimumScaleY)
+    }
+
+    return appliedScaleY
+  }
+
+  /**
+   * Применяет ограниченный scale к рамке ActiveSelection, сохраняя anchor текущего transform.
+   */
+  private _applySelectionScale({
+    selection,
+    transform,
+    scaleX,
+    scaleY
+  }: {
+    selection: ActiveSelection
+    transform: Transform
+    scaleX: number
+    scaleY: number
+  }): void {
+    const currentScaleX = Math.abs(selection.scaleX ?? 1) || 1
+    const currentScaleY = Math.abs(selection.scaleY ?? 1) || 1
+    const hasScaleChange = Math.abs(currentScaleX - scaleX) > SCALE_EPSILON
+      || Math.abs(currentScaleY - scaleY) > SCALE_EPSILON
+
+    if (!hasScaleChange) return
+
+    const originX = resolveShapeTransformOriginXValue({
+      value: transform.originX
+    })
+    const originY = resolveShapeTransformOriginYValue({
+      value: transform.originY
+    })
+    const anchorPoint = originX !== null && originY !== null
+      ? selection.getPositionByOrigin(originX, originY)
+      : null
+
+    selection.set({
+      flipX: false,
+      flipY: false,
+      scaleX,
+      scaleY
+    })
+
+    if (anchorPoint && originX !== null && originY !== null) {
+      selection.setPositionByOrigin(anchorPoint, originX, originY)
+    }
+
+    selection.setCoords()
+  }
+}

--- a/src/editor/shape-manager/scaling/shape-controls.ts
+++ b/src/editor/shape-manager/scaling/shape-controls.ts
@@ -1,9 +1,9 @@
 import {
   Control,
   controlsUtils,
+  type FabricObject,
   type Transform
 } from 'fabric'
-import type { ShapeGroupLike } from '../types'
 
 const SHAPE_CORNER_CONTROL_KEYS = ['tl', 'tr', 'bl', 'br'] as const
 
@@ -139,26 +139,30 @@ const createShapeCornerFreeScaleControl = ({
 }
 
 /**
- * Подменяет угловые контролы shape-группы так, чтобы diagonal drag работал как свободный resize.
+ * Подменяет угловые контролы объекта так, чтобы диагональный resize шейпа работал свободно по двум осям.
  */
 export const applyShapeCornerFreeScaleControls = ({
-  group
+  target
 }: {
-  group: ShapeGroupLike
+  target: FabricObject
 }): void => {
   const nextControls = {
-    ...group.controls
+    ...target.controls
   }
+  let hasControlChange = false
 
   SHAPE_CORNER_CONTROL_KEYS.forEach((key) => {
-    const control = group.controls[key] as ShapeCornerControl | undefined
+    const control = target.controls[key] as ShapeCornerControl | undefined
     if (!control) return
     if (control.shapeFreeScaleCornerControl) return
 
     nextControls[key] = createShapeCornerFreeScaleControl({
       control
     })
+    hasControlChange = true
   })
 
-  group.controls = nextControls
+  if (!hasControlChange) return
+
+  target.controls = nextControls
 }

--- a/src/editor/shape-manager/scaling/shape-scaling-layout.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling-layout.ts
@@ -1,0 +1,582 @@
+import type { Transform } from 'fabric'
+import {
+  applyShapeTextLayout,
+  resolveShapeTextFixedWidthLayout,
+  resolveRequiredShapeHeightForText
+} from '../layout/shape-layout'
+import type {
+  ResolvedShapeTextLayout
+} from '../layout/shape-layout'
+import {
+  normalizeShapeUserPadding,
+  resolveShapeTextContentInset
+} from '../layout/shape-padding'
+import {
+  getShapePreset,
+  resolveInternalShapeTextInset as resolvePresetInternalShapeTextInset,
+  SHAPE_DEFAULT_VERTICAL_ALIGN
+} from '../shape-presets'
+import type {
+  ShapeGroup,
+  ShapeHorizontalAlign,
+  ShapeNode,
+  ShapePadding,
+  ShapeScalingState,
+  ShapeTextNode,
+  ShapeVerticalAlign
+} from '../types'
+import {
+  resolveShapeScaleActionAxes,
+  resolveShapeScalingAnchorPoint,
+  resolveShapeTransformOriginalNumber,
+  resolveShapeTransformOriginXValue,
+  resolveShapeTransformOriginYValue
+} from './shape-scaling-transform'
+
+export const SHAPE_SCALING_MIN_SIZE = 1
+
+export const SHAPE_SCALING_SCALE_EPSILON = 0.0001
+export const SHAPE_SCALING_SIZE_EPSILON = 0.5
+
+export type ShapeScalingPointerEvent = Event | MouseEvent | PointerEvent | TouchEvent
+
+export type ShapeScalingStartDimensions = {
+  startWidth: number
+  startHeight: number
+  startManualBaseWidth: number
+  startManualBaseHeight: number
+  canScaleWidth: boolean
+  canScaleHeight: boolean
+}
+
+export type ShapeScalingCommitDimensions = {
+  width: number
+  height: number
+  hasWidthChange: boolean
+  hasDimensionChange: boolean
+}
+
+type ShapeScalingManualBaseDimensions = {
+  width: number
+  height: number
+}
+
+type ShapeScalingLayoutCommit = {
+  group: ShapeGroup
+  shape: ShapeNode
+  text: ShapeTextNode
+  width: number
+  height: number
+  alignH: ShapeHorizontalAlign
+  alignV: ShapeVerticalAlign
+  startManualBaseWidth: number
+  startManualBaseHeight: number
+  canScaleWidth: boolean
+  canScaleHeight: boolean
+  hasWidthChange: boolean
+}
+
+type ShapePreviewDimensions = {
+  previewWidth: number
+  previewHeight: number
+}
+
+type ShapePreviewLayout = ResolvedShapeTextLayout
+
+/**
+ * Возвращает пользовательский padding текста из метаданных группы.
+ */
+export function resolveShapeScalingUserPadding({ group }: { group: ShapeGroup }): ShapePadding {
+  return normalizeShapeUserPadding({
+    padding: {
+      top: group.shapePaddingTop,
+      right: group.shapePaddingRight,
+      bottom: group.shapePaddingBottom,
+      left: group.shapePaddingLeft
+    }
+  })
+}
+
+/**
+ * Возвращает полный внутренний inset текста для текущих размеров shape-группы с учетом пресета и обводки.
+ */
+export function resolveShapeScalingInternalTextInset({
+  group,
+  width,
+  height
+}: {
+  group: ShapeGroup
+  width: number
+  height: number
+}): ShapePadding {
+  const presetKey = group.shapePresetKey ?? ''
+  const preset = presetKey
+    ? getShapePreset({ presetKey })
+    : null
+  const presetInset = preset
+    ? resolvePresetInternalShapeTextInset({
+      preset,
+      width,
+      height
+    })
+    : undefined
+
+  return resolveShapeTextContentInset({
+    baseInset: presetInset,
+    stroke: group.shapeStroke,
+    strokeWidth: group.shapeStrokeWidth
+  })
+}
+
+/**
+ * Возвращает padding, который участвует в minimum-constraints во время scaling.
+ * Пользовательские отступы здесь игнорируются и при уменьшении шейпа могут быть съедены layout'ом.
+ */
+export function resolveShapeScalingConstraintPadding({
+  group,
+  width,
+  height
+}: {
+  group: ShapeGroup
+  width?: number
+  height?: number
+}): ShapePadding {
+  const resolvedWidth = Math.max(
+    SHAPE_SCALING_MIN_SIZE,
+    width ?? group.shapeBaseWidth ?? group.width ?? group.shapeManualBaseWidth ?? SHAPE_SCALING_MIN_SIZE
+  )
+  const resolvedHeight = Math.max(
+    SHAPE_SCALING_MIN_SIZE,
+    height ?? group.shapeBaseHeight ?? group.height ?? group.shapeManualBaseHeight ?? SHAPE_SCALING_MIN_SIZE
+  )
+
+  return resolveShapeScalingInternalTextInset({
+    group,
+    width: resolvedWidth,
+    height: resolvedHeight
+  })
+}
+
+/**
+ * Возвращает минимальную высоту shape, достаточную для размещения текста при переданной ширине.
+ */
+export function resolveMinimumTextFitHeight({
+  group,
+  text,
+  width,
+  padding
+}: {
+  group: ShapeGroup
+  text: ShapeTextNode
+  width: number
+  padding: ShapePadding
+}): number {
+  return resolveRequiredShapeHeightForText({
+    text,
+    width,
+    height: SHAPE_SCALING_MIN_SIZE,
+    padding,
+    resolvePaddingForSize: ({ width: nextWidth, height: nextHeight }) => {
+      return resolveShapeScalingConstraintPadding({
+        group,
+        width: nextWidth,
+        height: nextHeight
+      })
+    }
+  })
+}
+
+/**
+ * Возвращает preview-размеры shape для текущего live-scale с учетом переноса текста по строкам.
+ */
+export function resolveShapeScalingPreviewDimensions({
+  group,
+  text,
+  constraintPadding,
+  startDimensions,
+  appliedScaleX,
+  appliedScaleY,
+  minimumHeight
+}: {
+  group: ShapeGroup
+  text: ShapeTextNode
+  constraintPadding: ShapePadding
+  startDimensions: ShapeScalingStartDimensions
+  appliedScaleX: number
+  appliedScaleY: number
+  minimumHeight?: number | null
+}): ShapePreviewDimensions {
+  const previewWidth = startDimensions.canScaleWidth
+    ? Math.max(SHAPE_SCALING_MIN_SIZE, startDimensions.startWidth * appliedScaleX)
+    : startDimensions.startWidth
+  const scaledPreviewHeight = startDimensions.canScaleHeight
+    ? Math.max(SHAPE_SCALING_MIN_SIZE, startDimensions.startHeight * appliedScaleY)
+    : startDimensions.startManualBaseHeight
+  const resolvedMinimumHeight = minimumHeight ?? resolveRequiredShapeHeightForText({
+    text,
+    width: previewWidth,
+    height: scaledPreviewHeight,
+    padding: constraintPadding,
+    resolvePaddingForSize: ({ width, height }) => resolveShapeScalingConstraintPadding({
+      group,
+      width,
+      height
+    })
+  })
+  const previewHeight = Math.max(
+    scaledPreviewHeight,
+    resolvedMinimumHeight
+  )
+
+  return {
+    previewWidth,
+    previewHeight
+  }
+}
+
+/**
+ * Возвращает live-preview layout текста для уже выбранной ширины scaling.
+ * Width фиксируется текущим drag, а пользовательский padding поджимается по тому же контракту, что и final layout.
+ */
+export function resolveShapeScalingPreviewLayout({
+  group,
+  text,
+  state,
+  appliedScaleX,
+  appliedScaleY,
+  minimumHeight
+}: {
+  group: ShapeGroup
+  text: ShapeTextNode
+  state: ShapeScalingState
+  appliedScaleX: number
+  appliedScaleY: number
+  minimumHeight?: number | null
+}): ShapePreviewLayout {
+  const previewWidth = state.canScaleWidth
+    ? Math.max(SHAPE_SCALING_MIN_SIZE, state.startWidth * appliedScaleX)
+    : state.startWidth
+  const scaledPreviewHeight = state.canScaleHeight
+    ? Math.max(SHAPE_SCALING_MIN_SIZE, state.startHeight * appliedScaleY)
+    : state.startManualBaseHeight
+  const initialPreviewHeight = minimumHeight === null || minimumHeight === undefined
+    ? scaledPreviewHeight
+    : Math.max(scaledPreviewHeight, minimumHeight)
+  const expandShapeHeightToFitText = !state.canScaleHeight
+
+  return resolveShapeTextFixedWidthLayout({
+    text,
+    width: previewWidth,
+    height: initialPreviewHeight,
+    alignV: group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN,
+    padding: resolveShapeScalingUserPadding({ group }),
+    expandShapeHeightToFitText,
+    resolveInternalShapeTextInset: ({ width, height }) => resolveShapeScalingInternalTextInset({
+      group,
+      width,
+      height
+    })
+  })
+}
+
+/**
+ * Возвращает стартовые размеры drag-сессии: текущий laid-out размер shape и ручные базовые размеры.
+ */
+export function resolveShapeScalingStartDimensions({
+  group,
+  transform
+}: {
+  group: ShapeGroup
+  transform?: Transform | null
+}): ShapeScalingStartDimensions {
+  const {
+    canScaleWidth,
+    canScaleHeight
+  } = resolveShapeScaleActionAxes({
+    transform
+  })
+  const startWidth = Math.max(
+    SHAPE_SCALING_MIN_SIZE,
+    group.shapeBaseWidth ?? group.width ?? group.shapeManualBaseWidth ?? SHAPE_SCALING_MIN_SIZE
+  )
+  const startHeight = Math.max(
+    SHAPE_SCALING_MIN_SIZE,
+    group.shapeBaseHeight ?? group.height ?? group.shapeManualBaseHeight ?? SHAPE_SCALING_MIN_SIZE
+  )
+  const startManualBaseWidth = Math.max(
+    SHAPE_SCALING_MIN_SIZE,
+    group.shapeManualBaseWidth ?? startWidth
+  )
+  const startManualBaseHeight = Math.max(
+    SHAPE_SCALING_MIN_SIZE,
+    group.shapeManualBaseHeight ?? startHeight
+  )
+
+  return {
+    startWidth,
+    startHeight,
+    startManualBaseWidth,
+    startManualBaseHeight,
+    canScaleWidth,
+    canScaleHeight
+  }
+}
+
+/**
+ * Создает базовое состояние масштабирования для shape-группы.
+ */
+export function ensureShapeScalingState({
+  scalingState,
+  group,
+  text,
+  constraintPadding,
+  transform
+}: {
+  scalingState: WeakMap<ShapeGroup, ShapeScalingState>
+  group: ShapeGroup
+  text: ShapeTextNode
+  constraintPadding: ShapePadding
+  transform?: Transform | null
+}): ShapeScalingState {
+  let state = scalingState.get(group)
+
+  if (state) return state
+
+  const startDimensions = resolveShapeScalingStartDimensions({
+    group,
+    transform
+  })
+  const originalScaleX = resolveShapeTransformOriginalNumber({
+    transform,
+    key: 'scaleX'
+  })
+  const originalScaleY = resolveShapeTransformOriginalNumber({
+    transform,
+    key: 'scaleY'
+  })
+  const originalLeft = resolveShapeTransformOriginalNumber({
+    transform,
+    key: 'left'
+  })
+  const originalTop = resolveShapeTransformOriginalNumber({
+    transform,
+    key: 'top'
+  })
+  const startScaleX = Math.abs(originalScaleX ?? group.scaleX ?? 1) || 1
+  const startScaleY = Math.abs(originalScaleY ?? group.scaleY ?? 1) || 1
+  const startLeft = originalLeft ?? group.left ?? 0
+  const startTop = originalTop ?? group.top ?? 0
+  const startTransformOriginX = resolveShapeTransformOriginXValue({
+    value: transform?.original?.originX ?? transform?.originX
+  })
+  const startTransformOriginY = resolveShapeTransformOriginYValue({
+    value: transform?.original?.originY ?? transform?.originY
+  })
+  const startTransformCorner = typeof transform?.corner === 'string'
+    ? transform.corner
+    : null
+  const scalingAnchorPoint = resolveShapeScalingAnchorPoint({
+    group,
+    originX: startTransformOriginX,
+    originY: startTransformOriginY
+  })
+  const minimumHeightAtStart = resolveMinimumTextFitHeight({
+    group,
+    text,
+    width: startDimensions.startWidth,
+    padding: constraintPadding
+  })
+
+  state = {
+    startWidth: startDimensions.startWidth,
+    startHeight: startDimensions.startHeight,
+    startManualBaseWidth: startDimensions.startManualBaseWidth,
+    startManualBaseHeight: startDimensions.startManualBaseHeight,
+    canScaleWidth: startDimensions.canScaleWidth,
+    canScaleHeight: startDimensions.canScaleHeight,
+    cannotScaleDownAtStart: minimumHeightAtStart >= startDimensions.startHeight - SHAPE_SCALING_SCALE_EPSILON,
+    isProportionalScaling: false,
+    blockedScaleAttempt: false,
+    startLeft,
+    startTop,
+    startScaleX,
+    startScaleY,
+    startTransformOriginX,
+    startTransformOriginY,
+    startTransformCorner,
+    scalingAnchorX: scalingAnchorPoint?.x ?? null,
+    scalingAnchorY: scalingAnchorPoint?.y ?? null,
+    scalingAnchorOriginX: startTransformOriginX,
+    scalingAnchorOriginY: startTransformOriginY,
+    crossedOppositeCorner: false,
+    lastAllowedFlipX: Boolean(group.flipX),
+    lastAllowedFlipY: Boolean(group.flipY),
+    lastAllowedScaleX: startScaleX,
+    lastAllowedScaleY: startScaleY,
+    lastAllowedLeft: startLeft,
+    lastAllowedTop: startTop
+  }
+
+  scalingState.set(group, state)
+
+  return state
+}
+
+/**
+ * Возвращает итоговые размеры шага фиксации с учетом осей, которые реально скейлились.
+ */
+export function resolveShapeScalingCommitDimensions({
+  group,
+  text,
+  constraintPadding,
+  startDimensions,
+  scaleX,
+  scaleY
+}: {
+  group: ShapeGroup
+  text: ShapeTextNode
+  constraintPadding: ShapePadding
+  startDimensions: ShapeScalingStartDimensions
+  scaleX: number
+  scaleY: number
+}): ShapeScalingCommitDimensions {
+  const {
+    previewWidth,
+    previewHeight
+  } = resolveShapeScalingPreviewDimensions({
+    group,
+    text,
+    constraintPadding,
+    startDimensions,
+    appliedScaleX: scaleX,
+    appliedScaleY: scaleY
+  })
+  const {
+    startWidth,
+    startHeight
+  } = startDimensions
+  const hasWidthChange = Math.abs(previewWidth - startWidth) > SHAPE_SCALING_SIZE_EPSILON
+  const hasHeightChange = Math.abs(previewHeight - startHeight) > SHAPE_SCALING_SIZE_EPSILON
+
+  return {
+    width: previewWidth,
+    height: previewHeight,
+    hasWidthChange,
+    hasDimensionChange: hasWidthChange || hasHeightChange
+  }
+}
+
+/**
+ * Возвращает, какие ручные базовые размеры нужно сохранить после завершения скейлинга.
+ */
+function resolveNextManualBaseDimensionsAfterScaling({
+  startManualBaseWidth,
+  startManualBaseHeight,
+  canScaleWidth,
+  canScaleHeight,
+  finalWidth,
+  finalHeight
+}: {
+  startManualBaseWidth: number
+  startManualBaseHeight: number
+  canScaleWidth: boolean
+  canScaleHeight: boolean
+  finalWidth: number
+  finalHeight: number
+}): ShapeScalingManualBaseDimensions {
+  let nextManualBaseWidth = startManualBaseWidth
+  if (canScaleWidth) {
+    nextManualBaseWidth = finalWidth
+  }
+
+  let nextManualBaseHeight = startManualBaseHeight
+  if (canScaleHeight) {
+    nextManualBaseHeight = finalHeight
+  }
+
+  return {
+    width: nextManualBaseWidth,
+    height: nextManualBaseHeight
+  }
+}
+
+/**
+ * Применяет уже выбранные resize-размеры к layout шейпа и сбрасывает временный scale.
+ */
+export function commitResolvedShapeScalingLayout({
+  group,
+  shape,
+  text,
+  width,
+  height,
+  alignH,
+  alignV,
+  startManualBaseWidth,
+  startManualBaseHeight,
+  canScaleWidth,
+  canScaleHeight,
+  hasWidthChange
+}: ShapeScalingLayoutCommit): void {
+  const nextManualBaseDimensions = resolveNextManualBaseDimensionsAfterScaling({
+    startManualBaseWidth,
+    startManualBaseHeight,
+    canScaleWidth,
+    canScaleHeight,
+    finalWidth: width,
+    finalHeight: height
+  })
+
+  group.shapeManualBaseWidth = nextManualBaseDimensions.width
+  group.shapeManualBaseHeight = nextManualBaseDimensions.height
+
+  if (canScaleWidth && hasWidthChange) {
+    // Ручной resize по ширине фиксирует новую ширину как пользовательский контракт.
+    group.shapeTextAutoExpand = false
+  }
+
+  const userPadding = resolveShapeScalingUserPadding({ group })
+  const internalShapeTextInset = resolveShapeScalingInternalTextInset({
+    group,
+    width,
+    height
+  })
+  const expandShapeHeightToFitText = !canScaleHeight
+
+  applyShapeTextLayout({
+    group,
+    shape,
+    text,
+    width,
+    height,
+    alignH,
+    alignV,
+    padding: userPadding,
+    shapeTextAutoExpandEnabled: group.shapeTextAutoExpand !== false,
+    internalShapeTextInset,
+    expandShapeHeightToFitText,
+    resolveInternalShapeTextInset: ({ width: nextWidth, height: nextHeight }) => {
+      return resolveShapeScalingInternalTextInset({
+        group,
+        width: nextWidth,
+        height: nextHeight
+      })
+    }
+  })
+
+  group.shapeReplaceBoxWidth = Math.max(1, group.shapeBaseWidth ?? width)
+  group.shapeReplaceBoxHeight = Math.max(1, group.shapeBaseHeight ?? height)
+
+  text.set({
+    scaleX: 1,
+    scaleY: 1
+  })
+
+  group.set({
+    scaleX: 1,
+    scaleY: 1
+  })
+
+  group.setCoords()
+  text.setCoords()
+  shape.setCoords()
+}

--- a/src/editor/shape-manager/scaling/shape-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling.ts
@@ -7,55 +7,51 @@ import {
 } from 'fabric'
 import {
   applyShapeTextLayout,
-  resolveShapeTextFixedWidthLayout,
-  resolveMinimumShapeWidthForText,
-  resolveRequiredShapeHeightForText
+  resolveMinimumShapeWidthForText
 } from '../layout/shape-layout'
-import type {
-  ResolvedShapeTextLayout
-} from '../layout/shape-layout'
-import {
-  normalizeShapeUserPadding,
-  resolveShapeTextContentInset
-} from '../layout/shape-padding'
 import { resizeShapeNode } from '../shape-factory'
 import {
   ShapeGroup,
-  ShapeHorizontalAlign,
   ShapePadding,
   ShapeScalingState,
   ShapeNode,
-  ShapeTextNode,
-  ShapeVerticalAlign
+  ShapeTextNode
 } from '../types'
 import {
   getShapeNodes,
   isShapeGroup
 } from '../shape-utils'
 import {
-  getShapePreset,
   SHAPE_DEFAULT_HORIZONTAL_ALIGN,
-  SHAPE_DEFAULT_VERTICAL_ALIGN,
-  resolveInternalShapeTextInset as resolvePresetInternalShapeTextInset
+  SHAPE_DEFAULT_VERTICAL_ALIGN
 } from '../shape-presets'
 import {
   isShapeTransformCornerChanged,
   isShapeTransformOriginChanged,
   resolveShapeLocalPointerForTransform,
-  resolveShapeScaleActionAxes,
-  resolveShapeScalingAnchorPoint,
-  resolveShapeTransformOriginalNumber,
-  resolveShapeTransformOriginXValue,
-  resolveShapeTransformOriginYValue
+  resolveShapeScaleActionAxes
 } from './shape-scaling-transform'
 import { applyShapeScalingPreviewLayout } from './shape-scaling-preview'
-
-const MIN_SIZE = 1
-
-const SCALE_EPSILON = 0.0001
-const SIZE_EPSILON = 0.5
-
-type ShapeScalingPointerEvent = Event | MouseEvent | PointerEvent | TouchEvent
+import ShapeActiveSelectionScalingController from './shape-active-selection-scaling'
+import type {
+  ActiveSelectionAppliedScale
+} from './shape-active-selection-scaling'
+import {
+  commitResolvedShapeScalingLayout,
+  ensureShapeScalingState,
+  resolveMinimumTextFitHeight,
+  resolveShapeScalingCommitDimensions,
+  resolveShapeScalingConstraintPadding,
+  resolveShapeScalingInternalTextInset,
+  resolveShapeScalingPreviewDimensions,
+  resolveShapeScalingPreviewLayout,
+  resolveShapeScalingUserPadding,
+  SHAPE_SCALING_MIN_SIZE as MIN_SIZE,
+  SHAPE_SCALING_SCALE_EPSILON as SCALE_EPSILON
+} from './shape-scaling-layout'
+import type {
+  ShapeScalingPointerEvent
+} from './shape-scaling-layout'
 
 type ShapeScalingEvent = {
   target?: FabricObject | null
@@ -86,49 +82,6 @@ type ShapeScalingConstraintState = {
   resolvedMinimumHeight: number | null
 }
 
-type ShapePreviewDimensions = {
-  previewWidth: number
-  previewHeight: number
-}
-
-type ShapePreviewLayout = ResolvedShapeTextLayout
-
-type ShapeScalingStartDimensions = {
-  startWidth: number
-  startHeight: number
-  startManualBaseWidth: number
-  startManualBaseHeight: number
-  canScaleWidth: boolean
-  canScaleHeight: boolean
-}
-
-type ShapeScalingManualBaseDimensions = {
-  width: number
-  height: number
-}
-
-type ShapeScalingCommitDimensions = {
-  width: number
-  height: number
-  hasWidthChange: boolean
-  hasDimensionChange: boolean
-}
-
-type ShapeScalingLayoutCommit = {
-  group: ShapeGroup
-  shape: ShapeNode
-  text: ShapeTextNode
-  width: number
-  height: number
-  alignH: ShapeHorizontalAlign
-  alignV: ShapeVerticalAlign
-  startManualBaseWidth: number
-  startManualBaseHeight: number
-  canScaleWidth: boolean
-  canScaleHeight: boolean
-  hasWidthChange: boolean
-}
-
 type CanvasWithCurrentTransform = Canvas & {
   _currentTransform?: Transform | null
 }
@@ -147,9 +100,18 @@ export default class ShapeScalingController {
    */
   private scalingState: WeakMap<ShapeGroup, ShapeScalingState>
 
+  /**
+   * Контроллер масштабирования shape-групп внутри ActiveSelection.
+   */
+  private activeSelectionScalingController: ShapeActiveSelectionScalingController
+
   constructor({ canvas }: { canvas: Canvas }) {
     this.canvas = canvas
     this.scalingState = new WeakMap()
+    this.activeSelectionScalingController = new ShapeActiveSelectionScalingController({
+      canvas,
+      shapeScalingState: this.scalingState
+    })
   }
 
   /**
@@ -163,9 +125,10 @@ export default class ShapeScalingController {
       transform
     } = event
     if (target instanceof ActiveSelection) {
-      this._applyActiveSelectionScalingPreview({
+      this.activeSelectionScalingController.handleScalingPreview({
         selection: target,
-        transform
+        transform,
+        event: event.e
       })
       return
     }
@@ -185,8 +148,9 @@ export default class ShapeScalingController {
       centeredScaling: false
     })
 
-    const constraintPadding = ShapeScalingController._resolveScalingConstraintPadding({ group })
-    const state = this._ensureScalingState({
+    const constraintPadding = resolveShapeScalingConstraintPadding({ group })
+    const state = ensureShapeScalingState({
+      scalingState: this.scalingState,
       group,
       text,
       constraintPadding,
@@ -209,7 +173,7 @@ export default class ShapeScalingController {
       state,
       transform
     })
-    const previewLayout = this._resolvePreviewLayout({
+    const previewLayout = resolveShapeScalingPreviewLayout({
       group,
       text,
       state,
@@ -333,7 +297,7 @@ export default class ShapeScalingController {
       && !constraintState.shouldRestoreLastAllowedTransform
       && constraintState.clampedScaleX === null
 
-    const previewDimensions = this._resolvePreviewDimensions({
+    const previewDimensions = resolveShapeScalingPreviewDimensions({
       group,
       text,
       constraintPadding,
@@ -402,7 +366,7 @@ export default class ShapeScalingController {
       ? resolveMinimumShapeWidthForText({
         text,
         padding: constraintPadding,
-        resolvePaddingForWidth: ({ width }) => ShapeScalingController._resolveScalingConstraintPadding({
+        resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
           group,
           width,
           height: attemptedHeight
@@ -410,7 +374,7 @@ export default class ShapeScalingController {
       })
       : null
     const minimumHeight = canScaleHeight && isShrinkingY
-      ? this._resolveMinimumTextFitHeight({
+      ? resolveMinimumTextFitHeight({
         group,
         text,
         width: attemptedWidth,
@@ -447,99 +411,6 @@ export default class ShapeScalingController {
       clampedScaleY,
       resolvedMinimumHeight: minimumHeight
     }
-  }
-
-  /**
-   * Возвращает preview-размеры shape для текущего live-scale с учетом переноса текста по строкам.
-   */
-  private _resolvePreviewDimensions({
-    group,
-    text,
-    constraintPadding,
-    startDimensions,
-    appliedScaleX,
-    appliedScaleY,
-    minimumHeight
-  }: {
-    group: ShapeGroup
-    text: ShapeTextNode
-    constraintPadding: ShapePadding
-    startDimensions: ShapeScalingStartDimensions
-    appliedScaleX: number
-    appliedScaleY: number
-    minimumHeight?: number | null
-  }): ShapePreviewDimensions {
-    const previewWidth = startDimensions.canScaleWidth
-      ? Math.max(MIN_SIZE, startDimensions.startWidth * appliedScaleX)
-      : startDimensions.startWidth
-    const scaledPreviewHeight = startDimensions.canScaleHeight
-      ? Math.max(MIN_SIZE, startDimensions.startHeight * appliedScaleY)
-      : startDimensions.startManualBaseHeight
-    const resolvedMinimumHeight = minimumHeight ?? resolveRequiredShapeHeightForText({
-      text,
-      width: previewWidth,
-      height: scaledPreviewHeight,
-      padding: constraintPadding,
-      resolvePaddingForSize: ({ width, height }) => ShapeScalingController._resolveScalingConstraintPadding({
-        group,
-        width,
-        height
-      })
-    })
-    const previewHeight = Math.max(
-      scaledPreviewHeight,
-      resolvedMinimumHeight
-    )
-
-    return {
-      previewWidth,
-      previewHeight
-    }
-  }
-
-  /**
-   * Возвращает live-preview layout текста для уже выбранной ширины scaling.
-   * Width фиксируется текущим drag, а пользовательский padding поджимается по тому же контракту, что и final layout.
-   */
-  private _resolvePreviewLayout({
-    group,
-    text,
-    state,
-    appliedScaleX,
-    appliedScaleY,
-    minimumHeight
-  }: {
-    group: ShapeGroup
-    text: ShapeTextNode
-    state: ShapeScalingState
-    appliedScaleX: number
-    appliedScaleY: number
-    minimumHeight?: number | null
-  }): ShapePreviewLayout {
-    const previewWidth = state.canScaleWidth
-      ? Math.max(MIN_SIZE, state.startWidth * appliedScaleX)
-      : state.startWidth
-    const scaledPreviewHeight = state.canScaleHeight
-      ? Math.max(MIN_SIZE, state.startHeight * appliedScaleY)
-      : state.startManualBaseHeight
-    const initialPreviewHeight = minimumHeight === null || minimumHeight === undefined
-      ? scaledPreviewHeight
-      : Math.max(scaledPreviewHeight, minimumHeight)
-    const expandShapeHeightToFitText = !state.canScaleHeight
-
-    return resolveShapeTextFixedWidthLayout({
-      text,
-      width: previewWidth,
-      height: initialPreviewHeight,
-      alignV: group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN,
-      padding: ShapeScalingController._resolveUserPadding({ group }),
-      expandShapeHeightToFitText,
-      resolveInternalShapeTextInset: ({ width, height }) => ShapeScalingController._resolveInternalShapeTextInset({
-        group,
-        width,
-        height
-      })
-    })
   }
 
   /**
@@ -598,9 +469,10 @@ export default class ShapeScalingController {
 
     const { target } = transform
     if (target instanceof ActiveSelection) {
-      this._applyActiveSelectionScalingPreview({
+      this.activeSelectionScalingController.handleScalingPreview({
         selection: target,
-        transform
+        transform,
+        event: event.e
       })
       return
     }
@@ -627,7 +499,7 @@ export default class ShapeScalingController {
 
     if (!shape || !text) return
 
-    const constraintPadding = ShapeScalingController._resolveScalingConstraintPadding({ group })
+    const constraintPadding = resolveShapeScalingConstraintPadding({ group })
     const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
     const currentScaleX = Math.abs(group.scaleX ?? state.lastAllowedScaleX ?? 1) || 1
     const currentScaleY = Math.abs(group.scaleY ?? state.lastAllowedScaleY ?? 1) || 1
@@ -650,7 +522,7 @@ export default class ShapeScalingController {
       const minimumWidth = resolveMinimumShapeWidthForText({
         text,
         padding: constraintPadding,
-        resolvePaddingForWidth: ({ width }) => ShapeScalingController._resolveScalingConstraintPadding({
+        resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
           group,
           width,
           height: Math.max(MIN_SIZE, state.startHeight * nextScaleY)
@@ -670,7 +542,7 @@ export default class ShapeScalingController {
       axis: 'y'
     })
     if (pointerReachedOrPassedOriginY) {
-      resolvedMinimumHeight = this._resolveMinimumTextFitHeight({
+      resolvedMinimumHeight = resolveMinimumTextFitHeight({
         group,
         text,
         width: Math.max(MIN_SIZE, state.startWidth * nextScaleX),
@@ -685,7 +557,7 @@ export default class ShapeScalingController {
 
     if (!shouldApplyClamp) return
 
-    const previewDimensions = this._resolvePreviewDimensions({
+    const previewDimensions = resolveShapeScalingPreviewDimensions({
       group,
       text,
       constraintPadding,
@@ -694,7 +566,7 @@ export default class ShapeScalingController {
       appliedScaleY: nextScaleY,
       minimumHeight: didClampWidth ? null : resolvedMinimumHeight
     })
-    const previewLayout = this._resolvePreviewLayout({
+    const previewLayout = resolveShapeScalingPreviewLayout({
       group,
       text,
       state,
@@ -737,85 +609,6 @@ export default class ShapeScalingController {
       currentTop: state.lastAllowedTop,
       currentFlipX: state.lastAllowedFlipX,
       currentFlipY: state.lastAllowedFlipY
-    })
-
-    this.canvas.requestRenderAll()
-  }
-
-  /**
-   * Применяет shape-specific live preview для shape-групп внутри ActiveSelection,
-   * чтобы текст перераскладывался по shape-layout контракту, а не скейлился пропорционально с selection.
-   */
-  private _applyActiveSelectionScalingPreview({
-    selection,
-    transform
-  }: {
-    selection: ActiveSelection
-    transform?: Transform | null
-  }): void {
-    if (!transform) return
-
-    const {
-      canScaleWidth,
-      canScaleHeight
-    } = resolveShapeScaleActionAxes({
-      transform
-    })
-    if (!canScaleWidth && !canScaleHeight) return
-
-    const scaleX = Math.abs(selection.scaleX ?? 1) || 1
-    const scaleY = Math.abs(selection.scaleY ?? 1) || 1
-    const shapeGroups = selection.getObjects().filter((object): object is ShapeGroup => {
-      return isShapeGroup(object)
-    })
-
-    if (!shapeGroups.length) return
-
-    shapeGroups.forEach((group) => {
-      const {
-        shape,
-        text
-      } = getShapeNodes({ group })
-
-      if (!shape || !text) return
-
-      const constraintPadding = ShapeScalingController._resolveScalingConstraintPadding({ group })
-      const state = this._ensureScalingState({
-        group,
-        text,
-        constraintPadding,
-        transform
-      })
-      const previewDimensions = this._resolvePreviewDimensions({
-        group,
-        text,
-        constraintPadding,
-        startDimensions: state,
-        appliedScaleX: scaleX,
-        appliedScaleY: scaleY
-      })
-      const previewLayout = this._resolvePreviewLayout({
-        group,
-        text,
-        state,
-        appliedScaleX: scaleX,
-        appliedScaleY: scaleY,
-        minimumHeight: previewDimensions.previewHeight
-      })
-
-      applyShapeScalingPreviewLayout({
-        group,
-        shape,
-        text,
-        layout: previewLayout,
-        alignH: group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN,
-        scaleX,
-        scaleY,
-        minSize: MIN_SIZE,
-        scaleEpsilon: SCALE_EPSILON
-      })
-
-      group.setCoords()
     })
 
     this.canvas.requestRenderAll()
@@ -920,7 +713,7 @@ export default class ShapeScalingController {
     const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
     const alignV = group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN
 
-    const constraintPadding = ShapeScalingController._resolveScalingConstraintPadding({ group })
+    const constraintPadding = resolveShapeScalingConstraintPadding({ group })
     const resolvedAxes = event.transform
       ? resolveShapeScaleActionAxes({
         transform: event.transform
@@ -937,7 +730,7 @@ export default class ShapeScalingController {
     const minimumWidth = resolveMinimumShapeWidthForText({
       text,
       padding: constraintPadding,
-      resolvePaddingForWidth: ({ width }) => ShapeScalingController._resolveScalingConstraintPadding({
+      resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
         group,
         width,
         height: Math.max(MIN_SIZE, startHeight * allowedScaleY)
@@ -955,7 +748,7 @@ export default class ShapeScalingController {
         allowedScaleX = Math.max(MIN_SIZE / startWidth, minimumWidth / startWidth)
       }
 
-      const minimumHeight = this._resolveMinimumTextFitHeight({
+      const minimumHeight = resolveMinimumTextFitHeight({
         group,
         text,
         width: Math.max(MIN_SIZE, startWidth * allowedScaleX),
@@ -978,7 +771,7 @@ export default class ShapeScalingController {
       height,
       hasWidthChange,
       hasDimensionChange
-    } = this._resolveScalingCommitDimensions({
+    } = resolveShapeScalingCommitDimensions({
       group,
       text,
       constraintPadding,
@@ -1004,7 +797,7 @@ export default class ShapeScalingController {
         startHeight,
         alignH,
         alignV,
-        userPadding: ShapeScalingController._resolveUserPadding({ group })
+        userPadding: resolveShapeScalingUserPadding({ group })
       })
 
       this.scalingState.delete(group)
@@ -1019,7 +812,7 @@ export default class ShapeScalingController {
       })
     }
 
-    this._commitResolvedShapeScalingLayout({
+    commitResolvedShapeScalingLayout({
       group,
       shape,
       text,
@@ -1065,78 +858,12 @@ export default class ShapeScalingController {
     scaleY: number
     transform?: Transform | null
   }): boolean {
-    const {
-      shape,
-      text
-    } = getShapeNodes({ group })
-
-    if (!shape || !text) {
-      this.scalingState.delete(group)
-      return false
-    }
-
-    const state = this.scalingState.get(group)
-    const startDimensions = state ?? this._resolveScalingStartDimensions({
+    return this.activeSelectionScalingController.commitGroupScaling({
       group,
+      scaleX,
+      scaleY,
       transform
     })
-    const resolvedAxes = transform
-      ? resolveShapeScaleActionAxes({
-        transform
-      })
-      : null
-    const canScaleWidth = state?.canScaleWidth
-      ?? resolvedAxes?.canScaleWidth
-      ?? (Math.abs(scaleX - 1) > SCALE_EPSILON)
-    const canScaleHeight = state?.canScaleHeight
-      ?? resolvedAxes?.canScaleHeight
-      ?? (Math.abs(scaleY - 1) > SCALE_EPSILON)
-    const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
-    const alignV = group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN
-    const constraintPadding = ShapeScalingController._resolveScalingConstraintPadding({ group })
-    const {
-      width,
-      height,
-      hasWidthChange,
-      hasDimensionChange
-    } = this._resolveScalingCommitDimensions({
-      group,
-      text,
-      constraintPadding,
-      startDimensions: {
-        ...startDimensions,
-        canScaleWidth,
-        canScaleHeight
-      },
-      scaleX,
-      scaleY
-    })
-
-    if (!hasDimensionChange) {
-      this.scalingState.delete(group)
-      group.shapeScalingNoopTransform = false
-      return false
-    }
-
-    this._commitResolvedShapeScalingLayout({
-      group,
-      shape,
-      text,
-      width,
-      height,
-      alignH,
-      alignV,
-      startManualBaseWidth: startDimensions.startManualBaseWidth,
-      startManualBaseHeight: startDimensions.startManualBaseHeight,
-      canScaleWidth,
-      canScaleHeight,
-      hasWidthChange
-    })
-
-    this.scalingState.delete(group)
-    group.shapeScalingNoopTransform = false
-
-    return true
   }
 
   /**
@@ -1260,203 +987,24 @@ export default class ShapeScalingController {
   }
 
   /**
-   * Создает базовое состояние масштабирования для shape-группы.
+   * Возвращает scale ActiveSelection, который был реально применён в live-preview.
    */
-  private _ensureScalingState({
-    group,
-    text,
-    constraintPadding,
-    transform
+  public resolveActiveSelectionCommittedScale({
+    selection
   }: {
-    group: ShapeGroup
-    text: ShapeTextNode
-    constraintPadding: ShapePadding
-    transform?: Transform | null
-  }): ShapeScalingState {
-    let state = this.scalingState.get(group)
-
-    if (!state) {
-      const startDimensions = this._resolveScalingStartDimensions({
-        group,
-        transform
-      })
-      const originalScaleX = resolveShapeTransformOriginalNumber({
-        transform,
-        key: 'scaleX'
-      })
-      const originalScaleY = resolveShapeTransformOriginalNumber({
-        transform,
-        key: 'scaleY'
-      })
-      const originalLeft = resolveShapeTransformOriginalNumber({
-        transform,
-        key: 'left'
-      })
-      const originalTop = resolveShapeTransformOriginalNumber({
-        transform,
-        key: 'top'
-      })
-      const startScaleX = Math.abs(originalScaleX ?? group.scaleX ?? 1) || 1
-      const startScaleY = Math.abs(originalScaleY ?? group.scaleY ?? 1) || 1
-      const startLeft = originalLeft ?? group.left ?? 0
-      const startTop = originalTop ?? group.top ?? 0
-      const startTransformOriginX = resolveShapeTransformOriginXValue({
-        value: transform?.original?.originX ?? transform?.originX
-      })
-      const startTransformOriginY = resolveShapeTransformOriginYValue({
-        value: transform?.original?.originY ?? transform?.originY
-      })
-      const startTransformCorner = typeof transform?.corner === 'string'
-        ? transform.corner
-        : null
-      const scalingAnchorPoint = resolveShapeScalingAnchorPoint({
-        group,
-        originX: startTransformOriginX,
-        originY: startTransformOriginY
-      })
-      const minimumHeightAtStart = this._resolveMinimumTextFitHeight({
-        group,
-        text,
-        width: startDimensions.startWidth,
-        padding: constraintPadding
-      })
-
-      state = {
-        startWidth: startDimensions.startWidth,
-        startHeight: startDimensions.startHeight,
-        startManualBaseWidth: startDimensions.startManualBaseWidth,
-        startManualBaseHeight: startDimensions.startManualBaseHeight,
-        canScaleWidth: startDimensions.canScaleWidth,
-        canScaleHeight: startDimensions.canScaleHeight,
-        cannotScaleDownAtStart: minimumHeightAtStart >= startDimensions.startHeight - SCALE_EPSILON,
-        isProportionalScaling: false,
-        blockedScaleAttempt: false,
-        startLeft,
-        startTop,
-        startScaleX,
-        startScaleY,
-        startTransformOriginX,
-        startTransformOriginY,
-        startTransformCorner,
-        scalingAnchorX: scalingAnchorPoint?.x ?? null,
-        scalingAnchorY: scalingAnchorPoint?.y ?? null,
-        scalingAnchorOriginX: startTransformOriginX,
-        scalingAnchorOriginY: startTransformOriginY,
-        crossedOppositeCorner: false,
-        lastAllowedFlipX: Boolean(group.flipX),
-        lastAllowedFlipY: Boolean(group.flipY),
-        lastAllowedScaleX: startScaleX,
-        lastAllowedScaleY: startScaleY,
-        lastAllowedLeft: startLeft,
-        lastAllowedTop: startTop
-      }
-
-      this.scalingState.set(group, state)
-    }
-
-    return state
-  }
-
-  /**
-   * Возвращает минимальную высоту shape, достаточную для размещения текста при переданной ширине.
-   */
-  private _resolveMinimumTextFitHeight({
-    group,
-    text,
-    width,
-    padding
-  }: {
-    group: ShapeGroup
-    text: ShapeTextNode
-    width: number
-    padding: ShapePadding
-  }): number {
-    return resolveRequiredShapeHeightForText({
-      text,
-      width,
-      height: MIN_SIZE,
-      padding,
-      resolvePaddingForSize: ({ width: nextWidth, height: nextHeight }) => {
-        return ShapeScalingController._resolveScalingConstraintPadding({
-          group,
-          width: nextWidth,
-          height: nextHeight
-        })
-      }
+    selection: ActiveSelection
+  }): ActiveSelectionAppliedScale {
+    return this.activeSelectionScalingController.resolveCommittedScale({
+      selection
     })
   }
 
   /**
-   * Возвращает пользовательский padding текста из метаданных группы.
+   * Очищает состояние масштабирования для переданного ActiveSelection.
    */
-  private static _resolveUserPadding({ group }: { group: ShapeGroup }): ShapePadding {
-    return normalizeShapeUserPadding({
-      padding: {
-        top: group.shapePaddingTop,
-        right: group.shapePaddingRight,
-        bottom: group.shapePaddingBottom,
-        left: group.shapePaddingLeft
-      }
-    })
-  }
-
-  /**
-   * Возвращает полный внутренний inset текста для текущих размеров shape-группы с учетом пресета и обводки.
-   */
-  private static _resolveInternalShapeTextInset({
-    group,
-    width,
-    height
-  }: {
-    group: ShapeGroup
-    width: number
-    height: number
-  }): ShapePadding {
-    const presetKey = group.shapePresetKey ?? ''
-    const preset = presetKey
-      ? getShapePreset({ presetKey })
-      : null
-    const presetInset = preset
-      ? resolvePresetInternalShapeTextInset({
-        preset,
-        width,
-        height
-      })
-      : undefined
-
-    return resolveShapeTextContentInset({
-      baseInset: presetInset,
-      stroke: group.shapeStroke,
-      strokeWidth: group.shapeStrokeWidth
-    })
-  }
-
-  /**
-   * Возвращает padding, который участвует в minimum-constraints во время scaling.
-   * Пользовательские отступы здесь игнорируются и при уменьшении шейпа могут быть съедены layout'ом.
-   */
-  private static _resolveScalingConstraintPadding({
-    group,
-    width,
-    height
-  }: {
-    group: ShapeGroup
-    width?: number
-    height?: number
-  }): ShapePadding {
-    const resolvedWidth = Math.max(
-      MIN_SIZE,
-      width ?? group.shapeBaseWidth ?? group.width ?? group.shapeManualBaseWidth ?? MIN_SIZE
-    )
-    const resolvedHeight = Math.max(
-      MIN_SIZE,
-      height ?? group.shapeBaseHeight ?? group.height ?? group.shapeManualBaseHeight ?? MIN_SIZE
-    )
-
-    return ShapeScalingController._resolveInternalShapeTextInset({
-      group,
-      width: resolvedWidth,
-      height: resolvedHeight
+  public clearActiveSelectionState({ selection }: { selection: ActiveSelection }): void {
+    this.activeSelectionScalingController.clearState({
+      selection
     })
   }
 
@@ -1528,7 +1076,7 @@ export default class ShapeScalingController {
       MIN_SIZE,
       group.shapeBaseHeight ?? group.height ?? startHeight
     )
-    const internalShapeTextInset = ShapeScalingController._resolveInternalShapeTextInset({
+    const internalShapeTextInset = resolveShapeScalingInternalTextInset({
       group,
       width: layoutWidth,
       height: layoutHeight
@@ -1546,7 +1094,7 @@ export default class ShapeScalingController {
       alignV: verticalAlign,
       padding: userPadding,
       internalShapeTextInset,
-      resolveInternalShapeTextInset: ({ width, height }) => ShapeScalingController._resolveInternalShapeTextInset({
+      resolveInternalShapeTextInset: ({ width, height }) => resolveShapeScalingInternalTextInset({
         group,
         width,
         height
@@ -1629,207 +1177,5 @@ export default class ShapeScalingController {
       group,
       state
     })
-  }
-
-  /**
-   * Возвращает стартовые размеры drag-сессии: текущий laid-out размер shape и ручные базовые размеры.
-   */
-  private _resolveScalingStartDimensions({
-    group,
-    transform
-  }: {
-    group: ShapeGroup
-    transform?: Transform | null
-  }): ShapeScalingStartDimensions {
-    const {
-      canScaleWidth,
-      canScaleHeight
-    } = resolveShapeScaleActionAxes({
-      transform
-    })
-    const startWidth = Math.max(
-      MIN_SIZE,
-      group.shapeBaseWidth ?? group.width ?? group.shapeManualBaseWidth ?? MIN_SIZE
-    )
-    const startHeight = Math.max(
-      MIN_SIZE,
-      group.shapeBaseHeight ?? group.height ?? group.shapeManualBaseHeight ?? MIN_SIZE
-    )
-    const startManualBaseWidth = Math.max(
-      MIN_SIZE,
-      group.shapeManualBaseWidth ?? startWidth
-    )
-    const startManualBaseHeight = Math.max(
-      MIN_SIZE,
-      group.shapeManualBaseHeight ?? startHeight
-    )
-
-    return {
-      startWidth,
-      startHeight,
-      startManualBaseWidth,
-      startManualBaseHeight,
-      canScaleWidth,
-      canScaleHeight
-    }
-  }
-
-  /**
-   * Возвращает, какие ручные базовые размеры нужно сохранить после завершения скейлинга.
-   */
-  private _resolveNextManualBaseDimensionsAfterScaling({
-    startManualBaseWidth,
-    startManualBaseHeight,
-    canScaleWidth,
-    canScaleHeight,
-    finalWidth,
-    finalHeight
-  }: {
-    startManualBaseWidth: number
-    startManualBaseHeight: number
-    canScaleWidth: boolean
-    canScaleHeight: boolean
-    finalWidth: number
-    finalHeight: number
-  }): ShapeScalingManualBaseDimensions {
-    let nextManualBaseWidth = startManualBaseWidth
-    if (canScaleWidth) {
-      nextManualBaseWidth = finalWidth
-    }
-
-    let nextManualBaseHeight = startManualBaseHeight
-    if (canScaleHeight) {
-      nextManualBaseHeight = finalHeight
-    }
-
-    return {
-      width: nextManualBaseWidth,
-      height: nextManualBaseHeight
-    }
-  }
-
-  /**
-   * Возвращает итоговые размеры шага фиксации с учетом осей, которые реально скейлились.
-   */
-  private _resolveScalingCommitDimensions({
-    group,
-    text,
-    constraintPadding,
-    startDimensions,
-    scaleX,
-    scaleY
-  }: {
-    group: ShapeGroup
-    text: ShapeTextNode
-    constraintPadding: ShapePadding
-    startDimensions: ShapeScalingStartDimensions
-    scaleX: number
-    scaleY: number
-  }): ShapeScalingCommitDimensions {
-    const {
-      previewWidth,
-      previewHeight
-    } = this._resolvePreviewDimensions({
-      group,
-      text,
-      constraintPadding,
-      startDimensions,
-      appliedScaleX: scaleX,
-      appliedScaleY: scaleY
-    })
-    const {
-      startWidth,
-      startHeight
-    } = startDimensions
-    const hasWidthChange = Math.abs(previewWidth - startWidth) > SIZE_EPSILON
-    const hasHeightChange = Math.abs(previewHeight - startHeight) > SIZE_EPSILON
-
-    return {
-      width: previewWidth,
-      height: previewHeight,
-      hasWidthChange,
-      hasDimensionChange: hasWidthChange || hasHeightChange
-    }
-  }
-
-  /**
-   * Применяет уже выбранные resize-размеры к layout шейпа и сбрасывает временный scale.
-   */
-  private _commitResolvedShapeScalingLayout({
-    group,
-    shape,
-    text,
-    width,
-    height,
-    alignH,
-    alignV,
-    startManualBaseWidth,
-    startManualBaseHeight,
-    canScaleWidth,
-    canScaleHeight,
-    hasWidthChange
-  }: ShapeScalingLayoutCommit): void {
-    const nextManualBaseDimensions = this._resolveNextManualBaseDimensionsAfterScaling({
-      startManualBaseWidth,
-      startManualBaseHeight,
-      canScaleWidth,
-      canScaleHeight,
-      finalWidth: width,
-      finalHeight: height
-    })
-
-    group.shapeManualBaseWidth = nextManualBaseDimensions.width
-    group.shapeManualBaseHeight = nextManualBaseDimensions.height
-
-    if (canScaleWidth && hasWidthChange) {
-      // Ручной resize по ширине фиксирует новую ширину как пользовательский контракт.
-      group.shapeTextAutoExpand = false
-    }
-
-    const userPadding = ShapeScalingController._resolveUserPadding({ group })
-    const internalShapeTextInset = ShapeScalingController._resolveInternalShapeTextInset({
-      group,
-      width,
-      height
-    })
-    const expandShapeHeightToFitText = !canScaleHeight
-
-    applyShapeTextLayout({
-      group,
-      shape,
-      text,
-      width,
-      height,
-      alignH,
-      alignV,
-      padding: userPadding,
-      shapeTextAutoExpandEnabled: group.shapeTextAutoExpand !== false,
-      internalShapeTextInset,
-      expandShapeHeightToFitText,
-      resolveInternalShapeTextInset: ({ width: nextWidth, height: nextHeight }) => {
-        return ShapeScalingController._resolveInternalShapeTextInset({
-          group,
-          width: nextWidth,
-          height: nextHeight
-        })
-      }
-    })
-
-    group.shapeReplaceBoxWidth = Math.max(1, group.shapeBaseWidth ?? width)
-    group.shapeReplaceBoxHeight = Math.max(1, group.shapeBaseHeight ?? height)
-
-    text.set({
-      scaleX: 1,
-      scaleY: 1
-    })
-
-    group.set({
-      scaleX: 1,
-      scaleY: 1
-    })
-
-    group.setCoords()
-    text.setCoords()
-    shape.setCoords()
   }
 }

--- a/src/editor/shape-manager/shape-group.ts
+++ b/src/editor/shape-manager/shape-group.ts
@@ -1,9 +1,11 @@
 import {
   FabricObject,
   Group,
+  LayoutManager,
   classRegistry,
   util,
-  type Abortable
+  type Abortable,
+  type LayoutStrategy
 } from 'fabric'
 import {
   getShapePreset,
@@ -28,36 +30,33 @@ import type {
 
 type ShapeGroupOptions = ConstructorParameters<typeof Group>[1] & Partial<ShapeGroupMetadata>
 
-type SerializedShapeGroupOptions = ShapeGroupOptions & {
-  layoutManager?: {
-    strategy?: string
-    type: string
-  }
-  objects?: object[]
+type SerializedShapeGroupLayoutManager = {
+  type: string
+  strategy?: string
+}
+
+interface SerializedShapeGroupObject extends Partial<ShapeGroupMetadata> {
+  [key: string]: unknown
   type?: string
+  objects?: object[]
+  layoutManager?: SerializedShapeGroupLayoutManager
+}
+
+type RegisteredLayoutStrategyClass = {
+  new(): LayoutStrategy
 }
 
 const SHAPE_GROUP_TYPE = 'shape-group'
 
-type NoopShapeLayoutManager = {
-  performLayout: (options?: object) => void
-}
-
-type ShapeLayoutManager = {
-  subscribeTargets: (options: {
-    target: Group
-    targets: FabricObject[]
-    type: string
-  }) => void
-}
-
 /**
  * Создаёт временный layout manager без реального layout, используемый только на стадии deserialization.
  */
-function createNoopShapeLayoutManager(): NoopShapeLayoutManager {
-  return {
-    performLayout(): void {}
-  }
+function createNoopShapeLayoutManager(): LayoutManager {
+  const layoutManager = new LayoutManager()
+
+  layoutManager.performLayout = (): void => {}
+
+  return layoutManager
 }
 
 /**
@@ -66,11 +65,9 @@ function createNoopShapeLayoutManager(): NoopShapeLayoutManager {
 function resolveShapeGroupLayoutManager({
   layoutManager
 }: {
-  layoutManager?: SerializedShapeGroupOptions['layoutManager']
-}): ShapeLayoutManager {
-  const LayoutManagerClass = classRegistry.getClass('layoutManager') as new (
-    ...args: unknown[]
-  ) => ShapeLayoutManager
+  layoutManager?: SerializedShapeGroupLayoutManager
+}): LayoutManager {
+  const LayoutManagerClass = classRegistry.getClass<typeof LayoutManager>('layoutManager')
 
   if (!layoutManager) {
     return new LayoutManagerClass()
@@ -80,15 +77,13 @@ function resolveShapeGroupLayoutManager({
     strategy,
     type
   } = layoutManager
-  const RegisteredLayoutManagerClass = classRegistry.getClass(type) as new (
-    ...args: unknown[]
-  ) => ShapeLayoutManager
+  const RegisteredLayoutManagerClass = classRegistry.getClass<typeof LayoutManager>(type)
 
   if (!strategy) {
     return new RegisteredLayoutManagerClass()
   }
 
-  const StrategyClass = classRegistry.getClass(strategy) as new (...args: unknown[]) => object
+  const StrategyClass = classRegistry.getClass<RegisteredLayoutStrategyClass>(strategy)
 
   return new RegisteredLayoutManagerClass(new StrategyClass())
 }
@@ -160,7 +155,7 @@ export class ShapeGroupObject extends Group {
       group: this as ShapeGroupLike
     })
     applyShapeCornerFreeScaleControls({
-      group: this as ShapeGroupLike
+      target: this as ShapeGroupLike
     })
 
     const text = getShapeRuntimeTextNode({
@@ -187,7 +182,7 @@ export class ShapeGroupObject extends Group {
       objects = [],
       layoutManager,
       ...options
-    }: SerializedShapeGroupOptions,
+    }: SerializedShapeGroupObject,
     abortable?: Abortable
   ): Promise<ShapeGroupObject> {
     const [enlivenedObjects, hydratedOptions] = await Promise.all([
@@ -199,7 +194,7 @@ export class ShapeGroupObject extends Group {
       ...options,
       ...hydratedOptions,
       layoutManager: createNoopShapeLayoutManager()
-    })
+    } as ShapeGroupOptions)
 
     group.layoutManager = resolveShapeGroupLayoutManager({ layoutManager })
     group.layoutManager.subscribeTargets({

--- a/src/editor/types/fabric-extensions.d.ts
+++ b/src/editor/types/fabric-extensions.d.ts
@@ -362,6 +362,11 @@ declare module 'fabric' {
     shapeRounding?: number;
 
     /**
+     * Флаг, указывающий поддерживает ли фигура скругление.
+     */
+    shapeCanRound?: boolean;
+
+    /**
      * Роль объекта внутри shape-группы.
      */
     shapeNodeType?: 'shape' | 'text';


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавляем 2 одинаковых шейпа с текстом "TEST" (скрин 1)

<img width="472" height="462" alt="image" src="https://github.com/user-attachments/assets/6ced933c-500c-4c47-b083-f3a1b308616f" />

2. Выделяем оба шейпа как одно массовое выделение (activeselection) и уменьшаем их высоту путём вертикального или горизонтального скейлинга

Ожидаемый результат.

В процессе уменьшения высоты мы упираемся в минимальную высоту шейпов
В процессе уменьшения ширины мы упираемся в минимальную ширину шейпов обьекта

Фактический результат.

В процессе уменьшения высоты мы упираемся в минимальную высоту шейпов обьекта подобно тому как это работает в Canva.com, однако сама рамка выделения сужается плоть до полоски в 1px (скрин 2), и сбрасывается после завершения скейлинга (скрин 3)

<img width="487" height="475" alt="image" src="https://github.com/user-attachments/assets/a1e2b05f-52d9-47aa-b488-5d039ba07d0b" />

<img width="466" height="266" alt="image" src="https://github.com/user-attachments/assets/a8ba2f76-854c-4037-aed2-524339b28491" />

В процессе уменьшения ширины мы не учитываем минимальную ширину (скрин 4), а учитываем её только после завершения скейлинга и отпускания ЛКМ (скрин 5)

<img width="523" height="507" alt="image" src="https://github.com/user-attachments/assets/a549d555-7d22-4133-9c08-d96a4192ca40" />

<img width="489" height="486" alt="image" src="https://github.com/user-attachments/assets/8f740feb-014b-446e-b842-0010fbd28d05" />

Всё что описано выше мы точно так же должны учитывать и при скейлинге по диагонали, когда происходит одновременное уменьшение высоты и ширины.

---

FIXED.