### PR TITLE
ShapeManager. Чиним баг, когда при массовом скейлинге шейпов разных высот не получается уменьшить высоту до конца, а также залипание скейлинга на разных высотах.

### DIFF
--- a/e2e/fixtures/data/shape-multi-scaling.data.ts
+++ b/e2e/fixtures/data/shape-multi-scaling.data.ts
@@ -22,9 +22,35 @@ export const SHAPE_MULTI_SCALING_RIGHT_OPTIONS = {
   }
 }
 
+export const SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS = {
+  id: 'shape-multi-scaling-short-left',
+  left: 120,
+  top: 260,
+  width: 220,
+  height: 120,
+  text: 'TEST',
+  textStyle: {
+    fontSize: 48
+  }
+}
+
+export const SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS = {
+  id: 'shape-multi-scaling-tall-right',
+  left: 420,
+  top: 120,
+  width: 220,
+  height: 260,
+  text: 'TEST',
+  textStyle: {
+    fontSize: 48
+  }
+}
+
 export const SHAPE_MULTI_SCALING_SCALE_X = 0.55
 
 export const SHAPE_MULTI_SCALING_EXPAND_SCALE_X = 1.85
+
+export const SHAPE_MULTI_SCALING_EXPAND_SCALE_Y = 1.85
 
 export const SHAPE_MULTI_SCALING_SCALE_Y = 0.55
 

--- a/e2e/models/selection.model.ts
+++ b/e2e/models/selection.model.ts
@@ -85,6 +85,19 @@ export class SelectionModel {
     })
   }
 
+  /** Масштабирует текущее общее выделение сверху и возвращает live-состояние. */
+  async scaleVerticallyFromTop(
+    params: {
+      scaleY: number
+    }
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'mt',
+      oppositeControl: 'mb',
+      scaleY: params.scaleY
+    })
+  }
+
   /** Масштабирует текущее общее выделение из правого нижнего угла и возвращает live-состояние. */
   async scaleDiagonallyFromBottomRight(
     params: {
@@ -95,6 +108,21 @@ export class SelectionModel {
     return this._scaleFromControl({
       startControl: 'br',
       oppositeControl: 'tl',
+      scaleX: params.scaleX,
+      scaleY: params.scaleY
+    })
+  }
+
+  /** Масштабирует текущее общее выделение из правого верхнего угла и возвращает live-состояние. */
+  async scaleDiagonallyFromTopRight(
+    params: {
+      scaleX: number
+      scaleY: number
+    }
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'tr',
+      oppositeControl: 'bl',
       scaleX: params.scaleX,
       scaleY: params.scaleY
     })
@@ -122,6 +150,17 @@ export class SelectionModel {
     })
   }
 
+  /** Сжимает текущее общее выделение сверху до минимальной высоты и возвращает live-состояние. */
+  async shrinkVerticallyFromTopToMinimum(
+    params: SelectionMinimumSizeParams
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'mt',
+      oppositeControl: 'mb',
+      minimumHeight: params.minimumSize
+    })
+  }
+
   /** Сжимает текущее общее выделение из правого нижнего угла до минимальных ширины и высоты и возвращает live-состояние. */
   async shrinkDiagonallyFromBottomRightToMinimum(
     params: SelectionMinimumSizeParams
@@ -129,6 +168,18 @@ export class SelectionModel {
     return this._scaleFromControl({
       startControl: 'br',
       oppositeControl: 'tl',
+      minimumWidth: params.minimumSize,
+      minimumHeight: params.minimumSize
+    })
+  }
+
+  /** Сжимает текущее общее выделение из правого верхнего угла до минимальных ширины и высоты и возвращает live-состояние. */
+  async shrinkDiagonallyFromTopRightToMinimum(
+    params: SelectionMinimumSizeParams
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'tr',
+      oppositeControl: 'bl',
       minimumWidth: params.minimumSize,
       minimumHeight: params.minimumSize
     })

--- a/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
+++ b/e2e/tests/shape-manager/shape-active-selection-scaling.spec.ts
@@ -2,15 +2,19 @@ import { test, expect } from '../../fixtures/editor.fixture'
 import {
   SHAPE_MULTI_SCALING_EDITED_TEXT,
   SHAPE_MULTI_SCALING_EXPAND_SCALE_X,
+  SHAPE_MULTI_SCALING_EXPAND_SCALE_Y,
   SHAPE_MULTI_SCALING_LEFT_OPTIONS,
   SHAPE_MULTI_SCALING_RIGHT_OPTIONS,
   SHAPE_MULTI_SCALING_SCALE_X,
   SHAPE_MULTI_SCALING_SCALE_Y,
+  SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS,
+  SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS,
   SHAPE_MULTI_SCALING_TOLERANCE
 } from '../../fixtures/data/shape-multi-scaling.data'
 
 const SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE = 1
 const SHAPE_MULTI_SCALING_BEYOND_MINIMUM_DRAG_DELTA = -120
+const SHAPE_MULTI_SCALING_BEYOND_TOP_MINIMUM_DRAG_DELTA = 120
 
 test.describe('Изменение размера нескольких шейпов', () => {
   test.beforeEach(async({ editorModel, shapes }) => {
@@ -400,6 +404,235 @@ test.describe('Изменение размера нескольких шейпо
     })
   })
 
+  test('при уменьшении нескольких шейпов сверху их высота меняется без деформации текста и без рывка после mouseup', async({
+    selection,
+    shapes
+  }) => {
+    const initialSelectionSnapshot = await test.step('Получить исходную высоту общего выделения', () => {
+      return selection.getSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в левом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в правом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    const liveSelectionSnapshot = await test.step('Уменьшить общее выделение сверху во время drag', () => {
+      return selection.scaleVerticallyFromTop({
+        scaleY: SHAPE_MULTI_SCALING_SCALE_Y
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние левого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightShape = await test.step('Получить состояние правого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const liveLeftText = await test.step('Получить текст в левом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const liveRightText = await test.step('Получить текст в правом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что во время drag уменьшается только высота, а текст не деформируется', () => {
+      expect(initialLeftText, 'текст в левом шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в правом шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.boundsHeight)
+        .toBeLessThan(initialSelectionSnapshot.boundsHeight - SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(liveSelectionSnapshot.boundsWidth - initialSelectionSnapshot.boundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+      expect(liveLeftText.lineCount).toBe(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBe(initialRightText.lineCount)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', async() => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в левом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_LEFT_OPTIONS.id })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в правом шейпе', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что после mouseup высота не дёрнулась и текст остался тем же', () => {
+      expect(finalLeftText, 'итоговый текст в левом шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в правом шейпе должен существовать').not.toBeNull()
+
+      if (!finalLeftText || !finalRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
+      }
+
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.boundsHeight - liveSelectionSnapshot.boundsHeight)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('при сужении нескольких шейпов за правый верхний угол текст переносится во время drag и размер не дёргается после mouseup', async({
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_RIGHT_OPTIONS
+    const { mouseupJump } = SHAPE_MULTI_SCALING_TOLERANCE
+
+    const initialSelectionSnapshot = await test.step('Получить исходный размер общего выделения', () => {
+      return selection.getSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в левом шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в правом шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const liveSelectionSnapshot = await test.step('Сузить общее выделение из правого верхнего угла во время drag', () => {
+      return selection.scaleDiagonallyFromTopRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X,
+        scaleY: SHAPE_MULTI_SCALING_SCALE_Y
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние левого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const liveRightShape = await test.step('Получить состояние правого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const liveLeftText = await test.step('Получить текст в левом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const liveRightText = await test.step('Получить текст в правом шейпе во время drag', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние левого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние правого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в левом шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в правом шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что во время drag изменяются обе оси и текст переносится внутри шейпов', () => {
+      expect(initialLeftText, 'текст в левом шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в правом шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.boundsWidth)
+        .toBeLessThan(initialSelectionSnapshot.boundsWidth - mouseupJump)
+      expect(liveSelectionSnapshot.boundsHeight)
+        .toBeLessThan(initialSelectionSnapshot.boundsHeight - mouseupJump)
+      expect(liveLeftText.lineCount).toBeGreaterThan(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBeGreaterThan(initialRightText.lineCount)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    await test.step('Проверить что после mouseup размер не дёрнулся и переносы строк сохранились', () => {
+      expect(liveLeftText, 'текст в левом шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в правом шейпе во время drag должен существовать').not.toBeNull()
+      expect(finalLeftText, 'итоговый текст в левом шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в правом шейпе должен существовать').not.toBeNull()
+
+      if (!liveLeftText || !liveRightText || !finalLeftText || !finalRightText) {
+        throw new Error('текст в обоих шейпах должен существовать во время drag и после mouseup')
+      }
+
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.boundsWidth - liveSelectionSnapshot.boundsWidth)
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.boundsHeight - liveSelectionSnapshot.boundsHeight)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(selectionHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
   test('при сужении нескольких шейпов за угол текст переносится во время drag и размер не дёргается после mouseup', async({
     selection,
     shapes
@@ -731,6 +964,1044 @@ test.describe('Изменение размера нескольких шейпо
         .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
       expect(Math.abs(finalRightShape.groupBoundsWidth - resizedRightShape.groupBoundsWidth))
         .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+})
+
+test.describe('Изменение размера нескольких шейпов разной высоты', () => {
+  test.beforeEach(async({ editorModel, shapes }) => {
+    const leftShape = await shapes.addAtBounds({
+      presetKey: 'square',
+      options: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    })
+    const rightShape = await shapes.addAtBounds({
+      presetKey: 'square',
+      options: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+    })
+
+    shapes.checkCreation({
+      shape: leftShape,
+      presetKey: 'square'
+    })
+    shapes.checkCreation({
+      shape: rightShape,
+      presetKey: 'square'
+    })
+
+    await editorModel.selectAllObjects()
+  })
+
+  test('при сужении нескольких шейпов разной высоты справа текст переносится во время drag и размер не дёргается после mouseup', async({
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+    const { mouseupJump } = SHAPE_MULTI_SCALING_TOLERANCE
+
+    const initialSelectionSnapshot = await test.step('Получить исходную ширину общего выделения', () => {
+      return selection.getSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в меньшем шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в высоком шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const liveSelectionSnapshot = await test.step('Сузить общее выделение справа во время drag', () => {
+      return selection.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние меньшего шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const liveRightShape = await test.step('Получить состояние высокого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const liveLeftText = await test.step('Получить текст в меньшем шейпе во время drag', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const liveRightText = await test.step('Получить текст в высоком шейпе во время drag', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговую ширину общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в меньшем шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в высоком шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что во время drag текст переносится внутри шейпов', () => {
+      expect(initialLeftText, 'текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в высоком шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в меньшем шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в высоком шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.boundsWidth)
+        .toBeLessThan(initialSelectionSnapshot.boundsWidth - mouseupJump)
+      expect(liveLeftText.lineCount).toBeGreaterThan(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBeGreaterThan(initialRightText.lineCount)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    await test.step('Проверить что после mouseup ширина не дёрнулась и переносы строк сохранились', () => {
+      expect(liveLeftText, 'текст в меньшем шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в высоком шейпе во время drag должен существовать').not.toBeNull()
+      expect(finalLeftText, 'итоговый текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в высоком шейпе должен существовать').not.toBeNull()
+
+      if (!liveLeftText || !liveRightText || !finalLeftText || !finalRightText) {
+        throw new Error('текст в обоих шейпах должен существовать во время drag и после mouseup')
+      }
+
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.boundsWidth - liveSelectionSnapshot.boundsWidth)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('при уменьшении нескольких шейпов разной высоты снизу их высота меняется без деформации текста и без рывка после mouseup', async({
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+    const { mouseupJump } = SHAPE_MULTI_SCALING_TOLERANCE
+
+    const initialSelectionSnapshot = await test.step('Получить исходную высоту общего выделения', () => {
+      return selection.getSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в меньшем шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в высоком шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const liveSelectionSnapshot = await test.step('Уменьшить общее выделение снизу во время drag', () => {
+      return selection.scaleVerticallyFromBottom({
+        scaleY: SHAPE_MULTI_SCALING_SCALE_Y
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние меньшего шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const liveRightShape = await test.step('Получить состояние высокого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const liveLeftText = await test.step('Получить текст в меньшем шейпе во время drag', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const liveRightText = await test.step('Получить текст в высоком шейпе во время drag', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в меньшем шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в высоком шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что во время drag уменьшается только высота, а текст не деформируется', () => {
+      expect(initialLeftText, 'текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в высоком шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в меньшем шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в высоком шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.boundsHeight)
+        .toBeLessThan(initialSelectionSnapshot.boundsHeight - mouseupJump)
+      expect(Math.abs(liveSelectionSnapshot.boundsWidth - initialSelectionSnapshot.boundsWidth))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+      expect(liveLeftText.lineCount).toBe(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBe(initialRightText.lineCount)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    await test.step('Проверить что после mouseup высота не дёрнулась и текст остался тем же', () => {
+      expect(finalLeftText, 'итоговый текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в высоком шейпе должен существовать').not.toBeNull()
+
+      if (!finalLeftText || !finalRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
+      }
+
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.boundsHeight - liveSelectionSnapshot.boundsHeight)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  // eslint-disable-next-line max-len
+  test('при сужении нескольких шейпов разной высоты за правый нижний угол текст переносится во время drag и размер не дёргается после mouseup', async({
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+    const { mouseupJump } = SHAPE_MULTI_SCALING_TOLERANCE
+
+    const initialSelectionSnapshot = await test.step('Получить исходный размер общего выделения', () => {
+      return selection.getSnapshot()
+    })
+    const initialLeftText = await test.step('Получить исходное состояние текста в меньшем шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const initialRightText = await test.step('Получить исходное состояние текста в высоком шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const liveSelectionSnapshot = await test.step('Сузить общее выделение из правого нижнего угла во время drag', () => {
+      return selection.scaleDiagonallyFromBottomRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X,
+        scaleY: SHAPE_MULTI_SCALING_SCALE_Y
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние меньшего шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const liveRightShape = await test.step('Получить состояние высокого шейпа во время drag', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const liveLeftText = await test.step('Получить текст в меньшем шейпе во время drag', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const liveRightText = await test.step('Получить текст в высоком шейпе во время drag', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в меньшем шейпе', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в высоком шейпе', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что во время drag изменяются обе оси и текст переносится внутри шейпов', () => {
+      expect(initialLeftText, 'текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(initialRightText, 'текст в высоком шейпе должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в меньшем шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в высоком шейпе во время drag должен существовать').not.toBeNull()
+
+      if (!initialLeftText || !initialRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и во время drag')
+      }
+
+      expect(liveSelectionSnapshot.boundsWidth)
+        .toBeLessThan(initialSelectionSnapshot.boundsWidth - mouseupJump)
+      expect(liveSelectionSnapshot.boundsHeight)
+        .toBeLessThan(initialSelectionSnapshot.boundsHeight - mouseupJump)
+      expect(liveLeftText.lineCount).toBeGreaterThan(initialLeftText.lineCount)
+      expect(liveRightText.lineCount).toBeGreaterThan(initialRightText.lineCount)
+      expect(liveLeftText.fontSize).toBe(initialLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(initialRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    await test.step('Проверить что после mouseup размер не дёрнулся и переносы строк сохранились', () => {
+      expect(liveLeftText, 'текст в меньшем шейпе во время drag должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в высоком шейпе во время drag должен существовать').not.toBeNull()
+      expect(finalLeftText, 'итоговый текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в высоком шейпе должен существовать').not.toBeNull()
+
+      if (!liveLeftText || !liveRightText || !finalLeftText || !finalRightText) {
+        throw new Error('текст в обоих шейпах должен существовать во время drag и после mouseup')
+      }
+
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.boundsWidth - liveSelectionSnapshot.boundsWidth)
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.boundsHeight - liveSelectionSnapshot.boundsHeight)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(selectionHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(mouseupJump)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('после undo и redo несколько шейпов разной высоты сохраняют тот же размер и те же переносы строк', async({
+    history,
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+
+    await test.step('Сузить несколько шейпов разной высоты справа и завершить изменение размера', async() => {
+      await selection.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+      await selection.finishScale()
+      await history.flushPendingSave()
+    })
+
+    const resizedLeftShape = await test.step('Получить состояние меньшего шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const resizedRightShape = await test.step('Получить состояние высокого шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const resizedLeftText = await test.step('Получить текст в меньшем шейпе после изменения размера', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const resizedRightText = await test.step('Получить текст в высоком шейпе после изменения размера', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Сделать undo и redo', async() => {
+      await history.undo()
+      await history.redo()
+    })
+
+    const restoredLeftShape = await test.step('Получить состояние меньшего шейпа после redo', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const restoredRightShape = await test.step('Получить состояние высокого шейпа после redo', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const restoredLeftText = await test.step('Получить текст в меньшем шейпе после redo', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const restoredRightText = await test.step('Получить текст в высоком шейпе после redo', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что redo вернул тот же размер и те же переносы строк', () => {
+      expect(resizedLeftText, 'текст в меньшем шейпе после resize должен существовать').not.toBeNull()
+      expect(resizedRightText, 'текст в высоком шейпе после resize должен существовать').not.toBeNull()
+      expect(restoredLeftText, 'текст в меньшем шейпе после redo должен существовать').not.toBeNull()
+      expect(restoredRightText, 'текст в высоком шейпе после redo должен существовать').not.toBeNull()
+
+      if (!resizedLeftText || !resizedRightText || !restoredLeftText || !restoredRightText) {
+        throw new Error('текст в обоих шейпах должен существовать после resize и после redo')
+      }
+
+      expect(Math.abs(restoredLeftShape.groupBoundsWidth - resizedLeftShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(restoredRightShape.groupBoundsWidth - resizedRightShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(restoredLeftText.lineCount).toBe(resizedLeftText.lineCount)
+      expect(restoredRightText.lineCount).toBe(resizedRightText.lineCount)
+      expect(restoredLeftText.fontSize).toBe(resizedLeftText.fontSize)
+      expect(restoredRightText.fontSize).toBe(resizedRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: restoredLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: restoredRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('если продолжать тянуть нижнюю ручку после упора в минимальную высоту, выделение не расширяется рывком', async({
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+
+    const minimumSelectionSnapshot = await test.step('Сжать общее выделение снизу до минимальной высоты', () => {
+      return selection.shrinkVerticallyFromBottomToMinimum({
+        minimumSize: SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE
+      })
+    })
+    const minimumLeftShape = await test.step('Получить состояние меньшего шейпа на минимальной высоте', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const minimumRightShape = await test.step('Получить состояние высокого шейпа на минимальной высоте', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+
+    const continuedSelectionSnapshot = await test.step('Продолжить тянуть нижнюю ручку вверх после упора', () => {
+      return selection.dragActiveScaleHandleBy({
+        deltaX: 0,
+        deltaY: SHAPE_MULTI_SCALING_BEYOND_MINIMUM_DRAG_DELTA
+      })
+    })
+    const continuedLeftShape = await test.step('Получить состояние меньшего шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const continuedRightShape = await test.step('Получить состояние высокого шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что продолжение drag не расширило выделение по высоте и шейпы остались корректными', () => {
+      expect(continuedSelectionSnapshot.boundsHeight)
+        .toBeGreaterThan(SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE + SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(continuedSelectionSnapshot.boundsWidth)
+        .toBeGreaterThan(SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE + SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+
+      expect(Math.abs(continuedSelectionSnapshot.boundsHeight - minimumSelectionSnapshot.boundsHeight))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalSelectionSnapshot.boundsHeight - continuedSelectionSnapshot.boundsHeight))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+
+      expect(Math.abs(continuedLeftShape.groupBoundsHeight - minimumLeftShape.groupBoundsHeight))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(continuedRightShape.groupBoundsHeight - minimumRightShape.groupBoundsHeight))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalLeftShape.groupBoundsHeight - continuedLeftShape.groupBoundsHeight))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalRightShape.groupBoundsHeight - continuedRightShape.groupBoundsHeight))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalSelectionSnapshot.boundsWidth).toBeGreaterThan(0)
+      expect(finalLeftShape.groupBoundsWidth).toBeGreaterThan(0)
+      expect(finalRightShape.groupBoundsWidth).toBeGreaterThan(0)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedRightShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('после массового сужения нескольких шейпов разной высоты можно редактировать текст без возврата старой ширины', async({
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+
+    await test.step('Сузить несколько шейпов разной высоты справа и завершить изменение размера', async() => {
+      await selection.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+      await selection.finishScale()
+    })
+
+    const resizedLeftShape = await test.step('Получить состояние меньшего шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const resizedLeftText = await test.step('Получить текст в меньшем шейпе после изменения размера', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const resizedRightShape = await test.step('Получить состояние высокого шейпа после изменения размера', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+
+    await test.step('Изменить текст только в меньшем шейпе после массового resize', async() => {
+      await shapes.enterTextEditing({ id: leftShapeId })
+      await shapes.updateEditingText({
+        id: leftShapeId,
+        text: SHAPE_MULTI_SCALING_EDITED_TEXT
+      })
+      await shapes.exitTextEditing({ id: leftShapeId })
+    })
+
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа после редактирования текста', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа после редактирования текста', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в меньшем шейпе после редактирования', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+
+    await test.step('Проверить что меньший шейп сохранил текущую ширину, а текст просто перенёсся внутри неё', () => {
+      expect(resizedLeftText, 'текст в меньшем шейпе после resize должен существовать').not.toBeNull()
+      expect(finalLeftText, 'итоговый текст в меньшем шейпе должен существовать').not.toBeNull()
+
+      if (!resizedLeftText || !finalLeftText) {
+        throw new Error('текст в меньшем шейпе должен существовать до и после редактирования')
+      }
+
+      expect(finalLeftText.text).toBe(SHAPE_MULTI_SCALING_EDITED_TEXT)
+      expect(finalLeftText.fontSize).toBe(resizedLeftText.fontSize)
+      expect(finalLeftText.lineCount).toBeGreaterThan(resizedLeftText.lineCount)
+      expect(Math.abs(finalLeftShape.groupBoundsWidth - resizedLeftShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(Math.abs(finalRightShape.groupBoundsWidth - resizedRightShape.groupBoundsWidth))
+        .toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('после сужения и обратного расширения справа нескольких шейпов разной высоты ширина не дёргается после mouseup', async({
+    editorModel,
+    selection,
+    shapes
+  }) => {
+    const { id: leftShapeId } = SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS
+    const { id: rightShapeId } = SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS
+
+    await test.step('Сузить несколько шейпов разной высоты справа и завершить изменение размера', async() => {
+      await selection.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_SCALE_X
+      })
+      await selection.finishScale()
+    })
+
+    await test.step('Заново выделить оба шейпа перед обратным расширением', async() => {
+      await editorModel.selectAllObjects()
+    })
+
+    const narrowedSelectionSnapshot = await test.step('Получить ширину выделения после сужения', () => {
+      return selection.getSnapshot()
+    })
+    const narrowedLeftText = await test.step('Получить текст в меньшем шейпе после сужения', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const narrowedRightText = await test.step('Получить текст в высоком шейпе после сужения', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    const liveSelectionSnapshot = await test.step('Расширить общее выделение справа во время drag', () => {
+      return selection.scaleHorizontallyFromRight({
+        scaleX: SHAPE_MULTI_SCALING_EXPAND_SCALE_X
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние меньшего шейпа во время обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const liveRightShape = await test.step('Получить состояние высокого шейпа во время обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const liveLeftText = await test.step('Получить текст в меньшем шейпе во время обратного расширения', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const liveRightText = await test.step('Получить текст в высоком шейпе во время обратного расширения', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что во время обратного расширения ширина выросла и текст вернулся в одну строку', () => {
+      expect(narrowedLeftText, 'текст в меньшем шейпе после сужения должен существовать').not.toBeNull()
+      expect(narrowedRightText, 'текст в высоком шейпе после сужения должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в меньшем шейпе во время обратного расширения должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в высоком шейпе во время обратного расширения должен существовать').not.toBeNull()
+
+      if (!narrowedLeftText || !narrowedRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать после сужения и во время обратного расширения')
+      }
+
+      expect(liveSelectionSnapshot.boundsWidth)
+        .toBeGreaterThan(narrowedSelectionSnapshot.boundsWidth + SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(narrowedLeftText.lineCount).toBeGreaterThan(1)
+      expect(narrowedRightText.lineCount).toBeGreaterThan(1)
+      expect(liveLeftText.lineCount).toBe(1)
+      expect(liveRightText.lineCount).toBe(1)
+      expect(liveLeftText.fontSize).toBe(narrowedLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(narrowedRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', async() => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа после обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: leftShapeId })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа после обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: rightShapeId })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в меньшем шейпе после обратного расширения', () => {
+      return shapes.getTextNode({ id: leftShapeId })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в высоком шейпе после обратного расширения', () => {
+      return shapes.getTextNode({ id: rightShapeId })
+    })
+
+    await test.step('Проверить что после mouseup размер не дёрнулся и переносы строк сохранились', () => {
+      expect(finalLeftText, 'итоговый текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в высоком шейпе должен существовать').not.toBeNull()
+
+      if (!finalLeftText || !finalRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
+      }
+
+      const selectionWidthJump = Math.abs(finalSelectionSnapshot.boundsWidth - liveSelectionSnapshot.boundsWidth)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+
+      expect(selectionWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalLeftText.lineCount).toBe(liveLeftText.lineCount)
+      expect(finalRightText.lineCount).toBe(liveRightText.lineCount)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('при уменьшении сверху меньший шейп остаётся у нижней границы выделения', async({
+    selection,
+    shapes
+  }) => {
+    const minimumSelection = await test.step('Сжать общее выделение сверху до минимальной высоты', () => {
+      return selection.shrinkVerticallyFromTopToMinimum({
+        minimumSize: SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE
+      })
+    })
+    const minimumLeftShape = await test.step('Получить состояние меньшего шейпа на минимальной высоте', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const minimumRightShape = await test.step('Получить состояние высокого шейпа на минимальной высоте', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    const continuedSelection = await test.step('Продолжить тянуть верхнюю ручку вниз после упора', () => {
+      return selection.dragActiveScaleHandleBy({
+        deltaX: 0,
+        deltaY: SHAPE_MULTI_SCALING_BEYOND_TOP_MINIMUM_DRAG_DELTA
+      })
+    })
+    const continuedLeftShape = await test.step('Получить состояние меньшего шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const continuedRightShape = await test.step('Получить состояние высокого шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    const finalSelection = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что меньший шейп не выпрыгнул вверх и не дёрнулся после mouseup', () => {
+      const { mouseupJump } = SHAPE_MULTI_SCALING_TOLERANCE
+
+      expect(minimumLeftShape.groupBoundsTop).toBeGreaterThanOrEqual(minimumSelection.boundsTop - mouseupJump)
+      expect(minimumLeftShape.groupBoundsBottom).toBeLessThanOrEqual(minimumSelection.boundsBottom + mouseupJump)
+      expect(Math.abs(minimumLeftShape.groupBoundsBottom - minimumSelection.boundsBottom))
+        .toBeLessThanOrEqual(mouseupJump)
+
+      expect(Math.abs(continuedSelection.boundsHeight - minimumSelection.boundsHeight))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(continuedLeftShape.groupBoundsTop).toBeGreaterThanOrEqual(continuedSelection.boundsTop - mouseupJump)
+      expect(continuedLeftShape.groupBoundsBottom).toBeLessThanOrEqual(continuedSelection.boundsBottom + mouseupJump)
+      expect(Math.abs(continuedLeftShape.groupBoundsBottom - continuedSelection.boundsBottom))
+        .toBeLessThanOrEqual(mouseupJump)
+
+      expect(Math.abs(finalSelection.boundsHeight - continuedSelection.boundsHeight))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(Math.abs(finalLeftShape.groupBoundsTop - continuedLeftShape.groupBoundsTop))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(Math.abs(finalLeftShape.groupBoundsBottom - continuedLeftShape.groupBoundsBottom))
+        .toBeLessThanOrEqual(mouseupJump)
+
+      expect(minimumRightShape.groupBoundsHeight).toBeGreaterThan(0)
+      expect(continuedRightShape.groupBoundsHeight).toBeGreaterThan(0)
+      expect(finalRightShape.groupBoundsHeight).toBeGreaterThan(0)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: minimumLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: minimumRightShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedRightShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('при уменьшении из правого верхнего угла меньший шейп остаётся внутри выделения', async({
+    selection,
+    shapes
+  }) => {
+    const minimumSelection = await test.step('Сжать общее выделение из правого верхнего угла до минимального размера', () => {
+      return selection.shrinkDiagonallyFromTopRightToMinimum({
+        minimumSize: SHAPE_MULTI_SCALING_MINIMUM_TARGET_SIZE
+      })
+    })
+    const minimumLeftShape = await test.step('Получить состояние меньшего шейпа на минимальном размере', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const minimumRightShape = await test.step('Получить состояние высокого шейпа на минимальном размере', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    const continuedSelection = await test.step('Продолжить тянуть угол влево и вниз после упора', () => {
+      return selection.dragActiveScaleHandleBy({
+        deltaX: SHAPE_MULTI_SCALING_BEYOND_MINIMUM_DRAG_DELTA,
+        deltaY: SHAPE_MULTI_SCALING_BEYOND_TOP_MINIMUM_DRAG_DELTA
+      })
+    })
+    const continuedLeftShape = await test.step('Получить состояние меньшего шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const continuedRightShape = await test.step('Получить состояние высокого шейпа после продолжения drag', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    const finalSelection = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', () => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что меньший шейп не вышел за рамку выделения и не дёрнулся после mouseup', () => {
+      const { mouseupJump } = SHAPE_MULTI_SCALING_TOLERANCE
+
+      expect(minimumLeftShape.groupBoundsTop).toBeGreaterThanOrEqual(minimumSelection.boundsTop - mouseupJump)
+      expect(minimumLeftShape.groupBoundsBottom).toBeLessThanOrEqual(minimumSelection.boundsBottom + mouseupJump)
+      expect(Math.abs(minimumLeftShape.groupBoundsBottom - minimumSelection.boundsBottom))
+        .toBeLessThanOrEqual(mouseupJump)
+
+      expect(Math.abs(continuedSelection.boundsWidth - minimumSelection.boundsWidth))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(Math.abs(continuedSelection.boundsHeight - minimumSelection.boundsHeight))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(continuedLeftShape.groupBoundsTop).toBeGreaterThanOrEqual(continuedSelection.boundsTop - mouseupJump)
+      expect(continuedLeftShape.groupBoundsBottom).toBeLessThanOrEqual(continuedSelection.boundsBottom + mouseupJump)
+      expect(Math.abs(continuedLeftShape.groupBoundsBottom - continuedSelection.boundsBottom))
+        .toBeLessThanOrEqual(mouseupJump)
+
+      expect(Math.abs(finalSelection.boundsWidth - continuedSelection.boundsWidth))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(Math.abs(finalSelection.boundsHeight - continuedSelection.boundsHeight))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(Math.abs(finalLeftShape.groupBoundsTop - continuedLeftShape.groupBoundsTop))
+        .toBeLessThanOrEqual(mouseupJump)
+      expect(Math.abs(finalLeftShape.groupBoundsBottom - continuedLeftShape.groupBoundsBottom))
+        .toBeLessThanOrEqual(mouseupJump)
+
+      expect(minimumRightShape.groupBoundsHeight).toBeGreaterThan(0)
+      expect(continuedRightShape.groupBoundsHeight).toBeGreaterThan(0)
+      expect(finalRightShape.groupBoundsHeight).toBeGreaterThan(0)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: minimumLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: minimumRightShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: continuedRightShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: finalRightShape,
+        kind: 'text'
+      })
+    })
+  })
+
+  test('после сужения и обратного расширения сверху нескольких шейпов разной высоты высота не дёргается после mouseup', async({
+    editorModel,
+    selection,
+    shapes
+  }) => {
+    await test.step('Сузить несколько шейпов сверху и завершить изменение размера', async() => {
+      await selection.scaleVerticallyFromTop({
+        scaleY: SHAPE_MULTI_SCALING_SCALE_Y
+      })
+      await selection.finishScale()
+    })
+
+    await test.step('Заново выделить оба шейпа перед обратным расширением', async() => {
+      await editorModel.selectAllObjects()
+    })
+
+    const narrowedSelectionSnapshot = await test.step('Получить высоту выделения после сужения', () => {
+      return selection.getSnapshot()
+    })
+    const narrowedLeftText = await test.step('Получить текст в меньшем шейпе после сужения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const narrowedRightText = await test.step('Получить текст в высоком шейпе после сужения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    const liveSelectionSnapshot = await test.step('Расширить общее выделение сверху во время drag', () => {
+      return selection.scaleVerticallyFromTop({
+        scaleY: SHAPE_MULTI_SCALING_EXPAND_SCALE_Y
+      })
+    })
+    const liveLeftShape = await test.step('Получить состояние меньшего шейпа во время обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const liveRightShape = await test.step('Получить состояние высокого шейпа во время обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+    const liveLeftText = await test.step('Получить текст в меньшем шейпе во время обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const liveRightText = await test.step('Получить текст в высоком шейпе во время обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что во время обратного расширения высота выросла и текст остался внутри шейпов', () => {
+      expect(narrowedLeftText, 'текст в меньшем шейпе после сужения должен существовать').not.toBeNull()
+      expect(narrowedRightText, 'текст в высоком шейпе после сужения должен существовать').not.toBeNull()
+      expect(liveLeftText, 'текст в меньшем шейпе во время обратного расширения должен существовать').not.toBeNull()
+      expect(liveRightText, 'текст в высоком шейпе во время обратного расширения должен существовать').not.toBeNull()
+
+      if (!narrowedLeftText || !narrowedRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать после сужения и во время обратного расширения')
+      }
+
+      expect(liveSelectionSnapshot.boundsHeight)
+        .toBeGreaterThan(narrowedSelectionSnapshot.boundsHeight + SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(liveLeftText.fontSize).toBe(narrowedLeftText.fontSize)
+      expect(liveRightText.fontSize).toBe(narrowedRightText.fontSize)
+
+      shapes.checkNodeInsideGroup({
+        snapshot: liveLeftShape,
+        kind: 'text'
+      })
+      shapes.checkNodeInsideGroup({
+        snapshot: liveRightShape,
+        kind: 'text'
+      })
+    })
+
+    const finalSelectionSnapshot = await test.step('Отпустить мышь и получить итоговое состояние общего выделения', async() => {
+      return selection.finishScale()
+    })
+    const finalLeftShape = await test.step('Получить итоговое состояние меньшего шейпа после обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const finalRightShape = await test.step('Получить итоговое состояние высокого шейпа после обратного расширения', () => {
+      return shapes.getScaleSnapshot({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+    const finalLeftText = await test.step('Получить итоговый текст в меньшем шейпе после обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_SHORT_LEFT_OPTIONS.id })
+    })
+    const finalRightText = await test.step('Получить итоговый текст в высоком шейпе после обратного расширения', () => {
+      return shapes.getTextNode({ id: SHAPE_MULTI_SCALING_TALL_RIGHT_OPTIONS.id })
+    })
+
+    await test.step('Проверить что после mouseup размер не дёрнулся и текст остался тем же', () => {
+      expect(finalLeftText, 'итоговый текст в меньшем шейпе должен существовать').not.toBeNull()
+      expect(finalRightText, 'итоговый текст в высоком шейпе должен существовать').not.toBeNull()
+
+      if (!finalLeftText || !finalRightText || !liveLeftText || !liveRightText) {
+        throw new Error('текст в обоих шейпах должен существовать до и после mouseup')
+      }
+
+      const selectionHeightJump = Math.abs(finalSelectionSnapshot.boundsHeight - liveSelectionSnapshot.boundsHeight)
+      const leftHeightJump = Math.abs(finalLeftShape.groupBoundsHeight - liveLeftShape.groupBoundsHeight)
+      const rightHeightJump = Math.abs(finalRightShape.groupBoundsHeight - liveRightShape.groupBoundsHeight)
+      const leftWidthJump = Math.abs(finalLeftShape.groupBoundsWidth - liveLeftShape.groupBoundsWidth)
+      const rightWidthJump = Math.abs(finalRightShape.groupBoundsWidth - liveRightShape.groupBoundsWidth)
+
+      expect(selectionHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightHeightJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(leftWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(rightWidthJump).toBeLessThanOrEqual(SHAPE_MULTI_SCALING_TOLERANCE.mouseupJump)
+      expect(finalLeftText.fontSize).toBe(liveLeftText.fontSize)
+      expect(finalRightText.fontSize).toBe(liveRightText.fontSize)
 
       shapes.checkNodeInsideGroup({
         snapshot: finalLeftShape,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/shape-manager/shape-manager-events.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-events.spec.ts
@@ -461,6 +461,12 @@ describe('shape-manager events', () => {
     }
 
     const appliedSelectionScaleX = minimumShapeWidth / shapeBaseWidth
+    for (const shape of [firstShape, secondShape]) {
+      shape.getPositionByOrigin = jest.fn((
+        originX: Parameters<ActiveSelection['getPositionByOrigin']>[0],
+        originY: Parameters<ActiveSelection['getPositionByOrigin']>[1]
+      ) => shape.getPointByOrigin(originX, originY)) as never
+    }
     const scalingController = (manager as unknown as {
       scalingController: {
         commitActiveSelectionGroupScaling: (payload: unknown) => boolean

--- a/specs/src/editor/shape-manager/shape-scaling.spec.ts
+++ b/specs/src/editor/shape-manager/shape-scaling.spec.ts
@@ -775,6 +775,71 @@ describe('shape-scaling', () => {
     expect(nonShapeObject.setCoords).not.toHaveBeenCalled()
   })
 
+  it('при уменьшении нескольких шейпов снизу не сдвигает вверх шейп у нижней границы', () => {
+    const {
+      controller,
+      groups,
+      selection
+    } = createActiveSelectionShapeScalingSetup({
+      shapeBounds: [
+        {
+          left: 100,
+          top: 220,
+          width: 200,
+          height: 120
+        },
+        {
+          left: 340,
+          top: 100,
+          width: 200,
+          height: 240
+        }
+      ]
+    })
+    const bottomShape = groups[0]
+    const bottomShapeInitialBottom = bottomShape.getPositionByOrigin('center', 'bottom').y
+    const transform = {
+      ...createShapeScalingTransform({
+        target: selection,
+        action: 'scaleY',
+        corner: 'mb',
+        originX: 'center',
+        originY: 'top'
+      }),
+      target: selection
+    } as never
+
+    isShapeTextFrameFilledMock.mockReturnValue(false)
+    resolveRequiredShapeHeightForTextMock.mockImplementation(({ height }: { height: number }) => {
+      if (height === 1) return 80
+
+      return height
+    })
+
+    selection.scaleX = 1
+    selection.scaleY = 0.65
+
+    controller.handleObjectScaling({
+      target: selection,
+      transform
+    })
+
+    expect(bottomShape.setPositionByOrigin).toHaveBeenLastCalledWith(expect.objectContaining({
+      y: bottomShapeInitialBottom
+    }), 'center', 'bottom')
+
+    selection.scaleY = 0.2
+
+    controller.handleObjectScaling({
+      target: selection,
+      transform
+    })
+
+    expect(bottomShape.setPositionByOrigin).toHaveBeenLastCalledWith(expect.objectContaining({
+      y: bottomShapeInitialBottom
+    }), 'center', 'bottom')
+  })
+
   it('после горизонтального изменения размера нескольких шейпов не увеличивает высоту после завершения drag', () => {
     const {
       controller,

--- a/specs/test-utils/shape-helpers.ts
+++ b/specs/test-utils/shape-helpers.ts
@@ -593,6 +593,10 @@ export const createMockShapeGroup = ({
 
     return new Point(x, y)
   }) as never
+  group.getPositionByOrigin = jest.fn((
+    originX: PlacementOriginX,
+    originY: PlacementOriginY
+  ) => group.getPointByOrigin(originX, originY)) as never
 
   const textWithGroup = text as { group?: Group }
   textWithGroup.group = group

--- a/specs/test-utils/shape-scaling-helpers.ts
+++ b/specs/test-utils/shape-scaling-helpers.ts
@@ -15,6 +15,8 @@ type ShapeScalingTransformTarget = ShapeScalingTestGroup | ActiveSelection
 type ActiveSelectionShapeScalingSelection = ActiveSelection & {
   scaleX?: number
   scaleY?: number
+  getPositionByOrigin: jest.Mock<Point, [originX: GroupOriginX, originY: GroupOriginY]>
+  setPositionByOrigin: jest.Mock<void, [point: Point, originX: GroupOriginX, originY: GroupOriginY]>
   setCoords: jest.Mock
 }
 
@@ -30,6 +32,13 @@ type ShapeScalingTransformOptions = {
   signX?: number
   signY?: number
   target?: ShapeScalingTransformTarget
+}
+
+type ActiveSelectionShapeScalingShapeBounds = {
+  left: number
+  top: number
+  width: number
+  height: number
 }
 
 export type ShapeScalingTransformStub = {
@@ -118,9 +127,11 @@ export const createShapeScalingSetup = (): ShapeScalingTestSetup => {
  * Создаёт setup для ActiveSelection c несколькими shape-группами.
  */
 export const createActiveSelectionShapeScalingSetup = ({
-  includeNonShapeObject = false
+  includeNonShapeObject = false,
+  shapeBounds
 }: {
   includeNonShapeObject?: boolean
+  shapeBounds?: ActiveSelectionShapeScalingShapeBounds[]
 } = {}): ActiveSelectionShapeScalingTestSetup => {
   const canvas = createMockCanvas()
   const controller = new ShapeScalingController({
@@ -135,22 +146,29 @@ export const createActiveSelectionShapeScalingSetup = ({
   }>()
 
   for (let index = 0; index < 2; index += 1) {
+    const bounds = shapeBounds?.[index]
+    const width = bounds?.width ?? 200
+    const height = bounds?.height ?? 200
     const shape = createMockShapeNode({
-      width: 200,
-      height: 200
+      width,
+      height
     })
     const text = createMockShapeTextbox({
       text: `test text ${index + 1}`,
-      width: 200,
+      width,
       fontSize: 30
     })
     const group = createMockShapeGroup({
       shape,
       text,
-      left: 480 + (index * 140),
-      top: 420,
-      width: 200,
-      height: 200
+      left: bounds
+        ? bounds.left + (bounds.width / 2)
+        : 480 + (index * 140),
+      top: bounds
+        ? bounds.top + (bounds.height / 2)
+        : 420,
+      width,
+      height
     })
 
     groups.push(group)
@@ -174,6 +192,21 @@ export const createActiveSelectionShapeScalingSetup = ({
   const selection = new ActiveSelection(selectionObjects as never[], {
     canvas: canvas as never
   }) as ActiveSelectionShapeScalingSelection
+  selection.getPositionByOrigin = jest.fn((
+    _originX: GroupOriginX,
+    _originY: GroupOriginY
+  ) => new Point(
+    Number(selection.left) || 0,
+    Number(selection.top) || 0
+  ))
+  selection.setPositionByOrigin = jest.fn((
+    point: Point,
+    _originX: GroupOriginX,
+    _originY: GroupOriginY
+  ) => {
+    selection.left = point.x
+    selection.top = point.y
+  })
   selection.setCoords = jest.fn()
 
   const getShapeNodesMock = getShapeNodes as jest.Mock

--- a/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
@@ -1,6 +1,7 @@
 import {
   ActiveSelection,
   Canvas,
+  Point,
   Transform
 } from 'fabric'
 import {
@@ -19,10 +20,13 @@ import type {
   ShapeNode,
   ShapePadding,
   ShapeScalingState,
-  ShapeTextNode
+  ShapeTextNode,
+  ShapeTransformOriginX,
+  ShapeTransformOriginY
 } from '../types'
 import { applyShapeScalingPreviewLayout } from './shape-scaling-preview'
 import {
+  resolveScaleLocalPointerForTransform,
   resolveShapeScaleActionAxes,
   resolveShapeTransformOriginXValue,
   resolveShapeTransformOriginYValue
@@ -43,7 +47,7 @@ import type {
   ShapeScalingPointerEvent
 } from './shape-scaling-layout'
 
-type ActiveSelectionShapeScalingPreviewItem = {
+type ActiveSelectionShapeScalingItem = {
   group: ShapeGroup
   shape: ShapeNode
   text: ShapeTextNode
@@ -56,6 +60,30 @@ export type ActiveSelectionAppliedScale = {
   scaleY: number
 }
 
+type ActiveSelectionLocalBounds = {
+  left: number
+  right: number
+  top: number
+  bottom: number
+}
+
+type ActiveSelectionShapeScalingSessionItem = {
+  bounds: ActiveSelectionLocalBounds
+  originX: ShapeTransformOriginX
+  originY: ShapeTransformOriginY
+  originPoint: Point
+}
+
+type ActiveSelectionShapeLayoutScale = {
+  scaleX: number
+  scaleY: number
+}
+
+type ActiveSelectionScalingSession = {
+  bounds: ActiveSelectionLocalBounds
+  items: Map<ShapeGroup, ActiveSelectionShapeScalingSessionItem>
+}
+
 /**
  * Контроллер масштабирования shape-групп внутри ActiveSelection.
  */
@@ -65,6 +93,10 @@ export default class ShapeActiveSelectionScalingController {
   private shapeScalingState: WeakMap<ShapeGroup, ShapeScalingState>
 
   private scalingState: WeakMap<ActiveSelection, ActiveSelectionAppliedScale>
+
+  private scalingSessions: WeakMap<ActiveSelection, ActiveSelectionScalingSession>
+
+  private groupLayoutScales: WeakMap<ShapeGroup, ActiveSelectionShapeLayoutScale>
 
   constructor({
     canvas,
@@ -76,6 +108,8 @@ export default class ShapeActiveSelectionScalingController {
     this.canvas = canvas
     this.shapeScalingState = shapeScalingState
     this.scalingState = new WeakMap()
+    this.scalingSessions = new WeakMap()
+    this.groupLayoutScales = new WeakMap()
   }
 
   /**
@@ -107,45 +141,66 @@ export default class ShapeActiveSelectionScalingController {
 
     if (!items.length) return
 
+    const session = this._ensureScalingSession({
+      selection,
+      transform,
+      items
+    })
     const scaleX = Math.abs(selection.scaleX ?? 1) || 1
     const scaleY = Math.abs(selection.scaleY ?? 1) || 1
-    const appliedScale = this._resolveAppliedScale({
+    let selectionScale = this._resolveSelectionScale({
       items,
+      session,
       transform,
       scaleX,
       scaleY,
+      event
+    })
+    selectionScale = this._resolveSelectionScaleAtPointerBoundary({
+      selection,
+      items,
+      session,
+      transform,
+      selectionScale,
       event
     })
 
     this._applySelectionScale({
       selection,
       transform,
-      scaleX: appliedScale.scaleX,
-      scaleY: appliedScale.scaleY
+      scaleX: selectionScale.scaleX,
+      scaleY: selectionScale.scaleY
     })
-    this.scalingState.set(selection, appliedScale)
+    this.scalingState.set(selection, selectionScale)
 
-    items.forEach(({
-      group,
-      shape,
-      text,
-      constraintPadding,
-      state
-    }) => {
+    for (const item of items) {
+      const {
+        group,
+        shape,
+        text,
+        constraintPadding,
+        state
+      } = item
+      const sessionItem = session.items.get(group) as ActiveSelectionShapeScalingSessionItem
+
+      const layoutScale = this._resolveShapeLayoutScale({
+        item,
+        selectionScale
+      })
       const previewDimensions = resolveShapeScalingPreviewDimensions({
         group,
         text,
         constraintPadding,
         startDimensions: state,
-        appliedScaleX: appliedScale.scaleX,
-        appliedScaleY: appliedScale.scaleY
+        appliedScaleX: layoutScale.scaleX,
+        appliedScaleY: layoutScale.scaleY
       })
       const previewLayout = resolveShapeScalingPreviewLayout({
         group,
         text,
         state,
-        appliedScaleX: appliedScale.scaleX,
-        appliedScaleY: appliedScale.scaleY,
+        appliedScaleX: layoutScale.scaleX,
+        appliedScaleY: layoutScale.scaleY,
         minimumHeight: previewDimensions.previewHeight
       })
 
@@ -155,14 +210,16 @@ export default class ShapeActiveSelectionScalingController {
         text,
         layout: previewLayout,
         alignH: group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN,
-        scaleX: appliedScale.scaleX,
-        scaleY: appliedScale.scaleY,
+        scaleX: selectionScale.scaleX,
+        scaleY: selectionScale.scaleY,
         minSize: MIN_SIZE,
         scaleEpsilon: SCALE_EPSILON
       })
 
+      this.groupLayoutScales.set(group, layoutScale)
+      this._restoreShapeOriginInSelection({ group, sessionItem })
       group.setCoords()
-    })
+    }
 
     selection.setCoords()
     this.canvas.requestRenderAll()
@@ -211,6 +268,10 @@ export default class ShapeActiveSelectionScalingController {
     const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
     const alignV = group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN
     const constraintPadding = resolveShapeScalingConstraintPadding({ group })
+    const layoutScale = this.groupLayoutScales.get(group) ?? {
+      scaleX,
+      scaleY
+    }
     const {
       width,
       height,
@@ -225,12 +286,13 @@ export default class ShapeActiveSelectionScalingController {
         canScaleWidth,
         canScaleHeight
       },
-      scaleX,
-      scaleY
+      scaleX: layoutScale.scaleX,
+      scaleY: layoutScale.scaleY
     })
 
     if (!hasDimensionChange) {
       this.shapeScalingState.delete(group)
+      this.groupLayoutScales.delete(group)
       group.shapeScalingNoopTransform = false
       return false
     }
@@ -251,6 +313,7 @@ export default class ShapeActiveSelectionScalingController {
     })
 
     this.shapeScalingState.delete(group)
+    this.groupLayoutScales.delete(group)
     group.shapeScalingNoopTransform = false
 
     return true
@@ -283,6 +346,14 @@ export default class ShapeActiveSelectionScalingController {
    * Очищает состояние масштабирования для переданного ActiveSelection.
    */
   public clearState({ selection }: { selection: ActiveSelection }): void {
+    const session = this.scalingSessions.get(selection)
+    if (session) {
+      for (const group of session.items.keys()) {
+        this.groupLayoutScales.delete(group)
+      }
+    }
+
+    this.scalingSessions.delete(selection)
     this.scalingState.delete(selection)
   }
 
@@ -295,8 +366,8 @@ export default class ShapeActiveSelectionScalingController {
   }: {
     selection: ActiveSelection
     transform: Transform
-  }): ActiveSelectionShapeScalingPreviewItem[] {
-    const items: ActiveSelectionShapeScalingPreviewItem[] = []
+  }): ActiveSelectionShapeScalingItem[] {
+    const items: ActiveSelectionShapeScalingItem[] = []
 
     for (const object of selection.getObjects()) {
       if (!isShapeGroup(object)) continue
@@ -332,16 +403,71 @@ export default class ShapeActiveSelectionScalingController {
   }
 
   /**
-   * Возвращает scale общего выделения, ограниченный минимальными размерами всех shape-групп.
+   * Возвращает runtime-сессию текущего drag в локальной плоскости ActiveSelection.
    */
-  private _resolveAppliedScale({
+  private _ensureScalingSession({
+    selection,
+    transform,
+    items
+  }: {
+    selection: ActiveSelection
+    transform: Transform
+    items: ActiveSelectionShapeScalingItem[]
+  }): ActiveSelectionScalingSession {
+    const existingSession = this.scalingSessions.get(selection)
+    if (existingSession) return existingSession
+
+    const originX = resolveShapeTransformOriginXValue({
+      value: transform.originX
+    }) ?? 'center'
+    const originY = resolveShapeTransformOriginYValue({
+      value: transform.originY
+    }) ?? 'center'
+    const firstItem = items[0] as ActiveSelectionShapeScalingItem
+    const sessionItems = new Map<ShapeGroup, ActiveSelectionShapeScalingSessionItem>()
+    let selectionBounds = this._resolveShapeLocalBounds({
+      group: firstItem.group
+    })
+
+    for (const { group } of items) {
+      const bounds = this._resolveShapeLocalBounds({ group })
+
+      selectionBounds = this._mergeBounds({
+        current: selectionBounds,
+        next: bounds
+      })
+
+      sessionItems.set(group, {
+        bounds,
+        originX,
+        originY,
+        originPoint: group.getPositionByOrigin(originX, originY)
+      })
+    }
+
+    const session = {
+      bounds: selectionBounds,
+      items: sessionItems
+    }
+
+    this.scalingSessions.set(selection, session)
+
+    return session
+  }
+
+  /**
+   * Возвращает scale общего выделения, ограниченный bounds каждой shape-группы внутри ActiveSelection.
+   */
+  private _resolveSelectionScale({
     items,
+    session,
     transform,
     scaleX,
     scaleY,
     event
   }: {
-    items: ActiveSelectionShapeScalingPreviewItem[]
+    items: ActiveSelectionShapeScalingItem[]
+    session: ActiveSelectionScalingSession
     transform: Transform
     scaleX: number
     scaleY: number
@@ -359,27 +485,39 @@ export default class ShapeActiveSelectionScalingController {
     let appliedScaleY = scaleY
 
     if (canScaleWidth) {
-      appliedScaleX = this._resolveMinimumScaleX({
+      appliedScaleX = this._resolveSelectionScaleX({
         items,
+        session,
         scaleX,
-        scaleY: appliedScaleY
+        scaleY: appliedScaleY,
+        allowGrowth: canScaleHeight
       })
     }
 
     if (canScaleHeight) {
-      appliedScaleY = this._resolveMinimumScaleY({
+      appliedScaleY = this._resolveSelectionScaleY({
         items,
+        session,
         scaleX: appliedScaleX,
         scaleY,
-        isVerticalOnlyScale: canScaleHeight && !canScaleWidth
+        allowGrowth: canScaleWidth
       })
     }
 
     if (canScaleWidth && canScaleHeight) {
-      appliedScaleX = this._resolveMinimumScaleX({
+      appliedScaleX = this._resolveSelectionScaleX({
         items,
+        session,
         scaleX,
-        scaleY: appliedScaleY
+        scaleY: appliedScaleY,
+        allowGrowth: canScaleHeight
+      })
+      appliedScaleY = this._resolveSelectionScaleY({
+        items,
+        session,
+        scaleX: appliedScaleX,
+        scaleY,
+        allowGrowth: canScaleWidth
       })
     }
 
@@ -402,101 +540,461 @@ export default class ShapeActiveSelectionScalingController {
   }
 
   /**
-   * Возвращает общий scaleX, при котором каждый shape в выделении остаётся не уже своей минимальной ширины.
+   * Доводит ActiveSelection до minimum boundary на mousemove-кадрах,
+   * где Fabric уже перестал обновлять scale после быстрого движения pointer.
    */
-  private _resolveMinimumScaleX({
+  private _resolveSelectionScaleAtPointerBoundary({
+    selection,
     items,
-    scaleX,
-    scaleY
+    session,
+    transform,
+    selectionScale,
+    event
   }: {
-    items: ActiveSelectionShapeScalingPreviewItem[]
+    selection: ActiveSelection
+    items: ActiveSelectionShapeScalingItem[]
+    session: ActiveSelectionScalingSession
+    transform: Transform
+    selectionScale: ActiveSelectionAppliedScale
+    event?: ShapeScalingPointerEvent
+  }): ActiveSelectionAppliedScale {
+    const {
+      canScaleWidth,
+      canScaleHeight,
+      isCornerScaleAction
+    } = resolveShapeScaleActionAxes({
+      transform
+    })
+    const isShiftPressed = Boolean(event && 'shiftKey' in event && event.shiftKey)
+
+    if (isCornerScaleAction && isShiftPressed) return selectionScale
+
+    const pointerReachedOrPassedOriginX = canScaleWidth && this._hasPointerReachedSelectionScaleOrigin({
+      selection,
+      transform,
+      event,
+      axis: 'x'
+    })
+    const pointerReachedOrPassedOriginY = canScaleHeight && this._hasPointerReachedSelectionScaleOrigin({
+      selection,
+      transform,
+      event,
+      axis: 'y'
+    })
+
+    if (!pointerReachedOrPassedOriginX && !pointerReachedOrPassedOriginY) return selectionScale
+
+    let nextScaleX = selectionScale.scaleX
+    let nextScaleY = selectionScale.scaleY
+
+    if (pointerReachedOrPassedOriginX) {
+      nextScaleX = 0
+    }
+    if (pointerReachedOrPassedOriginY) {
+      nextScaleY = 0
+    }
+
+    return this._resolveSelectionScale({
+      items,
+      session,
+      transform,
+      scaleX: nextScaleX,
+      scaleY: nextScaleY,
+      event
+    })
+  }
+
+  /**
+   * Возвращает scaleX рамки ActiveSelection, при котором все shape-группы остаются внутри bounds выделения.
+   */
+  private _resolveSelectionScaleX({
+    items,
+    session,
+    scaleX,
+    scaleY,
+    allowGrowth
+  }: {
+    items: ActiveSelectionShapeScalingItem[]
+    session: ActiveSelectionScalingSession
     scaleX: number
     scaleY: number
+    allowGrowth: boolean
   }): number {
     let appliedScaleX = scaleX
 
-    for (const {
-      group,
-      text,
-      constraintPadding,
-      state
-    } of items) {
-      const attemptedWidth = Math.max(MIN_SIZE, state.startWidth * scaleX)
-      const isShrinkingX = scaleX < state.lastAllowedScaleX - SCALE_EPSILON
-
-      if (!isShrinkingX) continue
-
-      const attemptedHeight = Math.max(MIN_SIZE, state.startHeight * scaleY)
-      const minimumWidth = resolveMinimumShapeWidthForText({
-        text,
-        padding: constraintPadding,
-        resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
-          group,
-          width,
-          height: attemptedHeight
-        })
+    for (const item of items) {
+      const sessionItem = session.items.get(item.group) as ActiveSelectionShapeScalingSessionItem
+      const minimumWidth = this._resolveMinimumShapeWidth({
+        item,
+        scaleY
+      })
+      const availableWidth = this._resolveSelectionAvailableWidth({
+        selectionBounds: session.bounds,
+        shapeBounds: sessionItem.bounds,
+        originX: sessionItem.originX
+      })
+      const minimumSelectionScaleX = this._resolveMinimumScaleForSize({
+        minimumSize: minimumWidth,
+        startSize: availableWidth,
+        allowGrowth
       })
 
-      if (attemptedWidth >= minimumWidth + SCALE_EPSILON) continue
-
-      const minimumScaleX = Math.max(MIN_SIZE / state.startWidth, minimumWidth / state.startWidth)
-      appliedScaleX = Math.max(appliedScaleX, minimumScaleX)
+      appliedScaleX = Math.max(appliedScaleX, minimumSelectionScaleX)
     }
 
     return appliedScaleX
   }
 
   /**
-   * Возвращает общий scaleY, при котором каждый shape в выделении остаётся не ниже своей минимальной высоты.
+   * Возвращает scaleY рамки ActiveSelection, при котором все shape-группы остаются внутри bounds выделения.
    */
-  private _resolveMinimumScaleY({
+  private _resolveSelectionScaleY({
     items,
+    session,
     scaleX,
     scaleY,
-    isVerticalOnlyScale
+    allowGrowth
   }: {
-    items: ActiveSelectionShapeScalingPreviewItem[]
+    items: ActiveSelectionShapeScalingItem[]
+    session: ActiveSelectionScalingSession
     scaleX: number
     scaleY: number
-    isVerticalOnlyScale: boolean
+    allowGrowth: boolean
   }): number {
     let appliedScaleY = scaleY
 
-    for (const {
+    for (const item of items) {
+      const sessionItem = session.items.get(item.group) as ActiveSelectionShapeScalingSessionItem
+      const layoutScaleX = this._resolveShapeLayoutScaleX({
+        item,
+        selectionScaleX: scaleX,
+        selectionScaleY: scaleY
+      })
+      const minimumHeight = this._resolveMinimumShapeHeight({
+        item,
+        scaleX: layoutScaleX
+      })
+      const availableHeight = this._resolveSelectionAvailableHeight({
+        selectionBounds: session.bounds,
+        shapeBounds: sessionItem.bounds,
+        originY: sessionItem.originY
+      })
+      const minimumSelectionScaleY = this._resolveMinimumScaleForSize({
+        minimumSize: minimumHeight,
+        startSize: availableHeight,
+        allowGrowth
+      })
+
+      appliedScaleY = Math.max(appliedScaleY, minimumSelectionScaleY)
+    }
+
+    return appliedScaleY
+  }
+
+  /**
+   * Возвращает layout scale конкретной shape-группы. Он может отличаться от scale рамки выделения.
+   */
+  private _resolveShapeLayoutScale({
+    item,
+    selectionScale
+  }: {
+    item: ActiveSelectionShapeScalingItem
+    selectionScale: ActiveSelectionAppliedScale
+  }): ActiveSelectionShapeLayoutScale {
+    let scaleX = this._resolveShapeLayoutScaleX({
+      item,
+      selectionScaleX: selectionScale.scaleX,
+      selectionScaleY: selectionScale.scaleY
+    })
+    let scaleY = this._resolveShapeLayoutScaleY({
+      item,
+      scaleX,
+      selectionScaleY: selectionScale.scaleY
+    })
+    scaleX = this._resolveShapeLayoutScaleX({
+      item,
+      selectionScaleX: selectionScale.scaleX,
+      selectionScaleY: scaleY
+    })
+    scaleY = this._resolveShapeLayoutScaleY({
+      item,
+      scaleX,
+      selectionScaleY: selectionScale.scaleY
+    })
+
+    return {
+      scaleX,
+      scaleY
+    }
+  }
+
+  private _resolveShapeLayoutScaleX({
+    item,
+    selectionScaleX,
+    selectionScaleY
+  }: {
+    item: ActiveSelectionShapeScalingItem
+    selectionScaleX: number
+    selectionScaleY: number
+  }): number {
+    const { state } = item
+    if (!state.canScaleWidth) return 1
+
+    const minimumWidth = this._resolveMinimumShapeWidth({
+      item,
+      scaleY: selectionScaleY
+    })
+    const minimumScaleX = this._resolveMinimumScaleForSize({
+      minimumSize: minimumWidth,
+      startSize: state.startWidth,
+      allowGrowth: state.canScaleHeight
+    })
+
+    return Math.max(selectionScaleX, minimumScaleX)
+  }
+
+  private _resolveShapeLayoutScaleY({
+    item,
+    scaleX,
+    selectionScaleY
+  }: {
+    item: ActiveSelectionShapeScalingItem
+    scaleX: number
+    selectionScaleY: number
+  }): number {
+    const { state } = item
+    if (!state.canScaleHeight) return 1
+
+    const minimumHeight = this._resolveMinimumShapeHeight({
+      item,
+      scaleX
+    })
+    const minimumScaleY = this._resolveMinimumScaleForSize({
+      minimumSize: minimumHeight,
+      startSize: state.startHeight,
+      allowGrowth: state.canScaleWidth
+    })
+
+    return Math.max(selectionScaleY, minimumScaleY)
+  }
+
+  private _resolveMinimumShapeWidth({
+    item,
+    scaleY
+  }: {
+    item: ActiveSelectionShapeScalingItem
+    scaleY: number
+  }): number {
+    const {
       group,
       text,
       constraintPadding,
       state
-    } of items) {
-      const isShrinkingY = scaleY < state.lastAllowedScaleY - SCALE_EPSILON
+    } = item
+    const attemptedHeight = Math.max(MIN_SIZE, state.startHeight * scaleY)
 
-      if (!isShrinkingY) continue
-
-      if (
-        isVerticalOnlyScale
-        && state.cannotScaleDownAtStart
-        && scaleY < state.startScaleY - SCALE_EPSILON
-      ) {
-        appliedScaleY = Math.max(appliedScaleY, state.startScaleY)
-        continue
-      }
-
-      const attemptedWidth = Math.max(MIN_SIZE, state.startWidth * scaleX)
-      const attemptedHeight = Math.max(MIN_SIZE, state.startHeight * scaleY)
-      const minimumHeight = resolveMinimumTextFitHeight({
+    return resolveMinimumShapeWidthForText({
+      text,
+      padding: constraintPadding,
+      resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
         group,
-        text,
-        width: attemptedWidth,
-        padding: constraintPadding
+        width,
+        height: attemptedHeight
       })
+    })
+  }
 
-      if (attemptedHeight >= minimumHeight + SCALE_EPSILON) continue
+  private _resolveMinimumScaleForSize({
+    minimumSize,
+    startSize,
+    allowGrowth
+  }: {
+    minimumSize: number
+    startSize: number
+    allowGrowth: boolean
+  }): number {
+    const minimumScale = Math.max(MIN_SIZE / startSize, minimumSize / startSize)
 
-      const minimumScaleY = Math.max(MIN_SIZE / state.startHeight, minimumHeight / state.startHeight)
-      appliedScaleY = Math.max(appliedScaleY, minimumScaleY)
+    if (allowGrowth) return minimumScale
+
+    return Math.min(1, minimumScale)
+  }
+
+  private _resolveMinimumShapeHeight({
+    item,
+    scaleX
+  }: {
+    item: ActiveSelectionShapeScalingItem
+    scaleX: number
+  }): number {
+    const {
+      group,
+      text,
+      constraintPadding,
+      state
+    } = item
+    const attemptedWidth = Math.max(MIN_SIZE, state.startWidth * scaleX)
+
+    return resolveMinimumTextFitHeight({
+      group,
+      text,
+      width: attemptedWidth,
+      padding: constraintPadding
+    })
+  }
+
+  private _resolveSelectionAvailableWidth({
+    selectionBounds,
+    shapeBounds,
+    originX
+  }: {
+    selectionBounds: ActiveSelectionLocalBounds
+    shapeBounds: ActiveSelectionLocalBounds
+    originX: ShapeTransformOriginX
+  }): number {
+    const originOffset = this._resolveOriginOffset({ origin: originX })
+
+    if (originOffset > 0) {
+      return Math.max(MIN_SIZE, shapeBounds.right - selectionBounds.left)
+    }
+    if (originOffset < 0) {
+      return Math.max(MIN_SIZE, selectionBounds.right - shapeBounds.left)
     }
 
-    return appliedScaleY
+    const shapeCenterX = (shapeBounds.left + shapeBounds.right) / 2
+
+    return Math.max(
+      MIN_SIZE,
+      2 * Math.min(
+        shapeCenterX - selectionBounds.left,
+        selectionBounds.right - shapeCenterX
+      )
+    )
+  }
+
+  private _resolveSelectionAvailableHeight({
+    selectionBounds,
+    shapeBounds,
+    originY
+  }: {
+    selectionBounds: ActiveSelectionLocalBounds
+    shapeBounds: ActiveSelectionLocalBounds
+    originY: ShapeTransformOriginY
+  }): number {
+    const originOffset = this._resolveOriginOffset({ origin: originY })
+
+    if (originOffset > 0) {
+      return Math.max(MIN_SIZE, shapeBounds.bottom - selectionBounds.top)
+    }
+    if (originOffset < 0) {
+      return Math.max(MIN_SIZE, selectionBounds.bottom - shapeBounds.top)
+    }
+
+    const shapeCenterY = (shapeBounds.top + shapeBounds.bottom) / 2
+
+    return Math.max(
+      MIN_SIZE,
+      2 * Math.min(
+        shapeCenterY - selectionBounds.top,
+        selectionBounds.bottom - shapeCenterY
+      )
+    )
+  }
+
+  private _resolveShapeLocalBounds({
+    group
+  }: {
+    group: ShapeGroup
+  }): ActiveSelectionLocalBounds {
+    const topLeft = group.getPositionByOrigin('left', 'top')
+    const bottomRight = group.getPositionByOrigin('right', 'bottom')
+
+    return {
+      bottom: bottomRight.y,
+      left: topLeft.x,
+      right: bottomRight.x,
+      top: topLeft.y
+    }
+  }
+
+  private _mergeBounds({
+    current,
+    next
+  }: {
+    current: ActiveSelectionLocalBounds
+    next: ActiveSelectionLocalBounds
+  }): ActiveSelectionLocalBounds {
+    return {
+      bottom: Math.max(current.bottom, next.bottom),
+      left: Math.min(current.left, next.left),
+      right: Math.max(current.right, next.right),
+      top: Math.min(current.top, next.top)
+    }
+  }
+
+  private _resolveOriginOffset({
+    origin
+  }: {
+    origin: ShapeTransformOriginX | ShapeTransformOriginY
+  }): number {
+    if (origin === 'left' || origin === 'top') return -0.5
+    if (origin === 'right' || origin === 'bottom') return 0.5
+    if (origin === 'center') return 0
+
+    return origin - 0.5
+  }
+
+  private _restoreShapeOriginInSelection({
+    group,
+    sessionItem
+  }: {
+    group: ShapeGroup
+    sessionItem: ActiveSelectionShapeScalingSessionItem
+  }): void {
+    group.setPositionByOrigin(
+      sessionItem.originPoint,
+      sessionItem.originX,
+      sessionItem.originY
+    )
+  }
+
+  /**
+   * Возвращает true, если pointer уже дошёл до origin активного scale-transform по переданной оси.
+   */
+  private _hasPointerReachedSelectionScaleOrigin({
+    selection,
+    transform,
+    event,
+    axis
+  }: {
+    selection: ActiveSelection
+    transform: Transform
+    event?: ShapeScalingPointerEvent
+    axis: 'x' | 'y'
+  }): boolean {
+    const transformWithSign = transform as Transform & {
+      signX?: number
+      signY?: number
+    }
+    const sign = axis === 'x'
+      ? transformWithSign.signX
+      : transformWithSign.signY
+
+    if (typeof sign !== 'number' || !Number.isFinite(sign)) return false
+
+    const localPoint = resolveScaleLocalPointerForTransform({
+      target: selection,
+      transform,
+      event,
+      canvas: this.canvas
+    })
+    if (!localPoint) return false
+
+    const pointCoordinate = axis === 'x'
+      ? localPoint.x
+      : localPoint.y
+
+    return (pointCoordinate * sign) <= 0
   }
 
   /**

--- a/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
@@ -41,7 +41,8 @@ import {
   resolveShapeScalingPreviewLayout,
   resolveShapeScalingStartDimensions,
   SHAPE_SCALING_MIN_SIZE as MIN_SIZE,
-  SHAPE_SCALING_SCALE_EPSILON as SCALE_EPSILON
+  SHAPE_SCALING_SCALE_EPSILON as SCALE_EPSILON,
+  SHAPE_SCALING_SIZE_EPSILON as SIZE_EPSILON
 } from './shape-scaling-layout'
 import type {
   ShapeScalingPointerEvent
@@ -60,6 +61,8 @@ export type ActiveSelectionAppliedScale = {
   scaleY: number
 }
 
+type ActiveSelectionVerticalAttachment = 'top' | 'bottom' | 'center'
+
 type ActiveSelectionLocalBounds = {
   left: number
   right: number
@@ -69,9 +72,9 @@ type ActiveSelectionLocalBounds = {
 
 type ActiveSelectionShapeScalingSessionItem = {
   bounds: ActiveSelectionLocalBounds
-  originX: ShapeTransformOriginX
-  originY: ShapeTransformOriginY
-  originPoint: Point
+  transformOriginX: ShapeTransformOriginX
+  transformOriginPointX: number
+  verticalAttachment: ActiveSelectionVerticalAttachment
 }
 
 type ActiveSelectionShapeLayoutScale = {
@@ -217,7 +220,10 @@ export default class ShapeActiveSelectionScalingController {
       })
 
       this.groupLayoutScales.set(group, layoutScale)
-      this._restoreShapeOriginInSelection({ group, sessionItem })
+      this._positionShapeInSelection({
+        group,
+        sessionItem
+      })
       group.setCoords()
     }
 
@@ -417,13 +423,14 @@ export default class ShapeActiveSelectionScalingController {
     const existingSession = this.scalingSessions.get(selection)
     if (existingSession) return existingSession
 
-    const originX = resolveShapeTransformOriginXValue({
+    const transformOriginX = resolveShapeTransformOriginXValue({
       value: transform.originX
     }) ?? 'center'
-    const originY = resolveShapeTransformOriginYValue({
+    const transformOriginY = resolveShapeTransformOriginYValue({
       value: transform.originY
     }) ?? 'center'
     const firstItem = items[0] as ActiveSelectionShapeScalingItem
+    const shapeBoundsByGroup = new Map<ShapeGroup, ActiveSelectionLocalBounds>()
     const sessionItems = new Map<ShapeGroup, ActiveSelectionShapeScalingSessionItem>()
     let selectionBounds = this._resolveShapeLocalBounds({
       group: firstItem.group
@@ -432,16 +439,25 @@ export default class ShapeActiveSelectionScalingController {
     for (const { group } of items) {
       const bounds = this._resolveShapeLocalBounds({ group })
 
+      shapeBoundsByGroup.set(group, bounds)
+
       selectionBounds = this._mergeBounds({
         current: selectionBounds,
         next: bounds
       })
+    }
+
+    for (const [group, bounds] of shapeBoundsByGroup) {
+      const transformOriginPoint = group.getPositionByOrigin(transformOriginX, transformOriginY)
 
       sessionItems.set(group, {
         bounds,
-        originX,
-        originY,
-        originPoint: group.getPositionByOrigin(originX, originY)
+        transformOriginX,
+        transformOriginPointX: transformOriginPoint.x,
+        verticalAttachment: this._resolveVerticalAttachment({
+          selectionBounds,
+          shapeBounds: bounds
+        })
       })
     }
 
@@ -631,7 +647,7 @@ export default class ShapeActiveSelectionScalingController {
       const availableWidth = this._resolveSelectionAvailableWidth({
         selectionBounds: session.bounds,
         shapeBounds: sessionItem.bounds,
-        originX: sessionItem.originX
+        originX: sessionItem.transformOriginX
       })
       const minimumSelectionScaleX = this._resolveMinimumScaleForSize({
         minimumSize: minimumWidth,
@@ -677,7 +693,7 @@ export default class ShapeActiveSelectionScalingController {
       const availableHeight = this._resolveSelectionAvailableHeight({
         selectionBounds: session.bounds,
         shapeBounds: sessionItem.bounds,
-        originY: sessionItem.originY
+        verticalAttachment: sessionItem.verticalAttachment
       })
       const minimumSelectionScaleY = this._resolveMinimumScaleForSize({
         minimumSize: minimumHeight,
@@ -875,19 +891,18 @@ export default class ShapeActiveSelectionScalingController {
   private _resolveSelectionAvailableHeight({
     selectionBounds,
     shapeBounds,
-    originY
+    verticalAttachment
   }: {
     selectionBounds: ActiveSelectionLocalBounds
     shapeBounds: ActiveSelectionLocalBounds
-    originY: ShapeTransformOriginY
+    verticalAttachment: ActiveSelectionVerticalAttachment
   }): number {
-    const originOffset = this._resolveOriginOffset({ origin: originY })
-
-    if (originOffset > 0) {
-      return Math.max(MIN_SIZE, shapeBounds.bottom - selectionBounds.top)
-    }
-    if (originOffset < 0) {
+    if (verticalAttachment === 'top') {
       return Math.max(MIN_SIZE, selectionBounds.bottom - shapeBounds.top)
+    }
+
+    if (verticalAttachment === 'bottom') {
+      return Math.max(MIN_SIZE, shapeBounds.bottom - selectionBounds.top)
     }
 
     const shapeCenterY = (shapeBounds.top + shapeBounds.bottom) / 2
@@ -932,6 +947,25 @@ export default class ShapeActiveSelectionScalingController {
     }
   }
 
+  private _resolveVerticalAttachment({
+    selectionBounds,
+    shapeBounds
+  }: {
+    selectionBounds: ActiveSelectionLocalBounds
+    shapeBounds: ActiveSelectionLocalBounds
+  }): ActiveSelectionVerticalAttachment {
+    const topGap = Math.max(0, shapeBounds.top - selectionBounds.top)
+    const bottomGap = Math.max(0, selectionBounds.bottom - shapeBounds.bottom)
+    const isTopAttached = topGap <= SIZE_EPSILON
+    const isBottomAttached = bottomGap <= SIZE_EPSILON
+
+    if (isTopAttached && !isBottomAttached) return 'top'
+    if (isBottomAttached && !isTopAttached) return 'bottom'
+    if (Math.abs(topGap - bottomGap) <= SIZE_EPSILON) return 'center'
+
+    return topGap < bottomGap ? 'top' : 'bottom'
+  }
+
   private _resolveOriginOffset({
     origin
   }: {
@@ -944,17 +978,48 @@ export default class ShapeActiveSelectionScalingController {
     return origin - 0.5
   }
 
-  private _restoreShapeOriginInSelection({
+  /**
+   * Позиционирует shape по тому же vertical attachment, по которому считается clamp рамки.
+   * Координаты остаются в стартовой плоскости объектов; текущий transform ActiveSelection переводит их в preview.
+   */
+  private _positionShapeInSelection({
     group,
     sessionItem
   }: {
     group: ShapeGroup
     sessionItem: ActiveSelectionShapeScalingSessionItem
   }): void {
+    const {
+      bounds,
+      transformOriginX,
+      transformOriginPointX,
+      verticalAttachment
+    } = sessionItem
+
+    if (verticalAttachment === 'top') {
+      group.setPositionByOrigin(
+        new Point(transformOriginPointX, bounds.top),
+        transformOriginX,
+        'top'
+      )
+
+      return
+    }
+
+    if (verticalAttachment === 'bottom') {
+      group.setPositionByOrigin(
+        new Point(transformOriginPointX, bounds.bottom),
+        transformOriginX,
+        'bottom'
+      )
+
+      return
+    }
+
     group.setPositionByOrigin(
-      sessionItem.originPoint,
-      sessionItem.originX,
-      sessionItem.originY
+      new Point(transformOriginPointX, (bounds.top + bounds.bottom) / 2),
+      transformOriginX,
+      'center'
     )
   }
 

--- a/src/editor/shape-manager/scaling/shape-scaling-transform.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling-transform.ts
@@ -1,7 +1,8 @@
 import {
   Canvas,
   Point,
-  Transform
+  Transform,
+  type FabricObject
 } from 'fabric'
 import type {
   ShapeGroup,
@@ -102,37 +103,37 @@ export const resolveShapeScaleActionAxes = ({
 /**
  * Пересчитывает pointer из canvas-события в локальные координаты активного scale-transform.
  */
-export const resolveShapeLocalPointerForTransform = ({
+export const resolveScaleLocalPointerForTransform = ({
   event,
-  group,
+  target,
   transform,
   canvas
 }: {
   event?: ShapeScalingPointerEvent
-  group: ShapeGroup
+  target: FabricObject
   transform: Transform
   canvas: Canvas
 }): Point | null => {
   if (!event) return null
 
-  const resolvedCanvas = group.canvas ?? canvas
+  const resolvedCanvas = target.canvas ?? canvas
   const pointer = resolvedCanvas.getScenePoint(event as MouseEvent | PointerEvent | TouchEvent)
-  const centerPoint = group.getRelativeCenterPoint()
-  const originPoint = group.translateToGivenOrigin(
+  const centerPoint = target.getRelativeCenterPoint()
+  const originPoint = target.translateToGivenOrigin(
     centerPoint,
     'center',
     'center',
     transform.originX,
     transform.originY
   )
-  const angle = group.angle ?? 0
+  const angle = target.angle ?? 0
   const normalizedPointer = angle === 0
     ? pointer
     : pointer.rotate((-angle * Math.PI) / 180, centerPoint)
   const localPoint = normalizedPointer.subtract(originPoint)
-  const control = group.controls[transform.corner]
+  const control = target.controls[transform.corner]
   const zoom = resolvedCanvas.getZoom() || 1
-  const padding = (group.padding ?? 0) / zoom
+  const padding = (target.padding ?? 0) / zoom
 
   if (localPoint.x >= padding) {
     localPoint.x -= padding

--- a/src/editor/shape-manager/scaling/shape-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling.ts
@@ -28,7 +28,7 @@ import {
 import {
   isShapeTransformCornerChanged,
   isShapeTransformOriginChanged,
-  resolveShapeLocalPointerForTransform,
+  resolveScaleLocalPointerForTransform,
   resolveShapeScaleActionAxes
 } from './shape-scaling-transform'
 import { applyShapeScalingPreviewLayout } from './shape-scaling-preview'
@@ -964,9 +964,9 @@ export default class ShapeScalingController {
       : transformWithSign.signY
     if (typeof sign !== 'number' || !Number.isFinite(sign)) return false
 
-    const localPoint = resolveShapeLocalPointerForTransform({
+    const localPoint = resolveScaleLocalPointerForTransform({
       event: event.e,
-      group,
+      target: group,
       transform,
       canvas: this.canvas
     })


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавляем 2 шейпа с текстом "TEST", у одно шейпа высота будет примерно в 2 раза больше первого (скрин 1)

<img width="512" height="496" alt="image" src="https://github.com/user-attachments/assets/a0a0afbd-ef8e-4df1-b79d-7f402383e376" />

2. Выделяем оба шейпа как одно массовое выделение (activeselection) и уменьшаем их высоту путём вертикального скейлинга

Ожидаемый результат.

В процессе уменьшения высоты мы упираемся в минимальную высоту шейпов внутри массового выделения

Фактический результат.

В процессе уменьшения высоты мы упираемся в минимальную высоту шейпа слева, при этом высоту шейпа справа уменьшить до конца не получается (скрин 2). Для этого его нужно выделить отдельно и уменьшить высоту (скрин 3)

<img width="552" height="539" alt="image" src="https://github.com/user-attachments/assets/f3ec7352-9c82-4b12-9a38-46c24357f759" />

<img width="449" height="392" alt="image" src="https://github.com/user-attachments/assets/bf6d6e1a-5ed7-45d0-bb18-23ece49bf9fb" />

Всё что описано выше мы точно так же должны учитывать и при скейлинге по диагонали, когда происходит одновременное уменьшение высоты и ширины.

---

FIXED.