### PR TITLE
ShapeManager. Для пресета arrow-right-fat задаём internal вертикальные отступы чтобы текст не выходил за пределы

### DIFF
--- a/src/editor/shape-manager/shape-presets.ts
+++ b/src/editor/shape-manager/shape-presets.ts
@@ -277,9 +277,9 @@ const shapePresetsList: ShapePreset[] = [
       { x: 0, y: 62 }
     ],
     internalTextInset: {
-      top: 0.34,
+      top: 0.3,
       right: 0.42,
-      bottom: 0.34,
+      bottom: 0.3,
       left: 0.16
     }
   },

--- a/src/editor/shape-manager/shape-presets.ts
+++ b/src/editor/shape-manager/shape-presets.ts
@@ -277,9 +277,9 @@ const shapePresetsList: ShapePreset[] = [
       { x: 0, y: 62 }
     ],
     internalTextInset: {
-      top: 0.24,
+      top: 0.34,
       right: 0.42,
-      bottom: 0.24,
+      bottom: 0.34,
       left: 0.16
     }
   },


### PR DESCRIPTION
Before:

<img width="411" height="342" alt="image" src="https://github.com/user-attachments/assets/9923a595-cf1d-47ff-9b1d-45a34ae79b8e" />

After:

<img width="458" height="460" alt="image" src="https://github.com/user-attachments/assets/b8d7aa7b-a9d4-471a-a2db-4b8fbe012746" />
