### PR TITLE
ShapeManager. Фиксим баг когда после изменения угла поворота задание отступов или скругления сбрасывало угол поворота шейпа.

### DIFF
--- a/e2e/models/history.model.ts
+++ b/e2e/models/history.model.ts
@@ -29,6 +29,16 @@ export class HistoryModel {
     await waitForCanvasRender({ page: this.page })
   }
 
+  /** Явно сохраняет текущее состояние canvas в историю */
+  async saveState(): Promise<void> {
+    await this.page.evaluate(() => {
+      const { editor } = window as any
+      editor.historyManager.saveState()
+    })
+
+    await waitForCanvasRender({ page: this.page })
+  }
+
   /** Принудительно фиксирует отложенное сохранение после text editing */
   async flushPendingSave(): Promise<boolean> {
     return this.page.evaluate(() => {

--- a/e2e/models/shape.model.ts
+++ b/e2e/models/shape.model.ts
@@ -1370,6 +1370,26 @@ export class ShapeModel {
     return snapshot as ShapeScaleSnapshot
   }
 
+  /**
+   * Устанавливает абсолютный угол поворота фигуры.
+   * Использует TransformManager для корректного применения трансформации и сохранения в историю.
+   */
+  async setAngle(params: { angle: number } & ObjectTargetParams): Promise<void> {
+    await this.page.evaluate(({ angle, objectIndex, id }) => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+
+      const target = helpers.resolveCanvasObject(objectIndex, id)
+      if (!target) return
+
+      editor.transformManager.setAngle(target, angle)
+    }, params)
+
+    await waitForCanvasRender({ page: this.page })
+  }
+
   /** Обновляет shape — меняет пресет, размеры, стили. Сохраняет позицию и текст */
   async update(params: ShapeUpdateParams & ObjectTargetParams = {}): Promise<ShapeObjectInfo | null> {
     const shape = await this.page.evaluate(async({ presetKey, options, objectIndex, id }) => {

--- a/e2e/tests/shape-manager/shape-rotation.spec.ts
+++ b/e2e/tests/shape-manager/shape-rotation.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  SHAPE_ROUNDING_UPDATED_VALUE
+} from '../../fixtures/data/shape-rounding.data'
+
+test.describe('Повёрнутая фигура', () => {
+  test('после поворота обновление скругления не сбрасывает угол', async({ shapes }) => {
+    const createdShape = await test.step('Добавить прямоугольник с текстом', () => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          id: 'shape-rotation-rounding',
+          text: 'Текст',
+          textStyle: { fontSize: 32 }
+        }
+      })
+    })
+
+    shapes.checkCreation({ shape: createdShape, presetKey: 'square' })
+
+    await test.step('Повернуть фигуру на 45°', () => {
+      return shapes.setAngle({ id: 'shape-rotation-rounding', angle: 45 })
+    })
+
+    await test.step('Изменить скругление', () => {
+      return shapes.setRounding({ id: 'shape-rotation-rounding', rounding: SHAPE_ROUNDING_UPDATED_VALUE })
+    })
+
+    const updatedShape = await test.step('Получить состояние после изменения скругления', () => {
+      return shapes.getObject({ id: 'shape-rotation-rounding' })
+    })
+    const updatedSnapshot = await test.step('Получить геометрию после изменения скругления', () => {
+      return shapes.getScaleSnapshot({ id: 'shape-rotation-rounding' })
+    })
+
+    await test.step('Проверить что угол не сбросился, а скругление применилось', () => {
+      expect(updatedShape?.angle).toBeCloseTo(45, 1)
+      expect(updatedShape?.shapePresetKey).toBe('square')
+      expect(updatedShape?.shapeRounding).toBe(SHAPE_ROUNDING_UPDATED_VALUE)
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'shape' })
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'text' })
+    })
+  })
+
+  test('после поворота обновление отступов текста не сбрасывает угол', async({ shapes }) => {
+    const createdShape = await test.step('Добавить прямоугольник с текстом', () => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          id: 'shape-rotation-padding',
+          text: 'Текст',
+          textStyle: { fontSize: 32 }
+        }
+      })
+    })
+
+    shapes.checkCreation({ shape: createdShape, presetKey: 'square' })
+
+    await test.step('Повернуть фигуру на 45°', () => {
+      return shapes.setAngle({ id: 'shape-rotation-padding', angle: 45 })
+    })
+
+    await test.step('Изменить отступы текста', () => {
+      return shapes.update({
+        id: 'shape-rotation-padding',
+        options: {
+          textPadding: { top: 50 }
+        }
+      })
+    })
+
+    const updatedShape = await test.step('Получить состояние после изменения отступов', () => {
+      return shapes.getObject({ id: 'shape-rotation-padding' })
+    })
+    const updatedSnapshot = await test.step('Получить геометрию после изменения отступов', () => {
+      return shapes.getScaleSnapshot({ id: 'shape-rotation-padding' })
+    })
+
+    await test.step('Проверить что угол не сбросился, а отступы применились', () => {
+      expect(updatedShape?.angle).toBeCloseTo(45, 1)
+      expect(updatedShape?.shapePresetKey).toBe('square')
+      expect(updatedShape?.shapePaddingTop).toBe(50)
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'shape' })
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'text' })
+    })
+  })
+
+  test('после поворота замена пресета не сбрасывает угол', async({ shapes }) => {
+    const createdShape = await test.step('Добавить прямоугольник с текстом', () => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          id: 'shape-rotation-replace',
+          text: 'Текст',
+          textStyle: { fontSize: 32 }
+        }
+      })
+    })
+
+    shapes.checkCreation({ shape: createdShape, presetKey: 'square' })
+
+    await test.step('Повернуть фигуру на 45°', () => {
+      return shapes.setAngle({ id: 'shape-rotation-replace', angle: 45 })
+    })
+
+    const updatedShape = await test.step('Сменить прямоугольник на круг', () => {
+      return shapes.update({
+        id: 'shape-rotation-replace',
+        presetKey: 'circle'
+      })
+    })
+
+    const updatedSnapshot = await test.step('Получить геометрию после замены', () => {
+      return shapes.getScaleSnapshot({ id: 'shape-rotation-replace' })
+    })
+
+    await test.step('Проверить что угол не сбросился, а пресет сменился', () => {
+      expect(updatedShape?.angle).toBeCloseTo(45, 1)
+      expect(updatedShape?.shapePresetKey).toBe('circle')
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'shape' })
+      shapes.checkNodeInsideGroup({ snapshot: updatedSnapshot, kind: 'text' })
+    })
+  })
+
+  test('undo/redo после обновления повёрнутой фигуры возвращает повёрнутое состояние', async({ history, shapes }) => {
+    const createdShape = await test.step('Добавить прямоугольник с текстом', () => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          id: 'shape-rotation-undo',
+          text: 'Текст',
+          textStyle: { fontSize: 32 }
+        }
+      })
+    })
+
+    shapes.checkCreation({ shape: createdShape, presetKey: 'square' })
+
+    await test.step('Повернуть фигуру на 45°', () => {
+      return shapes.setAngle({ id: 'shape-rotation-undo', angle: 45 })
+    })
+
+    const beforeUpdate = await test.step('Получить состояние до обновления скругления', () => {
+      return shapes.getObject({ id: 'shape-rotation-undo' })
+    })
+
+    await test.step('Изменить скругление', () => {
+      return shapes.setRounding({ id: 'shape-rotation-undo', rounding: SHAPE_ROUNDING_UPDATED_VALUE })
+    })
+
+    const afterUpdate = await test.step('Получить состояние после обновления скругления', () => {
+      return shapes.getObject({ id: 'shape-rotation-undo' })
+    })
+
+    await test.step('Проверить что скругление изменилось, а угол остался 45°', () => {
+      expect(afterUpdate?.angle).toBeCloseTo(45, 1)
+      expect(afterUpdate?.shapeRounding).toBe(SHAPE_ROUNDING_UPDATED_VALUE)
+    })
+
+    await test.step('Отменить обновление', () => {
+      return history.undo()
+    })
+
+    const afterUndo = await test.step('Получить состояние после undo', () => {
+      return shapes.getObject({ id: 'shape-rotation-undo' })
+    })
+
+    await test.step('Проверить что скругление вернулось к исходному, а угол остался 45°', () => {
+      expect(afterUndo?.angle).toBeCloseTo(45, 1)
+      expect(afterUndo?.shapeRounding).toBe(beforeUpdate?.shapeRounding)
+    })
+
+    await test.step('Повторить обновление', () => {
+      return history.redo()
+    })
+
+    const afterRedo = await test.step('Получить состояние после redo', () => {
+      return shapes.getObject({ id: 'shape-rotation-undo' })
+    })
+
+    await test.step('Проверить что скругление снова применилось, а угол остался 45°', () => {
+      expect(afterRedo?.angle).toBeCloseTo(45, 1)
+      expect(afterRedo?.shapeRounding).toBe(SHAPE_ROUNDING_UPDATED_VALUE)
+    })
+  })
+})

--- a/specs/__mocks__/fabric.ts
+++ b/specs/__mocks__/fabric.ts
@@ -229,6 +229,8 @@ export class Group {
 
   height = 100
 
+  canvas: any = null
+
   controls: Record<string, unknown> = {}
 
   _objects: any[] = []
@@ -309,6 +311,23 @@ export class Group {
     }
 
     return objects
+  }
+
+  enterGroup(object: any, _removeParentTransform?: boolean): void {
+    object.group = this
+    object.parent = this
+    object.canvas = this.canvas
+    object.setCoords()
+  }
+
+  exitGroup(object: any, _removeParentTransform?: boolean): void {
+    object.group = undefined
+    object.parent = undefined
+    object.canvas = undefined
+  }
+
+  _set(key: string, value: any): void {
+    (this as any)[key] = value
   }
 
   set(props: any) {

--- a/src/editor/shape-manager/index.ts
+++ b/src/editor/shape-manager/index.ts
@@ -716,8 +716,12 @@ export default class ShapeManager {
         syncLineStylesWithText
       })
 
-      currentGroup.remove(currentShapeNode)
-      currentGroup.insertAt(currentShapeIndex, shape)
+      const groupRef = currentGroup as ShapeGroupObject
+      groupRef.replaceShapeNode(
+        currentShapeIndex,
+        currentShapeNode,
+        shape
+      )
 
       this._applyShapeGroupMetadata({
         group: currentGroup,

--- a/src/editor/shape-manager/shape-group.ts
+++ b/src/editor/shape-manager/shape-group.ts
@@ -209,6 +209,27 @@ export class ShapeGroupObject extends Group {
   }
 
   /**
+   * Заменяет внутренний shape-узел группы без пересчёта через матрицу группы.
+   *
+   * Generic Group.remove() + insertAt() здесь использовать нельзя:
+   * createShapeNode() уже возвращает child в локальной системе координат группы,
+   * а insertAt() повторно применил бы обратное преобразование через матрицу группы.
+   */
+  public replaceShapeNode(
+    index: number,
+    oldNode: FabricObject,
+    newNode: FabricObject
+  ): void {
+    this._objects.splice(index, 1)
+    this.exitGroup(oldNode, true)
+
+    this._objects.splice(index, 0, newNode)
+    this.enterGroup(newNode, false)
+
+    this._set('dirty', true)
+  }
+
+  /**
    * Гарантирует консистентность производных shape-свойств после materialization.
    */
   private _syncRoundability(): void {

--- a/src/editor/transform-manager/index.ts
+++ b/src/editor/transform-manager/index.ts
@@ -28,21 +28,24 @@ export default class TransformManager {
   }
 
   /**
-   * Поворот объекта на заданный угол
-   * @param angle
+   * Устанавливает абсолютный угол поворота объекта
+   * @param object - Целевой объект
+   * @param angle - Абсолютный угол в градусах
    * @param options
    * @param options.withoutSave - Не сохранять состояние
    * @fires editor:object-rotated
    */
-  public rotate(angle: number = DEFAULT_ROTATE_RATIO, { withoutSave }: { withoutSave?: boolean } = {}): void {
+  public setAngle(
+    object: FabricObject,
+    angle: number,
+    { withoutSave }: { withoutSave?: boolean } = {}
+  ): void {
     const { canvas, historyManager } = this.editor
 
-    const obj = canvas.getActiveObject()
-    if (!obj) return
-    const newAngle = obj.angle + angle
-    obj.rotate(newAngle)
-    obj.setCoords()
+    if (!object) return
 
+    object.rotate(angle)
+    object.setCoords()
     canvas.renderAll()
 
     if (!withoutSave) {
@@ -50,10 +53,27 @@ export default class TransformManager {
     }
 
     canvas.fire('editor:object-rotated', {
-      object: obj,
+      object,
       withoutSave,
-      angle: newAngle
+      angle
     })
+  }
+
+  /**
+   * Поворот активного объекта на относительный угол
+   * @param angle
+   * @param options
+   * @param options.withoutSave - Не сохранять состояние
+   * @fires editor:object-rotated
+   */
+  public rotate(angle: number = DEFAULT_ROTATE_RATIO, { withoutSave }: { withoutSave?: boolean } = {}): void {
+    const { canvas } = this.editor
+
+    const obj = canvas.getActiveObject()
+    if (!obj) return
+
+    const newAngle = (obj.angle ?? 0) + angle
+    this.setAngle(obj, newAngle, { withoutSave })
   }
 
   /**


### PR DESCRIPTION
Порядок воспроизведения

1. Добавить шейп с текстом "TEST" (скрин 1)

<img width="520" height="495" alt="image" src="https://github.com/user-attachments/assets/d8487a83-72e2-439c-abc4-4c91469c4256" />

2. Повернуть шейп на 45 градусов (скрин 2)

<img width="481" height="404" alt="image" src="https://github.com/user-attachments/assets/f85f7b48-977e-4c4b-9476-b722feb7c6e6" />

3. Применить отступы или скругление углов, или замену пресета для шейпа

Ожидаемый результат.

Скругление и отступы корректно применились, угол поворота объекта не сбросился, выделение осталось на месте.

Фактический результат.

Скругление корректно применились, но угол поворота объекта шейпа сбросился до нуля, при этом, текстовый объект внутри shape-group и область выделения объекта остались под углом 45 градусов (скрин 3)

<img width="1185" height="630" alt="image" src="https://github.com/user-attachments/assets/e9dec59e-5479-4d7b-a82c-823f4437173c" />

---

FIXED.