### PR TITLE
ShapeManager. Фиксим проблемы при работе скейлинга для шейпа с многострочным текстом и установленным пресетом.

### DIFF
--- a/badges/coverage-total.svg
+++ b/badges/coverage-total.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="126" height="20" role="img" aria-label="unit coverage: 82%">
+<svg xmlns="http://www.w3.org/2000/svg" width="126" height="20" role="img" aria-label="unit coverage: 85%">
 <linearGradient id="s" x2="0" y2="100%">
   <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
   <stop offset="1" stop-opacity=".1"/>
@@ -14,7 +14,7 @@
 <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
   <text x="47" y="15" fill="#010101" fill-opacity=".3">unit coverage</text>
   <text x="47" y="14">unit coverage</text>
-  <text x="110" y="15" fill="#010101" fill-opacity=".3">82%</text>
-  <text x="110" y="14">82%</text>
+  <text x="110" y="15" fill="#010101" fill-opacity=".3">85%</text>
+  <text x="110" y="14">85%</text>
 </g>
 </svg>

--- a/e2e/fixtures/data/shape-scaling-multiline-arrow.data.ts
+++ b/e2e/fixtures/data/shape-scaling-multiline-arrow.data.ts
@@ -1,0 +1,100 @@
+/* eslint-disable max-len */
+export type MultilineArrowSingleShapeScenario =
+  | {
+    title: string
+    axis: 'horizontal'
+    edge: 'left' | 'right'
+  }
+  | {
+    title: string
+    axis: 'diagonal'
+    corner: 'tr' | 'br'
+  }
+
+export type MultilineArrowSelectionScenario =
+  | {
+    title: string
+    axis: 'horizontal'
+  }
+  | {
+    title: string
+    axis: 'vertical'
+  }
+  | {
+    title: string
+    axis: 'diagonal'
+    corner: 'tr' | 'br'
+  }
+
+export const MULTILINE_ARROW_TEXT = 'TEST\nTEST\nTEST\nTEST'
+export const MULTILINE_ARROW_SCALE_CYCLES = 10
+export const MULTILINE_ARROW_EXPAND_BASE_SCALE = 1.12
+export const MULTILINE_ARROW_EXPAND_SCALE_STEP = 0.02
+export const MULTILINE_ARROW_SELECTION_MINIMUM_SIZE = 20
+export const MULTILINE_ARROW_SINGLE_SHAPE_ID = 'multiline-arrow-scaling-shape'
+export const MULTILINE_ARROW_SINGLE_SHAPE_BOUNDS = {
+  leftOffset: 120,
+  topOffset: 120,
+  width: 280,
+  height: 220
+}
+export const MULTILINE_ARROW_SELECTION_SHAPES = [
+  {
+    id: 'multiline-arrow-selection-first',
+    leftOffset: 100,
+    topOffset: 120,
+    width: 260,
+    height: 220
+  },
+  {
+    id: 'multiline-arrow-selection-second',
+    leftOffset: 430,
+    topOffset: 240,
+    width: 260,
+    height: 220
+  }
+] as const
+
+export const MULTILINE_ARROW_SINGLE_SHAPE_SCENARIOS = [
+  {
+    title: 'если в одном drag несколько раз сузить multiline arrow-right-fat справа до упора, шейп и текст каждый раз остаются в той же геометрии',
+    axis: 'horizontal',
+    edge: 'right'
+  },
+  {
+    title: 'если в одном drag несколько раз сузить multiline arrow-right-fat слева до упора, шейп и текст каждый раз остаются в той же геометрии',
+    axis: 'horizontal',
+    edge: 'left'
+  },
+  {
+    title: 'если в одном drag несколько раз уменьшить multiline arrow-right-fat по диагонали из правого нижнего угла до упора, шейп и текст не прыгают',
+    axis: 'diagonal',
+    corner: 'br'
+  },
+  {
+    title: 'если в одном drag несколько раз уменьшить multiline arrow-right-fat по диагонали из правого верхнего угла до упора, шейп и текст не прыгают',
+    axis: 'diagonal',
+    corner: 'tr'
+  }
+] as const satisfies readonly MultilineArrowSingleShapeScenario[]
+
+export const MULTILINE_ARROW_SELECTION_SCENARIOS = [
+  {
+    title: 'если в одном drag несколько раз сузить общее выделение справа до упора, обе multiline arrow-right-fat остаются в той же геометрии',
+    axis: 'horizontal'
+  },
+  {
+    title: 'если в одном drag несколько раз вернуть общее выделение сверху до упора, обе multiline arrow-right-fat остаются в той же геометрии',
+    axis: 'vertical'
+  },
+  {
+    title: 'если в одном drag несколько раз уменьшить общее выделение по диагонали из правого нижнего угла до упора, обе multiline arrow-right-fat не прыгают',
+    axis: 'diagonal',
+    corner: 'br'
+  },
+  {
+    title: 'если в одном drag несколько раз уменьшить общее выделение по диагонали из правого верхнего угла до упора, обе multiline arrow-right-fat не прыгают',
+    axis: 'diagonal',
+    corner: 'tr'
+  }
+] as const satisfies readonly MultilineArrowSelectionScenario[]

--- a/e2e/helpers/browser/editor-browser-helpers.installer.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.installer.ts
@@ -1,5 +1,7 @@
 import type {
   BrowserEditorHelpers,
+  BrowserSelectionScaleFromControlParams,
+  BrowserSelectionScaleFromControlResult,
   BoundsInfo,
   BrowserBoundedObject,
   BrowserEditorWindow,
@@ -904,6 +906,103 @@ export function installEditorBrowserHelpers(): void {
   }
 
   /**
+   * Выполняет один шаг scale для текущего ActiveSelection через указанный control.
+   * Может как начать drag-сессию, так и продолжить уже активную.
+   */
+  const scaleSelectionFromControl = ({
+    startControl: startControlName,
+    oppositeControl: oppositeControlName,
+    scaleX,
+    scaleY,
+    minimumWidth,
+    minimumHeight,
+    shiftKey = false,
+    continueInteraction = false
+  }: BrowserSelectionScaleFromControlParams): BrowserSelectionScaleFromControlResult | null => {
+    const target = browserWindow.editor.canvas.getActiveObject()
+    if (!target) return null
+
+    const targetObject = toBrowserObject({ value: target })
+    if (typeof targetObject.setCoords !== 'function') return null
+
+    targetObject.setCoords()
+
+    const controls = toBrowserObject({ value: targetObject.oCoords })
+    const startControl = toBrowserObject({ value: controls[startControlName] })
+    const oppositeControl = toBrowserObject({ value: controls[oppositeControlName] })
+    if (
+      typeof startControl.x !== 'number'
+      || typeof startControl.y !== 'number'
+      || typeof oppositeControl.x !== 'number'
+      || typeof oppositeControl.y !== 'number'
+    ) {
+      return null
+    }
+
+    const rect = browserWindow.editor.canvas.upperCanvasEl.getBoundingClientRect()
+    const startPoint = {
+      x: rect.left + startControl.x,
+      y: rect.top + startControl.y
+    }
+
+    if (!continueInteraction) {
+      browserWindow.editor.canvas.__onMouseDown(new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: startPoint.x,
+        clientY: startPoint.y,
+        shiftKey
+      }))
+    }
+
+    const transform = browserWindow.editor.canvas._currentTransform
+    if (!transform || transform.target !== target) return null
+
+    const controlWidth = startControl.x - oppositeControl.x
+    const controlHeight = startControl.y - oppositeControl.y
+    const widthSign = Math.sign(controlWidth) || 1
+    const heightSign = Math.sign(controlHeight) || 1
+    const targetWidth = typeof minimumWidth === 'number'
+      ? minimumWidth
+      : Math.abs(controlWidth) * (scaleX ?? 1)
+    const targetHeight = typeof minimumHeight === 'number'
+      ? minimumHeight
+      : Math.abs(controlHeight) * (scaleY ?? 1)
+    const movePoint = {
+      x: rect.left + oppositeControl.x + (widthSign * targetWidth),
+      y: rect.top + oppositeControl.y + (heightSign * targetHeight)
+    }
+
+    browserWindow.editor.canvas.__onMouseMove(new MouseEvent('mousemove', {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      clientX: movePoint.x,
+      clientY: movePoint.y,
+      shiftKey
+    }))
+
+    targetObject.setCoords()
+
+    const currentControl = toBrowserObject({
+      value: toBrowserObject({ value: targetObject.oCoords })[startControlName]
+    })
+    const currentPoint = typeof currentControl.x === 'number' && typeof currentControl.y === 'number'
+      ? {
+        x: rect.left + currentControl.x,
+        y: rect.top + currentControl.y
+      }
+      : movePoint
+
+    return {
+      point: currentPoint,
+      shiftKey,
+      snapshot: serializeSnappingObjectSnapshot(target) as BrowserSerializableObject
+    }
+  }
+
+  /**
    * Возвращает сериализованное состояние interaction blocker и маски блокировки.
    */
   function getInteractionBlockerState(): Record<string, unknown> {
@@ -1021,6 +1120,9 @@ export function installEditorBrowserHelpers(): void {
       },
       resolveCanvasObjectOrActive(objectIndex?: number, id?: string) {
         return resolveCanvasObjectOrActive({ objectIndex, id })
+      },
+      scaleSelectionFromControl(params: BrowserSelectionScaleFromControlParams) {
+        return scaleSelectionFromControl(params)
       },
       getSnappingGuideState() {
         return {

--- a/e2e/helpers/browser/editor-browser-helpers.types.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.types.ts
@@ -126,6 +126,28 @@ export type BrowserTextSelectionStyleParams = {
   end?: number
 }
 
+export type BrowserSelectionControlKey = 'tl' | 'tr' | 'bl' | 'br' | 'ml' | 'mr' | 'mt' | 'mb'
+
+export type BrowserSelectionScaleFromControlParams = {
+  startControl: BrowserSelectionControlKey
+  oppositeControl: BrowserSelectionControlKey
+  scaleX?: number
+  scaleY?: number
+  minimumWidth?: number
+  minimumHeight?: number
+  shiftKey?: boolean
+  continueInteraction?: boolean
+}
+
+export type BrowserSelectionScaleFromControlResult = {
+  point: {
+    x: number
+    y: number
+  }
+  shiftKey: boolean
+  snapshot: BrowserSerializableObject
+}
+
 export type BrowserSerializer = (obj: unknown) => Record<string, unknown>
 
 export interface BrowserEditorHelpers {
@@ -142,6 +164,9 @@ export interface BrowserEditorHelpers {
   resolveTarget: (objectIndex?: number, id?: string) => unknown
   resolveCanvasObject: (objectIndex?: number, id?: string) => unknown
   resolveCanvasObjectOrActive: (objectIndex?: number, id?: string) => unknown
+  scaleSelectionFromControl: (
+    params: BrowserSelectionScaleFromControlParams
+  ) => BrowserSelectionScaleFromControlResult | null
   getSnappingGuideState: () => BrowserSnappingGuideState
   getTextSelectionStyles: (params: BrowserTextSelectionStyleParams) => BrowserTextSelectionStyleInfo | null
   getShapeTextSelectionStyles: (params: BrowserTextSelectionStyleParams) => BrowserTextSelectionStyleInfo | null
@@ -170,7 +195,10 @@ export interface BrowserEditorWindow extends Window {
         target?: unknown
       } | null
       getActiveObject: () => unknown
+      __onMouseDown: (event: MouseEvent) => void
+      __onMouseMove: (event: MouseEvent) => void
       upperCanvasEl: {
+        getBoundingClientRect: () => DOMRect
         style: {
           pointerEvents: string
         }

--- a/e2e/helpers/shape-scaling-geometry.helper.ts
+++ b/e2e/helpers/shape-scaling-geometry.helper.ts
@@ -1,0 +1,96 @@
+import type { ShapeScaleSnapshot } from '../types'
+
+export interface StableMinimumGeometry {
+  groupWidth: number
+  groupHeight: number
+  shapeOffsetLeft: number
+  shapeOffsetTop: number
+  shapeWidth: number
+  shapeHeight: number
+  textOffsetLeft: number
+  textOffsetTop: number
+  textWidth: number
+  textHeight: number
+}
+
+function requireSnapshotNumber(params: {
+  value: number | null
+  phase: string
+  fieldLabel: string
+}): number {
+  const {
+    value,
+    phase,
+    fieldLabel
+  } = params
+
+  if (typeof value !== 'number') {
+    throw new Error(`${phase}: ${fieldLabel} должна существовать`)
+  }
+
+  return value
+}
+
+export function readStableMinimumGeometry(params: {
+  snapshot: ShapeScaleSnapshot
+  phase: string
+}): StableMinimumGeometry {
+  const {
+    snapshot,
+    phase
+  } = params
+
+  const shapeBoundsLeft = requireSnapshotNumber({
+    value: snapshot.shapeBoundsLeft,
+    phase,
+    fieldLabel: 'левая граница шейпа'
+  })
+  const shapeBoundsTop = requireSnapshotNumber({
+    value: snapshot.shapeBoundsTop,
+    phase,
+    fieldLabel: 'верхняя граница шейпа'
+  })
+  const shapeBoundsWidth = requireSnapshotNumber({
+    value: snapshot.shapeBoundsWidth,
+    phase,
+    fieldLabel: 'ширина шейпа'
+  })
+  const shapeBoundsHeight = requireSnapshotNumber({
+    value: snapshot.shapeBoundsHeight,
+    phase,
+    fieldLabel: 'высота шейпа'
+  })
+  const textBoundsLeft = requireSnapshotNumber({
+    value: snapshot.textBoundsLeft,
+    phase,
+    fieldLabel: 'левая граница текста'
+  })
+  const textBoundsTop = requireSnapshotNumber({
+    value: snapshot.textBoundsTop,
+    phase,
+    fieldLabel: 'верхняя граница текста'
+  })
+  const textBoundsWidth = requireSnapshotNumber({
+    value: snapshot.textBoundsWidth,
+    phase,
+    fieldLabel: 'ширина текста'
+  })
+  const textBoundsHeight = requireSnapshotNumber({
+    value: snapshot.textBoundsHeight,
+    phase,
+    fieldLabel: 'высота текста'
+  })
+
+  return {
+    groupWidth: snapshot.groupBoundsWidth,
+    groupHeight: snapshot.groupBoundsHeight,
+    shapeOffsetLeft: shapeBoundsLeft - snapshot.groupBoundsLeft,
+    shapeOffsetTop: shapeBoundsTop - snapshot.groupBoundsTop,
+    shapeWidth: shapeBoundsWidth,
+    shapeHeight: shapeBoundsHeight,
+    textOffsetLeft: textBoundsLeft - snapshot.groupBoundsLeft,
+    textOffsetTop: textBoundsTop - snapshot.groupBoundsTop,
+    textWidth: textBoundsWidth,
+    textHeight: textBoundsHeight
+  }
+}

--- a/e2e/models/selection.model.ts
+++ b/e2e/models/selection.model.ts
@@ -384,105 +384,28 @@ export class SelectionModel {
   private async _scaleFromControl(
     params: ScaleSelectionFromControlParams
   ): Promise<SnappingObjectSnapshot> {
-    expect(
-      this.activeScaleInteraction,
-      'нельзя начинать новое масштабирование общего выделения, пока предыдущий drag не завершён'
-    ).toBeNull()
+    const {
+      activeScaleInteraction
+    } = this
+    const requestedShiftKey = Boolean(params.shiftKey)
 
-    const result = await this.page.evaluate(({
-      startControl: startControlName,
-      oppositeControl: oppositeControlName,
-      scaleX,
-      scaleY,
-      minimumWidth,
-      minimumHeight,
-      shiftKey = false
-    }) => {
+    this._assertScaleInteractionCanContinue({
+      activeScaleInteraction,
+      startControl: params.startControl,
+      requestedShiftKey
+    })
+
+    const result = await this.page.evaluate((payload) => {
       const {
-        editor,
         __editorHelpers: helpers
       } = window as any
-      const target = editor.canvas.getActiveObject()
-      if (!target) return null
 
-      target.setCoords()
-
-      const startControl = target.oCoords?.[startControlName]
-      const oppositeControl = target.oCoords?.[oppositeControlName]
-      if (
-        !startControl
-        || !oppositeControl
-        || typeof startControl.x !== 'number'
-        || typeof startControl.y !== 'number'
-        || typeof oppositeControl.x !== 'number'
-        || typeof oppositeControl.y !== 'number'
-      ) {
-        return null
-      }
-
-      const rect = editor.canvas.upperCanvasEl.getBoundingClientRect()
-      const startPoint = {
-        x: rect.left + startControl.x,
-        y: rect.top + startControl.y
-      }
-
-      editor.canvas.__onMouseDown(new MouseEvent('mousedown', {
-        bubbles: true,
-        button: 0,
-        buttons: 1,
-        clientX: startPoint.x,
-        clientY: startPoint.y,
-        shiftKey
-      }))
-
-      const transform = editor.canvas._currentTransform
-      if (!transform || transform.target !== target) return null
-
-      const controlWidth = startControl.x - oppositeControl.x
-      const controlHeight = startControl.y - oppositeControl.y
-      const widthSign = Math.sign(controlWidth) || 1
-      const heightSign = Math.sign(controlHeight) || 1
-      const targetWidth = typeof minimumWidth === 'number'
-        ? minimumWidth
-        : Math.abs(controlWidth) * (scaleX ?? 1)
-      const targetHeight = typeof minimumHeight === 'number'
-        ? minimumHeight
-        : Math.abs(controlHeight) * (scaleY ?? 1)
-      const movePoint = {
-        x: rect.left + oppositeControl.x + (widthSign * targetWidth),
-        y: rect.top + oppositeControl.y + (heightSign * targetHeight)
-      }
-
-      editor.canvas.__onMouseMove(new MouseEvent('mousemove', {
-        bubbles: true,
-        button: 0,
-        buttons: 1,
-        clientX: movePoint.x,
-        clientY: movePoint.y,
-        shiftKey
-      }))
-
-      target.setCoords()
-      const currentControl = target.oCoords?.[startControlName]
-      let currentPoint = movePoint
-
-      if (
-        currentControl
-        && typeof currentControl.x === 'number'
-        && typeof currentControl.y === 'number'
-      ) {
-        currentPoint = {
-          x: rect.left + currentControl.x,
-          y: rect.top + currentControl.y
-        }
-      }
-
-      return {
-        point: currentPoint,
-        shiftKey,
-        snapshot: helpers.serializeSnappingObjectSnapshot(target)
-      }
-    }, params)
+      return helpers.scaleSelectionFromControl(payload)
+    }, {
+      ...params,
+      continueInteraction: activeScaleInteraction !== null,
+      shiftKey: requestedShiftKey
+    })
 
     expect(result, 'должно существовать live-состояние общего выделения после масштабирования').not.toBeNull()
 
@@ -490,7 +413,7 @@ export class SelectionModel {
 
     const {
       point,
-      shiftKey,
+      shiftKey: interactionShiftKey,
       snapshot
     } = result as {
       point: {
@@ -504,9 +427,32 @@ export class SelectionModel {
     this.activeScaleInteraction = {
       point,
       control: params.startControl,
-      shiftKey
+      shiftKey: interactionShiftKey
     }
 
     return snapshot
+  }
+
+  private _assertScaleInteractionCanContinue(params: {
+    activeScaleInteraction: SelectionScaleInteraction | null
+    startControl: SelectionControlKey
+    requestedShiftKey: boolean
+  }): void {
+    const {
+      activeScaleInteraction,
+      startControl,
+      requestedShiftKey
+    } = params
+
+    if (!activeScaleInteraction) return
+
+    expect(
+      activeScaleInteraction.control,
+      'нельзя продолжать активную drag-сессию общего выделения через другую ручку'
+    ).toBe(startControl)
+    expect(
+      activeScaleInteraction.shiftKey,
+      'нельзя продолжать активную drag-сессию общего выделения с другим состоянием Shift'
+    ).toBe(requestedShiftKey)
   }
 }

--- a/e2e/models/shape.model.ts
+++ b/e2e/models/shape.model.ts
@@ -429,19 +429,39 @@ export class ShapeModel {
   }
 
   /** Сжимает shape до minimum width в live drag-сессии и возвращает проверенный snapshot. */
-  async shrinkToMinimumWidth(params: ObjectTargetParams = {}): Promise<ShapeScaleSnapshot> {
+  async shrinkToMinimumWidth(
+    params: ({ edge?: 'left' | 'right' } & ObjectTargetParams) = {}
+  ): Promise<ShapeScaleSnapshot> {
     const {
+      edge = 'right',
       objectIndex,
       id
     } = params
 
+    const scaleHandleByEdge = {
+      right: {
+        pointerX: -20,
+        corner: 'mr' as const,
+        originX: 'left' as const,
+        signX: 1 as const
+      },
+      left: {
+        pointerX: 20,
+        corner: 'ml' as const,
+        originX: 'right' as const,
+        signX: -1 as const
+      }
+    }
+    const scaleHandle = scaleHandleByEdge[edge]
+
     const snapshot = await this.simulateScaleMouseMoveStep({
       scaleX: 0.2,
       scaleY: 1,
-      pointerX: -20,
+      pointerX: scaleHandle.pointerX,
       pointerY: 0,
-      corner: 'mr',
-      originX: 'left',
+      corner: scaleHandle.corner,
+      signX: scaleHandle.signX,
+      originX: scaleHandle.originX,
       originY: 'center',
       objectIndex,
       id
@@ -679,6 +699,26 @@ export class ShapeModel {
       scaleY: scale,
       corner,
       shiftKey: false,
+      objectIndex,
+      id
+    })
+  }
+
+  /** Сжимает shape до minimum по диагонали и возвращает live snapshot текущего кадра. */
+  async shrinkDiagonallyToMinimum(
+    params: {
+      corner: 'tl' | 'tr' | 'bl' | 'br'
+    } & ObjectTargetParams
+  ): Promise<ShapeScaleSnapshot> {
+    const {
+      corner,
+      objectIndex,
+      id
+    } = params
+
+    return this.scaleDiagonallyProportionally({
+      scale: 0.2,
+      corner,
       objectIndex,
       id
     })

--- a/e2e/tests/shape-manager/shape-scaling-multiline-arrow-directions.spec.ts
+++ b/e2e/tests/shape-manager/shape-scaling-multiline-arrow-directions.spec.ts
@@ -1,0 +1,253 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  SHAPE_SCALING_TOLERANCE
+} from '../../fixtures/data/shape-scaling.data'
+import {
+  MULTILINE_ARROW_TEXT,
+  MULTILINE_ARROW_SCALE_CYCLES,
+  MULTILINE_ARROW_EXPAND_BASE_SCALE,
+  MULTILINE_ARROW_EXPAND_SCALE_STEP,
+  MULTILINE_ARROW_SINGLE_SHAPE_ID,
+  MULTILINE_ARROW_SINGLE_SHAPE_BOUNDS,
+  MULTILINE_ARROW_SINGLE_SHAPE_SCENARIOS
+} from '../../fixtures/data/shape-scaling-multiline-arrow.data'
+import {
+  readStableMinimumGeometry
+} from '../../helpers/shape-scaling-geometry.helper'
+import type {
+  ShapeScaleSnapshot
+} from '../../types'
+import type {
+  StableMinimumGeometry
+} from '../../helpers/shape-scaling-geometry.helper'
+
+test.describe('Скейлинг multiline arrow-right-fat с разных сторон', () => {
+  test.beforeEach(async({ editorModel, shapes }) => {
+    const montageBounds = await editorModel.getMontageAreaBounds()
+    const createdShape = await shapes.addAtBounds({
+      presetKey: 'arrow-right-fat',
+      options: {
+        id: MULTILINE_ARROW_SINGLE_SHAPE_ID,
+        left: montageBounds.left + MULTILINE_ARROW_SINGLE_SHAPE_BOUNDS.leftOffset,
+        top: montageBounds.top + MULTILINE_ARROW_SINGLE_SHAPE_BOUNDS.topOffset,
+        width: MULTILINE_ARROW_SINGLE_SHAPE_BOUNDS.width,
+        height: MULTILINE_ARROW_SINGLE_SHAPE_BOUNDS.height,
+        text: MULTILINE_ARROW_TEXT
+      }
+    })
+
+    shapes.checkCreation({
+      shape: createdShape,
+      presetKey: 'arrow-right-fat'
+    })
+  })
+
+  for (const scenario of MULTILINE_ARROW_SINGLE_SHAPE_SCENARIOS) {
+    test(scenario.title, async({ shapes }) => {
+      const minimumStates: Array<{
+        phase: string
+        snapshot: ShapeScaleSnapshot
+        lineCount: number
+      }> = []
+      let baselineGeometry: StableMinimumGeometry | null = null
+      let baselineLineCount: number | null = null
+
+      for (let cycleIndex = 0; cycleIndex < MULTILINE_ARROW_SCALE_CYCLES; cycleIndex += 1) {
+        const cycleNumber = cycleIndex + 1
+        const expandedScale = MULTILINE_ARROW_EXPAND_BASE_SCALE + (cycleIndex * MULTILINE_ARROW_EXPAND_SCALE_STEP)
+        let liveMinimumStepTitle = `Цикл ${cycleNumber}: вернуть правую ручку обратно до упора`
+
+        if (scenario.axis === 'horizontal') {
+          liveMinimumStepTitle = scenario.edge === 'right'
+            ? `Цикл ${cycleNumber}: вернуть правую ручку обратно до упора`
+            : `Цикл ${cycleNumber}: вернуть левую ручку обратно до упора`
+
+          await test.step(
+            scenario.edge === 'right'
+              ? `Цикл ${cycleNumber}: потянуть правую ручку дальше вправо`
+              : `Цикл ${cycleNumber}: потянуть левую ручку дальше влево`,
+            async() => {
+              if (scenario.edge === 'right') {
+                await shapes.scaleHorizontallyFromRight({
+                  id: MULTILINE_ARROW_SINGLE_SHAPE_ID,
+                  scaleX: expandedScale
+                })
+                return
+              }
+
+              await shapes.scaleHorizontallyFromLeft({
+                id: MULTILINE_ARROW_SINGLE_SHAPE_ID,
+                scaleX: expandedScale
+              })
+            }
+          )
+        }
+
+        if (scenario.axis === 'diagonal') {
+          liveMinimumStepTitle = scenario.corner === 'br'
+            ? `Цикл ${cycleNumber}: вернуть правый нижний угол обратно до упора`
+            : `Цикл ${cycleNumber}: вернуть правый верхний угол обратно до упора`
+
+          await test.step(
+            scenario.corner === 'br'
+              ? `Цикл ${cycleNumber}: потянуть правый нижний угол наружу`
+              : `Цикл ${cycleNumber}: потянуть правый верхний угол наружу`,
+            async() => {
+              await shapes.scaleDiagonallyProportionally({
+                id: MULTILINE_ARROW_SINGLE_SHAPE_ID,
+                corner: scenario.corner,
+                scale: expandedScale
+              })
+            }
+          )
+        }
+
+        const liveMinimumSnapshot = await test.step(liveMinimumStepTitle, async() => {
+          if (scenario.axis === 'horizontal') {
+            return shapes.shrinkToMinimumWidth({
+              id: MULTILINE_ARROW_SINGLE_SHAPE_ID,
+              edge: scenario.edge
+            })
+          }
+
+          return shapes.shrinkDiagonallyToMinimum({
+            id: MULTILINE_ARROW_SINGLE_SHAPE_ID,
+            corner: scenario.corner
+          })
+        })
+
+        const liveText = await test.step(`Цикл ${cycleNumber}: получить состояние текста на minimum`, async() => {
+          return shapes.getTextNode({
+            id: MULTILINE_ARROW_SINGLE_SHAPE_ID
+          })
+        })
+
+        expect(liveText, `цикл ${cycleNumber}: текст на minimum должен существовать`).not.toBeNull()
+
+        if (!liveText) {
+          throw new Error(`цикл ${cycleNumber}: текст на minimum должен существовать`)
+        }
+
+        const phase = `цикл ${cycleNumber} live`
+        const geometry = readStableMinimumGeometry({
+          snapshot: liveMinimumSnapshot,
+          phase
+        })
+
+        if (!baselineGeometry) {
+          baselineGeometry = geometry
+          baselineLineCount = liveText.lineCount
+        }
+
+        minimumStates.push({
+          phase,
+          snapshot: liveMinimumSnapshot,
+          lineCount: liveText.lineCount
+        })
+      }
+
+      const finalSnapshot = await test.step('Отпустить мышь после последнего возврата на minimum', async() => {
+        return shapes.finishScale({
+          id: MULTILINE_ARROW_SINGLE_SHAPE_ID
+        })
+      })
+      const finalText = await test.step('Получить состояние текста после mouseup', async() => {
+        return shapes.getTextNode({
+          id: MULTILINE_ARROW_SINGLE_SHAPE_ID
+        })
+      })
+
+      expect(finalText, 'текст после mouseup должен существовать').not.toBeNull()
+
+      if (!finalText) {
+        throw new Error('текст после mouseup должен существовать')
+      }
+
+      if (!baselineGeometry || baselineLineCount === null) {
+        throw new Error('первый minimum должен определить базовую геометрию для сравнения')
+      }
+
+      minimumStates.push({
+        phase: 'после mouseup',
+        snapshot: finalSnapshot,
+        lineCount: finalText.lineCount
+      })
+
+      await test.step('Проверить, что все возвраты на minimum дают ту же геометрию шейпа и текста', () => {
+        for (const state of minimumStates) {
+          const phase = state.phase
+          const geometry = readStableMinimumGeometry({
+            snapshot: state.snapshot,
+            phase
+          })
+
+          expect(state.lineCount, `${phase}: число строк не должно меняться`).toBe(baselineLineCount)
+
+          expect(
+            Math.abs(geometry.groupWidth - baselineGeometry.groupWidth),
+            `${phase}: ширина группы не должна меняться`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+          expect(
+            Math.abs(geometry.groupHeight - baselineGeometry.groupHeight),
+            `${phase}: высота группы не должна меняться`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+          expect(
+            Math.abs(geometry.shapeOffsetLeft - baselineGeometry.shapeOffsetLeft),
+            `${phase}: шейп не должен смещаться внутри группы по X`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+          expect(
+            Math.abs(geometry.shapeOffsetTop - baselineGeometry.shapeOffsetTop),
+            `${phase}: шейп не должен смещаться внутри группы по Y`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+          expect(
+            Math.abs(geometry.shapeWidth - baselineGeometry.shapeWidth),
+            `${phase}: ширина шейпа внутри группы не должна меняться`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+          expect(
+            Math.abs(geometry.shapeHeight - baselineGeometry.shapeHeight),
+            `${phase}: высота шейпа внутри группы не должна меняться`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+          expect(
+            Math.abs(geometry.textOffsetLeft - baselineGeometry.textOffsetLeft),
+            `${phase}: текст не должен смещаться внутри группы по X`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+          expect(
+            Math.abs(geometry.textOffsetTop - baselineGeometry.textOffsetTop),
+            `${phase}: текст не должен смещаться внутри группы по Y`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+          expect(
+            Math.abs(geometry.textWidth - baselineGeometry.textWidth),
+            `${phase}: ширина текста не должна меняться`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+          expect(
+            Math.abs(geometry.textHeight - baselineGeometry.textHeight),
+            `${phase}: высота текста не должна меняться`
+          )
+            .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+          shapes.checkNodeInsideGroup({
+            snapshot: state.snapshot,
+            kind: 'shape',
+            tolerance: SHAPE_SCALING_TOLERANCE.mouseupJump
+          })
+          shapes.checkNodeInsideGroup({
+            snapshot: state.snapshot,
+            kind: 'text',
+            tolerance: SHAPE_SCALING_TOLERANCE.mouseupJump
+          })
+        }
+      })
+    })
+  }
+})

--- a/e2e/tests/shape-manager/shape-scaling-multiline-arrow-selection.spec.ts
+++ b/e2e/tests/shape-manager/shape-scaling-multiline-arrow-selection.spec.ts
@@ -1,0 +1,314 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  SHAPE_SCALING_TOLERANCE
+} from '../../fixtures/data/shape-scaling.data'
+import {
+  MULTILINE_ARROW_TEXT,
+  MULTILINE_ARROW_SCALE_CYCLES,
+  MULTILINE_ARROW_EXPAND_BASE_SCALE,
+  MULTILINE_ARROW_EXPAND_SCALE_STEP,
+  MULTILINE_ARROW_SELECTION_MINIMUM_SIZE,
+  MULTILINE_ARROW_SELECTION_SHAPES,
+  MULTILINE_ARROW_SELECTION_SCENARIOS
+} from '../../fixtures/data/shape-scaling-multiline-arrow.data'
+import {
+  readStableMinimumGeometry
+} from '../../helpers/shape-scaling-geometry.helper'
+import type {
+  ShapeScaleSnapshot
+} from '../../types'
+import type {
+  StableMinimumGeometry
+} from '../../helpers/shape-scaling-geometry.helper'
+
+test.describe('Скейлинг общего выделения из multiline arrow-right-fat', () => {
+  test.beforeEach(async({ editorModel, shapes }) => {
+    const montageBounds = await editorModel.getMontageAreaBounds()
+
+    for (const shapeConfig of MULTILINE_ARROW_SELECTION_SHAPES) {
+      const createdShape = await shapes.addAtBounds({
+        presetKey: 'arrow-right-fat',
+        options: {
+          id: shapeConfig.id,
+          left: montageBounds.left + shapeConfig.leftOffset,
+          top: montageBounds.top + shapeConfig.topOffset,
+          width: shapeConfig.width,
+          height: shapeConfig.height,
+          text: MULTILINE_ARROW_TEXT
+        }
+      })
+
+      shapes.checkCreation({
+        shape: createdShape,
+        presetKey: 'arrow-right-fat'
+      })
+    }
+
+    await editorModel.checkObjectCount({ count: MULTILINE_ARROW_SELECTION_SHAPES.length })
+    await editorModel.selectAllObjects()
+  })
+
+  for (const scenario of MULTILINE_ARROW_SELECTION_SCENARIOS) {
+    test(scenario.title, async({ selection, shapes }) => {
+      const minimumStates: Array<{
+        phase: string
+        shapes: Array<{
+          id: string
+          snapshot: ShapeScaleSnapshot
+          lineCount: number
+        }>
+      }> = []
+      const baselineGeometryById = new Map<string, StableMinimumGeometry>()
+      const baselineLineCountById = new Map<string, number>()
+
+      for (let cycleIndex = 0; cycleIndex < MULTILINE_ARROW_SCALE_CYCLES; cycleIndex += 1) {
+        const cycleNumber = cycleIndex + 1
+        const expandedScale = MULTILINE_ARROW_EXPAND_BASE_SCALE + (cycleIndex * MULTILINE_ARROW_EXPAND_SCALE_STEP)
+        let shrinkStepTitle = `Цикл ${cycleNumber}: вернуть правую ручку общего выделения обратно до упора`
+
+        if (scenario.axis === 'horizontal') {
+          await test.step(`Цикл ${cycleNumber}: потянуть правую ручку общего выделения дальше вправо`, async() => {
+            await selection.scaleHorizontallyFromRight({
+              scaleX: expandedScale
+            })
+          })
+        }
+
+        if (scenario.axis === 'vertical') {
+          shrinkStepTitle = `Цикл ${cycleNumber}: вернуть верхнюю ручку общего выделения обратно до упора`
+
+          await test.step(`Цикл ${cycleNumber}: потянуть верхнюю ручку общего выделения дальше вверх`, async() => {
+            await selection.scaleVerticallyFromTop({
+              scaleY: expandedScale
+            })
+          })
+        }
+
+        if (scenario.axis === 'diagonal') {
+          shrinkStepTitle = scenario.corner === 'br'
+            ? `Цикл ${cycleNumber}: вернуть правый нижний угол общего выделения обратно до упора`
+            : `Цикл ${cycleNumber}: вернуть правый верхний угол общего выделения обратно до упора`
+
+          await test.step(
+            scenario.corner === 'br'
+              ? `Цикл ${cycleNumber}: потянуть правый нижний угол общего выделения наружу`
+              : `Цикл ${cycleNumber}: потянуть правый верхний угол общего выделения наружу`,
+            async() => {
+              if (scenario.corner === 'br') {
+                await selection.scaleDiagonallyFromBottomRight({
+                  scaleX: expandedScale,
+                  scaleY: expandedScale
+                })
+                return
+              }
+
+              await selection.scaleDiagonallyFromTopRight({
+                scaleX: expandedScale,
+                scaleY: expandedScale
+              })
+            }
+          )
+        }
+
+        await test.step(shrinkStepTitle, async() => {
+          if (scenario.axis === 'horizontal') {
+            await selection.shrinkHorizontallyFromRightToMinimum({
+              minimumSize: MULTILINE_ARROW_SELECTION_MINIMUM_SIZE
+            })
+            return
+          }
+
+          if (scenario.axis === 'vertical') {
+            await selection.shrinkVerticallyFromTopToMinimum({
+              minimumSize: MULTILINE_ARROW_SELECTION_MINIMUM_SIZE
+            })
+            return
+          }
+
+          if (scenario.corner === 'br') {
+            await selection.shrinkDiagonallyFromBottomRightToMinimum({
+              minimumSize: MULTILINE_ARROW_SELECTION_MINIMUM_SIZE
+            })
+            return
+          }
+
+          await selection.shrinkDiagonallyFromTopRightToMinimum({
+            minimumSize: MULTILINE_ARROW_SELECTION_MINIMUM_SIZE
+          })
+        })
+
+        const shapesAtMinimum: Array<{
+          id: string
+          snapshot: ShapeScaleSnapshot
+          lineCount: number
+        }> = []
+
+        for (const shapeConfig of MULTILINE_ARROW_SELECTION_SHAPES) {
+          const snapshot = await test.step(`Цикл ${cycleNumber}: получить состояние ${shapeConfig.id} на minimum`, async() => {
+            return shapes.getScaleSnapshot({
+              id: shapeConfig.id
+            })
+          })
+          const text = await test.step(`Цикл ${cycleNumber}: получить текст внутри ${shapeConfig.id} на minimum`, async() => {
+            return shapes.getTextNode({
+              id: shapeConfig.id
+            })
+          })
+
+          expect(text, `цикл ${cycleNumber}: текст внутри ${shapeConfig.id} должен существовать`).not.toBeNull()
+
+          if (!text) {
+            throw new Error(`цикл ${cycleNumber}: текст внутри ${shapeConfig.id} должен существовать`)
+          }
+
+          const phase = `цикл ${cycleNumber} live ${shapeConfig.id}`
+          const geometry = readStableMinimumGeometry({
+            snapshot,
+            phase
+          })
+
+          if (!baselineGeometryById.has(shapeConfig.id)) {
+            baselineGeometryById.set(shapeConfig.id, geometry)
+            baselineLineCountById.set(shapeConfig.id, text.lineCount)
+          }
+
+          shapesAtMinimum.push({
+            id: shapeConfig.id,
+            snapshot,
+            lineCount: text.lineCount
+          })
+        }
+
+        minimumStates.push({
+          phase: `цикл ${cycleNumber} live`,
+          shapes: shapesAtMinimum
+        })
+      }
+
+      await test.step('Отпустить мышь после последнего возврата на minimum', async() => {
+        await selection.finishScale()
+      })
+
+      const finalShapesState: Array<{
+        id: string
+        snapshot: ShapeScaleSnapshot
+        lineCount: number
+      }> = []
+
+      for (const shapeConfig of MULTILINE_ARROW_SELECTION_SHAPES) {
+        const snapshot = await test.step(`Получить состояние ${shapeConfig.id} после mouseup`, async() => {
+          return shapes.getScaleSnapshot({
+            id: shapeConfig.id
+          })
+        })
+        const text = await test.step(`Получить текст внутри ${shapeConfig.id} после mouseup`, async() => {
+          return shapes.getTextNode({
+            id: shapeConfig.id
+          })
+        })
+
+        expect(text, `после mouseup: текст внутри ${shapeConfig.id} должен существовать`).not.toBeNull()
+
+        if (!text) {
+          throw new Error(`после mouseup: текст внутри ${shapeConfig.id} должен существовать`)
+        }
+
+        finalShapesState.push({
+          id: shapeConfig.id,
+          snapshot,
+          lineCount: text.lineCount
+        })
+      }
+
+      minimumStates.push({
+        phase: 'после mouseup',
+        shapes: finalShapesState
+      })
+
+      await test.step('Проверить, что обе фигуры после каждого возврата на minimum остаются в той же геометрии', () => {
+        for (const state of minimumStates) {
+          for (const shapeState of state.shapes) {
+            const baselineGeometry = baselineGeometryById.get(shapeState.id)
+            const baselineLineCount = baselineLineCountById.get(shapeState.id)
+
+            if (!baselineGeometry || baselineLineCount === undefined) {
+              throw new Error(`${shapeState.id}: первый minimum должен определить базовую геометрию`)
+            }
+
+            const phase = `${state.phase} ${shapeState.id}`
+            const geometry = readStableMinimumGeometry({
+              snapshot: shapeState.snapshot,
+              phase
+            })
+
+            expect(shapeState.lineCount, `${phase}: число строк не должно меняться`).toBe(baselineLineCount)
+
+            expect(
+              Math.abs(geometry.groupWidth - baselineGeometry.groupWidth),
+              `${phase}: ширина группы не должна меняться`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+            expect(
+              Math.abs(geometry.groupHeight - baselineGeometry.groupHeight),
+              `${phase}: высота группы не должна меняться`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+            expect(
+              Math.abs(geometry.shapeOffsetLeft - baselineGeometry.shapeOffsetLeft),
+              `${phase}: шейп не должен смещаться внутри группы по X`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+            expect(
+              Math.abs(geometry.shapeOffsetTop - baselineGeometry.shapeOffsetTop),
+              `${phase}: шейп не должен смещаться внутри группы по Y`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+            expect(
+              Math.abs(geometry.shapeWidth - baselineGeometry.shapeWidth),
+              `${phase}: ширина шейпа внутри группы не должна меняться`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+            expect(
+              Math.abs(geometry.shapeHeight - baselineGeometry.shapeHeight),
+              `${phase}: высота шейпа внутри группы не должна меняться`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+            expect(
+              Math.abs(geometry.textOffsetLeft - baselineGeometry.textOffsetLeft),
+              `${phase}: текст не должен смещаться внутри группы по X`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+            expect(
+              Math.abs(geometry.textOffsetTop - baselineGeometry.textOffsetTop),
+              `${phase}: текст не должен смещаться внутри группы по Y`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+            expect(
+              Math.abs(geometry.textWidth - baselineGeometry.textWidth),
+              `${phase}: ширина текста не должна меняться`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+            expect(
+              Math.abs(geometry.textHeight - baselineGeometry.textHeight),
+              `${phase}: высота текста не должна меняться`
+            )
+              .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+            shapes.checkNodeInsideGroup({
+              snapshot: shapeState.snapshot,
+              kind: 'shape',
+              tolerance: SHAPE_SCALING_TOLERANCE.mouseupJump
+            })
+            shapes.checkNodeInsideGroup({
+              snapshot: shapeState.snapshot,
+              kind: 'text',
+              tolerance: SHAPE_SCALING_TOLERANCE.mouseupJump
+            })
+          }
+        }
+      })
+    })
+  }
+})

--- a/e2e/tests/shape-manager/shape-scaling-multiline-arrow.spec.ts
+++ b/e2e/tests/shape-manager/shape-scaling-multiline-arrow.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  SHAPE_SCALING_TOLERANCE
+} from '../../fixtures/data/shape-scaling.data'
+import {
+  MULTILINE_ARROW_TEXT,
+  MULTILINE_ARROW_SCALE_CYCLES,
+  MULTILINE_ARROW_EXPAND_BASE_SCALE,
+  MULTILINE_ARROW_EXPAND_SCALE_STEP
+} from '../../fixtures/data/shape-scaling-multiline-arrow.data'
+import {
+  readStableMinimumGeometry
+} from '../../helpers/shape-scaling-geometry.helper'
+import type { ShapeScaleSnapshot } from '../../types'
+import type { StableMinimumGeometry } from '../../helpers/shape-scaling-geometry.helper'
+
+test.describe('Vertical scaling шейпа с многострочным текстом', () => {
+  test('в одном непрерывном vertical drag текст и shape не должны смещаться, когда ручка несколько раз возвращается вниз до упора', async({
+    shapes
+  }) => {
+    const createdShape = await test.step('Добавить arrow-right-fat тем же способом, что и в браузерном скрипте', async() => {
+      return shapes.add({
+        presetKey: 'arrow-right-fat',
+        options: {
+          text: MULTILINE_ARROW_TEXT
+        }
+      })
+    })
+
+    shapes.checkCreation({
+      shape: createdShape,
+      presetKey: 'arrow-right-fat'
+    })
+
+    const minimumStates: Array<{
+      phase: string
+      snapshot: ShapeScaleSnapshot
+      lineCount: number
+    }> = []
+    let baselineGeometry: StableMinimumGeometry | null = null
+    let baselineLineCount: number | null = null
+
+    for (let cycleIndex = 0; cycleIndex < MULTILINE_ARROW_SCALE_CYCLES; cycleIndex += 1) {
+      const cycleNumber = cycleIndex + 1
+
+      await test.step(`Цикл ${cycleNumber}: в той же drag-сессии потянуть ручку вверх`, async() => {
+        await shapes.scaleVerticallyFromTop({
+          objectIndex: 0,
+          scaleY: MULTILINE_ARROW_EXPAND_BASE_SCALE + (cycleIndex * MULTILINE_ARROW_EXPAND_SCALE_STEP)
+        })
+      })
+
+      const liveMinimumSnapshot = await test.step(`Цикл ${cycleNumber}: в той же drag-сессии вернуть ручку вниз до упора`, async() => {
+        return shapes.shrinkToMinimumHeight({
+          objectIndex: 0,
+          edge: 'top'
+        })
+      })
+
+      const liveText = await test.step(`Цикл ${cycleNumber}: получить состояние текста на нижнем упоре`, async() => {
+        return shapes.getTextNode({ objectIndex: 0 })
+      })
+
+      expect(liveText, `цикл ${cycleNumber}: текст на нижнем упоре должен существовать`).not.toBeNull()
+
+      if (!liveText) {
+        throw new Error(`цикл ${cycleNumber}: текст на нижнем упоре должен существовать`)
+      }
+
+      const phase = `цикл ${cycleNumber} live`
+      const geometry = readStableMinimumGeometry({
+        snapshot: liveMinimumSnapshot,
+        phase
+      })
+
+      if (!baselineGeometry) {
+        baselineGeometry = geometry
+        baselineLineCount = liveText.lineCount
+      }
+
+      minimumStates.push({
+        phase,
+        snapshot: liveMinimumSnapshot,
+        lineCount: liveText.lineCount
+      })
+    }
+
+    const finalSnapshot = await test.step('Отпустить мышь после последнего возврата вниз и получить финальное состояние', async() => {
+      return shapes.finishScale({ objectIndex: 0 })
+    })
+    const finalText = await test.step('Получить состояние текста после mouseup', async() => {
+      return shapes.getTextNode({ objectIndex: 0 })
+    })
+
+    expect(finalText, 'текст после mouseup должен существовать').not.toBeNull()
+
+    if (!finalText) {
+      throw new Error('текст после mouseup должен существовать')
+    }
+
+    if (!baselineGeometry || baselineLineCount === null) {
+      throw new Error('первый нижний упор должен определить базовую геометрию для сравнения')
+    }
+
+    minimumStates.push({
+      phase: 'после mouseup',
+      snapshot: finalSnapshot,
+      lineCount: finalText.lineCount
+    })
+
+    await test.step('Проверить что каждый возврат вниз даёт ту же геометрию текста и shape внутри группы', () => {
+      for (const state of minimumStates) {
+        const phase = state.phase
+        const geometry = readStableMinimumGeometry({
+          snapshot: state.snapshot,
+          phase
+        })
+
+        expect(state.lineCount, `${phase}: число строк не должно меняться на нижнем упоре`).toBe(baselineLineCount)
+
+        expect(
+          Math.abs(geometry.groupWidth - baselineGeometry.groupWidth),
+          `${phase}: ширина группы не должна меняться на нижнем упоре`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+        expect(
+          Math.abs(geometry.groupHeight - baselineGeometry.groupHeight),
+          `${phase}: высота группы не должна меняться на нижнем упоре`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+        expect(
+          Math.abs(geometry.shapeOffsetLeft - baselineGeometry.shapeOffsetLeft),
+          `${phase}: shape не должен смещаться внутри группы по X`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+        expect(
+          Math.abs(geometry.shapeOffsetTop - baselineGeometry.shapeOffsetTop),
+          `${phase}: shape не должен смещаться внутри группы по Y`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+        expect(
+          Math.abs(geometry.shapeWidth - baselineGeometry.shapeWidth),
+          `${phase}: ширина shape внутри группы не должна меняться`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+        expect(
+          Math.abs(geometry.shapeHeight - baselineGeometry.shapeHeight),
+          `${phase}: высота shape внутри группы не должна меняться`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+        expect(
+          Math.abs(geometry.textOffsetLeft - baselineGeometry.textOffsetLeft),
+          `${phase}: текст не должен смещаться внутри группы по X`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+        expect(
+          Math.abs(geometry.textOffsetTop - baselineGeometry.textOffsetTop),
+          `${phase}: текст не должен смещаться внутри группы по Y`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+        expect(
+          Math.abs(geometry.textWidth - baselineGeometry.textWidth),
+          `${phase}: ширина текста не должна меняться`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+        expect(
+          Math.abs(geometry.textHeight - baselineGeometry.textHeight),
+          `${phase}: высота текста не должна меняться`
+        )
+          .toBeLessThanOrEqual(SHAPE_SCALING_TOLERANCE.mouseupJump)
+
+        shapes.checkNodeInsideGroup({
+          snapshot: state.snapshot,
+          kind: 'shape'
+        })
+        shapes.checkNodeInsideGroup({
+          snapshot: state.snapshot,
+          kind: 'text'
+        })
+      }
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/shape-manager/shape-layout.spec.ts
+++ b/specs/src/editor/shape-manager/shape-layout.spec.ts
@@ -3,6 +3,7 @@ import {
   isShapeTextFrameFilled,
   resolveMinimumShapeWidthForText,
   resolveRequiredShapeHeightForText,
+  resolveShapeTextLayout,
   resolveShapeTextFixedWidthLayout,
   resolveShapeTextAutoExpandWidthForText,
   resolveShapeTextFrameLayout
@@ -30,6 +31,12 @@ describe('shape-layout', () => {
     right: 12,
     bottom: 12,
     left: 12
+  }
+  const zeroShapePadding = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0
   }
   const resizeShapeNodeMock = resizeShapeNode as jest.Mock
 
@@ -415,6 +422,47 @@ describe('shape-layout', () => {
     expect(nextHeight).toBe(80)
   })
 
+  it('resolveRequiredShapeHeightForText не меняет итоговую высоту из-за стартовой высоты', () => {
+    const preset = getShapePreset({
+      presetKey: 'arrow-right-fat'
+    })
+
+    if (!preset) {
+      throw new Error('arrow-right-fat preset is required for this test')
+    }
+
+    const text = createMockShapeTextbox({
+      text: 'TEST\nTEST\nTEST\nTEST',
+      width: preset.width,
+      fontSize: 48,
+      lineHeight: 1.16
+    })
+    const initialHeight = resolveRequiredShapeHeightForText({
+      text,
+      width: preset.width,
+      height: preset.height,
+      padding: zeroShapePadding,
+      resolvePaddingForSize: ({ width, height }) => resolveInternalShapeTextInset({
+        preset,
+        width,
+        height
+      })
+    })
+    const stabilizedHeight = resolveRequiredShapeHeightForText({
+      text,
+      width: preset.width,
+      height: initialHeight,
+      padding: zeroShapePadding,
+      resolvePaddingForSize: ({ width, height }) => resolveInternalShapeTextInset({
+        preset,
+        width,
+        height
+      })
+    })
+
+    expect(Math.abs(stabilizedHeight - initialHeight)).toBeLessThanOrEqual(0.5)
+  })
+
   it('isShapeTextFrameFilled возвращает false для пустого текста', () => {
     const text = createMockShapeTextbox({
       text: ''
@@ -663,6 +711,49 @@ describe('shape-layout', () => {
     expect(layout.frame.top).toBeGreaterThanOrEqual(-(layout.height / 2) - 0.5)
     expect(layout.frame.top + layout.frame.height).toBeLessThanOrEqual((layout.height / 2) + 0.5)
     expect(layout.frame.height).toBeLessThanOrEqual(availableTextHeight + 0.5)
+  })
+
+  it('первый layout после ввода текста и первый fixed-width preview дают одну и ту же высоту', () => {
+    const preset = getShapePreset({
+      presetKey: 'arrow-right-fat'
+    })
+
+    if (!preset) {
+      throw new Error('arrow-right-fat preset is required for this test')
+    }
+
+    const text = createMockShapeTextbox({
+      text: 'TEST\nTEST\nTEST\nTEST',
+      width: preset.width,
+      fontSize: 48,
+      lineHeight: 1.16
+    })
+    const initialLayout = resolveShapeTextLayout({
+      text,
+      width: preset.width,
+      height: preset.height,
+      alignV: 'middle',
+      padding: zeroShapePadding,
+      resolveInternalShapeTextInset: ({ width, height }) => resolveInternalShapeTextInset({
+        preset,
+        width,
+        height
+      })
+    })
+    const previewLayout = resolveShapeTextFixedWidthLayout({
+      text,
+      width: initialLayout.width,
+      height: initialLayout.height,
+      alignV: 'middle',
+      padding: zeroShapePadding,
+      resolveInternalShapeTextInset: ({ width, height }) => resolveInternalShapeTextInset({
+        preset,
+        width,
+        height
+      })
+    })
+
+    expect(Math.abs(previewLayout.height - initialLayout.height)).toBeLessThanOrEqual(0.5)
   })
 
   it('после narrow layout с переносом строк и обратного расширения возвращает actual height к manual base height', () => {

--- a/specs/src/editor/shape-manager/shape-scaling.spec.ts
+++ b/specs/src/editor/shape-manager/shape-scaling.spec.ts
@@ -1,5 +1,6 @@
 import { Point } from 'fabric'
 import {
+  applyFixedWidthShapeTextLayout,
   applyShapeTextLayout,
   isShapeTextFrameFilled,
   measureShapeTextFrameLayout,
@@ -21,6 +22,7 @@ import {
 } from '../../../test-utils/shape-scaling-helpers'
 
 jest.mock('../../../../src/editor/shape-manager/layout/shape-layout', () => ({
+  applyFixedWidthShapeTextLayout: jest.fn(),
   applyShapeTextLayout: jest.fn(),
   isShapeTextFrameFilled: jest.fn(),
   measureShapeTextFrameLayout: jest.fn(() => ({
@@ -73,6 +75,7 @@ jest.mock('../../../../src/editor/shape-manager/shape-utils', () => ({
 }))
 
 describe('shape-scaling', () => {
+  const applyFixedWidthShapeTextLayoutMock = applyFixedWidthShapeTextLayout as jest.Mock
   const applyShapeTextLayoutMock = applyShapeTextLayout as jest.Mock
   const isShapeTextFrameFilledMock = isShapeTextFrameFilled as jest.Mock
   const measureShapeTextFrameLayoutMock = measureShapeTextFrameLayout as jest.Mock
@@ -123,7 +126,7 @@ describe('shape-scaling', () => {
       splitByGrapheme: false,
       textTop: -20
     }))
-    applyShapeTextLayoutMock.mockImplementation(({
+    const applyLayoutMockImplementation = ({
       group,
       width,
       height
@@ -141,7 +144,10 @@ describe('shape-scaling', () => {
       group.height = height
       group.shapeBaseWidth = width
       group.shapeBaseHeight = height
-    })
+    }
+
+    applyShapeTextLayoutMock.mockImplementation(applyLayoutMockImplementation)
+    applyFixedWidthShapeTextLayoutMock.mockImplementation(applyLayoutMockImplementation)
   })
 
   it('обрабатывает vertical shrink как noop, если shape уже стоит на minimum height в начале drag', () => {
@@ -186,6 +192,10 @@ describe('shape-scaling', () => {
     })
 
     expect(applyShapeTextLayoutMock).not.toHaveBeenCalled()
+    expect(applyFixedWidthShapeTextLayoutMock).toHaveBeenCalledWith(expect.objectContaining({
+      width: 200,
+      height: 200
+    }))
     expect(group.scaleX).toBe(1)
     expect(group.scaleY).toBe(1)
     expect(group.shapeScalingNoopTransform).toBe(false)
@@ -851,6 +861,41 @@ describe('shape-scaling', () => {
     }
   })
 
+  it('при увеличении нескольких шейпов по диагонали не пересчитывает shrink minimum', () => {
+    const {
+      controller,
+      selection
+    } = createActiveSelectionShapeScalingSetup()
+    const resolveMinimumProportionalShapeScaleSpy = jest.spyOn(
+      shapeScalingLayout,
+      'resolveMinimumProportionalShapeScale'
+    )
+
+    try {
+      isShapeTextFrameFilledMock.mockReturnValue(false)
+      selection.scaleX = 1.4
+      selection.scaleY = 1.4
+
+      controller.handleObjectScaling({
+        target: selection,
+        transform: createShapeScalingTransform({
+          target: selection,
+          action: 'scale',
+          corner: 'br',
+          originX: 'left',
+          originY: 'top'
+        }) as never
+      })
+
+      expect(resolveMinimumProportionalShapeScaleSpy).not.toHaveBeenCalled()
+      expect(resolveShapeTextFixedWidthLayoutMock).toHaveBeenCalledTimes(2)
+      expect(selection.scaleX).toBeCloseTo(1.4, 4)
+      expect(selection.scaleY).toBeCloseTo(1.4, 4)
+    } finally {
+      resolveMinimumProportionalShapeScaleSpy.mockRestore()
+    }
+  })
+
   it('если Fabric пропустил scaling-кадр, продолжает лайв-перерасчёт текста для нескольких шейпов', () => {
     const {
       controller,
@@ -1178,7 +1223,7 @@ describe('shape-scaling', () => {
       } as never
     })
 
-    const layoutCall = applyShapeTextLayoutMock.mock.calls[applyShapeTextLayoutMock.mock.calls.length - 1]?.[0]
+    const layoutCall = applyFixedWidthShapeTextLayoutMock.mock.calls[applyFixedWidthShapeTextLayoutMock.mock.calls.length - 1]?.[0]
 
     expect(layoutCall).toEqual(expect.objectContaining({
       width: 200,
@@ -1288,7 +1333,7 @@ describe('shape-scaling', () => {
       } as never
     })
 
-    expect(applyShapeTextLayoutMock).toHaveBeenLastCalledWith(expect.objectContaining({
+    expect(applyFixedWidthShapeTextLayoutMock).toHaveBeenLastCalledWith(expect.objectContaining({
       expandShapeHeightToFitText: false
     }))
   })
@@ -1407,7 +1452,7 @@ describe('shape-scaling', () => {
       } as never
     })
 
-    const layoutCall = applyShapeTextLayoutMock.mock.calls[applyShapeTextLayoutMock.mock.calls.length - 1]?.[0]
+    const layoutCall = applyFixedWidthShapeTextLayoutMock.mock.calls[applyFixedWidthShapeTextLayoutMock.mock.calls.length - 1]?.[0]
 
     expect(layoutCall).toEqual(expect.objectContaining({
       width: 200,
@@ -1708,6 +1753,10 @@ describe('shape-scaling', () => {
     })
 
     expect(applyShapeTextLayoutMock).not.toHaveBeenCalled()
+    expect(applyFixedWidthShapeTextLayoutMock).toHaveBeenCalledWith(expect.objectContaining({
+      width: 60,
+      height: 180
+    }))
     expect(resizeShapeNodeMock).toHaveBeenLastCalledWith(expect.objectContaining({
       width: 60,
       height: 180
@@ -1781,7 +1830,7 @@ describe('shape-scaling', () => {
       target: group
     })
 
-    const layoutCall = applyShapeTextLayoutMock.mock.calls[applyShapeTextLayoutMock.mock.calls.length - 1]?.[0]
+    const layoutCall = applyFixedWidthShapeTextLayoutMock.mock.calls[applyFixedWidthShapeTextLayoutMock.mock.calls.length - 1]?.[0]
 
     expect(layoutCall).toEqual(expect.objectContaining({
       width: 209,
@@ -1826,6 +1875,9 @@ describe('shape-scaling', () => {
       localPoint: new Point(0, -10)
     })
 
+    group.shapeBaseWidth = 140
+    group.shapeManualBaseWidth = 140
+    group.width = 140
     group.scaleX = 0.7
     group.scaleY = 0.9
 
@@ -2049,12 +2101,12 @@ describe('shape-scaling', () => {
       target: group
     })
 
-    const layoutCall = applyShapeTextLayoutMock.mock.calls[applyShapeTextLayoutMock.mock.calls.length - 1]?.[0]
+    const layoutCall = applyFixedWidthShapeTextLayoutMock.mock.calls[applyFixedWidthShapeTextLayoutMock.mock.calls.length - 1]?.[0]
 
     expect(layoutCall).toEqual(expect.objectContaining({
       width: 200,
       height: 100,
-      shapeTextAutoExpandEnabled: true
+      expandShapeHeightToFitText: false
     }))
     expect(group.shapeTextAutoExpand).toBe(true)
     expect(group.shapeManualBaseWidth).toBe(200)

--- a/specs/test-utils/shape-helpers.ts
+++ b/specs/test-utils/shape-helpers.ts
@@ -1,5 +1,8 @@
 import { Group, Point } from 'fabric'
-import type { ShapeTextNode } from '../../src/editor/shape-manager/types'
+import type {
+  ShapeNode,
+  ShapeTextNode
+} from '../../src/editor/shape-manager/types'
 import { BackgroundTextbox } from '../../src/editor/text-manager/background-textbox'
 
 const CHAR_WIDTH_RATIO = 0.55
@@ -25,7 +28,7 @@ type MockCanvas = {
 type PlacementOriginX = 'left' | 'center' | 'right'
 type PlacementOriginY = 'top' | 'center' | 'bottom'
 
-type MockShapeNode = {
+interface MockShapeNode extends ShapeNode {
   id?: string
   type: string
   shapeNodeType: 'shape'
@@ -145,7 +148,7 @@ export const createMockShapeNode = ({
     setCoords: jest.fn()
   }
 
-  return shape
+  return shape as MockShapeNode
 }
 
 /**

--- a/src/editor/shape-manager/layout/shape-layout.ts
+++ b/src/editor/shape-manager/layout/shape-layout.ts
@@ -11,13 +11,14 @@ import {
 } from './shape-layout-padding'
 import {
   ShapeLayoutInput,
+  ShapeTextMeasurementCache,
   ShapePadding,
   ShapeVerticalAlign
 } from '../types'
 
 const MIN_TEXT_FRAME_SIZE = MIN_SHAPE_TEXT_FRAME_SIZE
 const TEXT_FRAME_FILL_EPSILON = 0.5
-const MAX_LAYOUT_RESOLVE_ITERATIONS = 8
+const MAX_DYNAMIC_PADDING_LAYOUT_ITERATIONS = 24
 const MAX_WIDTH_SEARCH_ITERATIONS = 20
 const MAX_WIDTH_BOUND_EXPANSIONS = 16
 
@@ -25,6 +26,8 @@ type TextboxMeasurementState = {
   autoExpand?: boolean
   splitByGrapheme?: boolean
   width?: number
+  scaleX?: number
+  scaleY?: number
 }
 
 type ShapeTextFrame = {
@@ -84,10 +87,33 @@ type ShapeTextLayoutResolution = {
 
 type ResolveShapeTextLayoutParams = Omit<ShapeLayoutInput, 'group' | 'shape' | 'alignH'>
 
-type ResolveShapeTextFixedWidthLayoutParams = Omit<
-ShapeLayoutInput,
-'group' | 'shape' | 'alignH' | 'preserveAspectRatio' | 'shapeTextAutoExpandEnabled' | 'montageAreaWidth'
->
+type ResolveShapeTextFixedWidthLayoutParams = {
+  text: ShapeLayoutInput['text']
+  width: number
+  height: number
+  alignV: ShapeVerticalAlign
+  padding: ShapePadding
+  internalShapeTextInset?: ShapePadding
+  resolveInternalShapeTextInset?: ShapeLayoutInput['resolveInternalShapeTextInset']
+  expandShapeHeightToFitText?: boolean
+  changedPadding?: ShapeLayoutInput['changedPadding']
+  measurementCache?: ShapeTextMeasurementCache
+}
+
+type ApplyFixedWidthShapeTextLayoutParams = {
+  group: ShapeLayoutInput['group']
+  shape: ShapeLayoutInput['shape']
+  text: ShapeLayoutInput['text']
+  width: number
+  height: number
+  alignH: ShapeLayoutInput['alignH']
+  alignV: ShapeLayoutInput['alignV']
+  padding: ShapePadding
+  internalShapeTextInset?: ShapePadding
+  resolveInternalShapeTextInset?: ShapeLayoutInput['resolveInternalShapeTextInset']
+  expandShapeHeightToFitText?: boolean
+  changedPadding?: ShapeLayoutInput['changedPadding']
+}
 
 type ResolveShapeTextLayoutStateParams = {
   text: ShapeLayoutInput['text']
@@ -221,7 +247,8 @@ export const resolveShapeTextFixedWidthLayout = ({
   internalShapeTextInset,
   resolveInternalShapeTextInset,
   expandShapeHeightToFitText = true,
-  changedPadding
+  changedPadding,
+  measurementCache
 }: ResolveShapeTextFixedWidthLayoutParams): ResolvedShapeTextLayout => {
   const requestedUserPadding = normalizeShapeUserPadding({
     padding
@@ -244,11 +271,18 @@ export const resolveShapeTextFixedWidthLayout = ({
     }),
     expandShapeHeightToFitText,
     changedPadding,
-    measureTextboxHeightForFrame,
-    resolveMinimumTextFrameWidth
+    measureTextboxHeightForFrame: ({ text: targetText, frameWidth }) => measureTextboxHeightForFrame({
+      text: targetText,
+      frameWidth,
+      measurementCache
+    }),
+    resolveMinimumTextFrameWidth: ({ text: targetText }) => resolveMinimumTextFrameWidth({
+      text: targetText,
+      measurementCache
+    })
   })
 
-  for (let iteration = 0; iteration < MAX_LAYOUT_RESOLVE_ITERATIONS; iteration += 1) {
+  for (let iteration = 0; iteration < MAX_DYNAMIC_PADDING_LAYOUT_ITERATIONS; iteration += 1) {
     const nextHeight = Math.max(resolvedHeight, resolvedPaddingLayout.requiredHeight)
 
     if (nextHeight <= resolvedHeight + TEXT_FRAME_FILL_EPSILON) {
@@ -269,8 +303,15 @@ export const resolveShapeTextFixedWidthLayout = ({
       }),
       expandShapeHeightToFitText,
       changedPadding,
-      measureTextboxHeightForFrame,
-      resolveMinimumTextFrameWidth
+      measureTextboxHeightForFrame: ({ text: targetText, frameWidth }) => measureTextboxHeightForFrame({
+        text: targetText,
+        frameWidth,
+        measurementCache
+      }),
+      resolveMinimumTextFrameWidth: ({ text: targetText }) => resolveMinimumTextFrameWidth({
+        text: targetText,
+        measurementCache
+      })
     })
   }
 
@@ -284,47 +325,29 @@ export const resolveShapeTextFixedWidthLayout = ({
   })
 }
 
-export const applyShapeTextLayout = ({
+function applyResolvedShapeTextLayout({
   group,
   shape,
   text,
-  width,
-  height,
   alignH,
   alignV,
-  padding,
-  internalShapeTextInset,
-  resolveInternalShapeTextInset,
-  preserveAspectRatio,
-  shapeTextAutoExpandEnabled,
-  montageAreaWidth,
-  expandShapeHeightToFitText = true,
-  changedPadding
-}: ShapeLayoutInput): void => {
+  resolvedLayout
+}: {
+  group: ShapeLayoutInput['group']
+  shape: ShapeLayoutInput['shape']
+  text: ShapeLayoutInput['text']
+  alignH: ShapeLayoutInput['alignH']
+  alignV: ShapeLayoutInput['alignV']
+  resolvedLayout: ResolvedShapeTextLayout
+}): void {
   const manualBaseWidth = Math.max(
     MIN_TEXT_FRAME_SIZE,
-    group.shapeManualBaseWidth ?? width
+    group.shapeManualBaseWidth ?? resolvedLayout.width
   )
   const manualBaseHeight = Math.max(
     MIN_TEXT_FRAME_SIZE,
-    group.shapeManualBaseHeight ?? height
+    group.shapeManualBaseHeight ?? resolvedLayout.height
   )
-  const isShapeTextAutoExpandEnabled = shapeTextAutoExpandEnabled
-    ?? group.shapeTextAutoExpand !== false
-  const resolvedLayout = resolveShapeTextLayout({
-    text,
-    width,
-    height,
-    alignV,
-    padding,
-    internalShapeTextInset,
-    resolveInternalShapeTextInset,
-    preserveAspectRatio,
-    shapeTextAutoExpandEnabled: isShapeTextAutoExpandEnabled,
-    montageAreaWidth,
-    expandShapeHeightToFitText,
-    changedPadding
-  })
   const {
     width: finalWidth,
     height: finalHeight,
@@ -385,6 +408,112 @@ export const applyShapeTextLayout = ({
 
   group.set('dirty', true)
   group.setCoords()
+}
+
+function resolveMeasurementFrameWidthCacheKey({
+  frameWidth
+}: {
+  frameWidth: number
+}): string {
+  return String(Math.round(Math.max(MIN_TEXT_FRAME_SIZE, frameWidth) * 1000) / 1000)
+}
+
+function resolveMeasurementCacheKey({
+  frameWidth,
+  splitByGrapheme
+}: {
+  frameWidth: number
+  splitByGrapheme: boolean
+}): string {
+  return `${resolveMeasurementFrameWidthCacheKey({ frameWidth })}:${splitByGrapheme ? 1 : 0}`
+}
+
+/**
+ * Применяет итоговый layout shape + text.
+ * Использует общий auto-fit commit-контракт и при необходимости расширяет размер shape по тексту.
+ */
+export const applyShapeTextLayout = ({
+  group,
+  shape,
+  text,
+  width,
+  height,
+  alignH,
+  alignV,
+  padding,
+  internalShapeTextInset,
+  resolveInternalShapeTextInset,
+  preserveAspectRatio,
+  shapeTextAutoExpandEnabled,
+  montageAreaWidth,
+  expandShapeHeightToFitText = true,
+  changedPadding
+}: ShapeLayoutInput): void => {
+  const isShapeTextAutoExpandEnabled = shapeTextAutoExpandEnabled
+    ?? group.shapeTextAutoExpand !== false
+  const resolvedLayout = resolveShapeTextLayout({
+    text,
+    width,
+    height,
+    alignV,
+    padding,
+    internalShapeTextInset,
+    resolveInternalShapeTextInset,
+    preserveAspectRatio,
+    shapeTextAutoExpandEnabled: isShapeTextAutoExpandEnabled,
+    montageAreaWidth,
+    expandShapeHeightToFitText,
+    changedPadding
+  })
+
+  applyResolvedShapeTextLayout({
+    group,
+    shape,
+    text,
+    alignH,
+    alignV,
+    resolvedLayout
+  })
+}
+
+/**
+ * Применяет итоговый layout shape + text в fixed-width режиме.
+ * Переданная ширина считается уже выбранной текущим контрактом объекта и не расширяется.
+ */
+export const applyFixedWidthShapeTextLayout = ({
+  group,
+  shape,
+  text,
+  width,
+  height,
+  alignH,
+  alignV,
+  padding,
+  internalShapeTextInset,
+  resolveInternalShapeTextInset,
+  expandShapeHeightToFitText = true,
+  changedPadding
+}: ApplyFixedWidthShapeTextLayoutParams): void => {
+  const resolvedLayout = resolveShapeTextFixedWidthLayout({
+    text,
+    width,
+    height,
+    alignV,
+    padding,
+    internalShapeTextInset,
+    resolveInternalShapeTextInset,
+    expandShapeHeightToFitText,
+    changedPadding
+  })
+
+  applyResolvedShapeTextLayout({
+    group,
+    shape,
+    text,
+    alignH,
+    alignV,
+    resolvedLayout
+  })
 }
 
 function resolveShapeTextLayoutResolutionForAspectRatio({
@@ -669,17 +798,22 @@ export const resolveShapeTextAutoExpandWidthForText = ({
 export const resolveMinimumShapeWidthForText = ({
   text,
   padding,
-  resolvePaddingForWidth
+  resolvePaddingForWidth,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
   padding?: ShapePadding
   resolvePaddingForWidth?: ResolvePaddingForWidth
+  measurementCache?: ShapeTextMeasurementCache
 }): number => {
   if (!hasShapeTextContent({
     text
   })) return MIN_TEXT_FRAME_SIZE
 
-  const minimumFrameWidth = resolveMinimumTextFrameWidth({ text })
+  const minimumFrameWidth = resolveMinimumTextFrameWidth({
+    text,
+    measurementCache
+  })
   const minimumSearchWidth = Math.max(MIN_TEXT_FRAME_SIZE, minimumFrameWidth)
   const isWidthValid: ResolveShapeWidthValidity = ({ width }) => {
     const currentPadding = resolveCurrentPaddingForWidth({
@@ -801,13 +935,15 @@ export const resolveRequiredShapeHeightForText = ({
   width,
   height,
   padding,
-  resolvePaddingForSize
+  resolvePaddingForSize,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
   width: number
   height: number
   padding: ShapePadding
   resolvePaddingForSize?: ResolvePaddingForSize
+  measurementCache?: ShapeTextMeasurementCache
 }): number => {
   const safeHeight = Math.max(MIN_TEXT_FRAME_SIZE, height)
   if (!hasShapeTextContent({
@@ -817,7 +953,7 @@ export const resolveRequiredShapeHeightForText = ({
   const safeWidth = Math.max(MIN_TEXT_FRAME_SIZE, width)
   let requiredHeight = safeHeight
 
-  for (let iteration = 0; iteration < MAX_LAYOUT_RESOLVE_ITERATIONS; iteration += 1) {
+  for (let iteration = 0; iteration < MAX_DYNAMIC_PADDING_LAYOUT_ITERATIONS; iteration += 1) {
     const currentPadding = resolveCurrentPaddingForSize({
       width: safeWidth,
       height: requiredHeight,
@@ -830,7 +966,8 @@ export const resolveRequiredShapeHeightForText = ({
     })
     const measuredHeight = measureTextboxHeightForFrame({
       text,
-      frameWidth
+      frameWidth,
+      measurementCache
     })
     const nextHeight = Math.max(
       safeHeight,
@@ -967,7 +1104,7 @@ function resolveShapeTextLayoutResolution({
     resolveMinimumTextFrameWidth
   })
 
-  for (let iteration = 0; iteration < MAX_LAYOUT_RESOLVE_ITERATIONS; iteration += 1) {
+  for (let iteration = 0; iteration < MAX_DYNAMIC_PADDING_LAYOUT_ITERATIONS; iteration += 1) {
     const nextWidth = Math.max(finalWidth, resolvedPaddingLayout.requiredWidth)
     const nextHeight = Math.max(finalHeight, resolvedPaddingLayout.requiredHeight)
 
@@ -1118,23 +1255,39 @@ function getTextboxHeight({ text }: { text: ShapeLayoutInput['text'] }): number 
 export function measureShapeTextFrameLayout({
   text,
   frameWidth,
-  splitByGrapheme
+  splitByGrapheme,
+  requiresGraphemeSplit,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
   frameWidth: number
   splitByGrapheme: boolean
+  requiresGraphemeSplit?: boolean
+  measurementCache?: ShapeTextMeasurementCache
 }): ShapeTextFrameMeasurement {
   const safeFrameWidth = Math.max(MIN_TEXT_FRAME_SIZE, frameWidth)
-  const previousState = captureTextboxMeasurementState({ text })
-  const requiresGraphemeSplit = resolveSplitByGraphemeForFrame({
-    text,
-    frameWidth: safeFrameWidth
+  const measurementCacheKey = resolveMeasurementCacheKey({
+    frameWidth: safeFrameWidth,
+    splitByGrapheme
   })
+  const cachedMeasurement = measurementCache?.measurementsByKey.get(measurementCacheKey)
+
+  if (cachedMeasurement) return cachedMeasurement
+
+  const previousState = captureTextboxMeasurementState({ text })
+  const resolvedRequiresGraphemeSplit = requiresGraphemeSplit
+    ?? resolveSplitByGraphemeForFrame({
+      text,
+      frameWidth: safeFrameWidth,
+      measurementCache
+    })
 
   text.set({
     autoExpand: false,
     width: safeFrameWidth,
-    splitByGrapheme
+    splitByGrapheme,
+    scaleX: 1,
+    scaleY: 1
   })
   text.initDimensions()
 
@@ -1144,13 +1297,15 @@ export function measureShapeTextFrameLayout({
     measuredHeight: getTextboxHeight({ text }),
     renderedLineCount: renderedLineCount > 0 ? renderedLineCount : explicitLineCount,
     longestLineWidth: Math.ceil(getTextboxLongestLineWidth({ text })),
-    requiresGraphemeSplit
+    requiresGraphemeSplit: resolvedRequiresGraphemeSplit
   }
 
   restoreTextboxMeasurementState({
     text,
     state: previousState
   })
+
+  measurementCache?.measurementsByKey.set(measurementCacheKey, measurement)
 
   return measurement
 }
@@ -1160,22 +1315,28 @@ export function measureShapeTextFrameLayout({
  */
 function measureTextboxLayoutForFrame({
   text,
-  frameWidth
+  frameWidth,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
   frameWidth: number
+  measurementCache?: ShapeTextMeasurementCache
 }): {
   hasWrappedLines: boolean
   longestLineWidth: number
 } {
   const explicitLineCount = getExplicitTextboxLineCount({ text })
+  const requiresGraphemeSplit = resolveSplitByGraphemeForFrame({
+    text,
+    frameWidth,
+    measurementCache
+  })
   const measurement = measureShapeTextFrameLayout({
     text,
     frameWidth,
-    splitByGrapheme: resolveSplitByGraphemeForFrame({
-      text,
-      frameWidth
-    })
+    splitByGrapheme: requiresGraphemeSplit,
+    requiresGraphemeSplit,
+    measurementCache
   })
 
   return {
@@ -1190,22 +1351,27 @@ function measureTextboxLayoutForFrame({
 function measureTextboxHeightForFrame({
   text,
   frameWidth,
-  splitByGrapheme
+  splitByGrapheme,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
   frameWidth: number
   splitByGrapheme?: boolean
+  measurementCache?: ShapeTextMeasurementCache
 }): number {
   const resolvedSplitByGrapheme = splitByGrapheme
     ?? resolveSplitByGraphemeForFrame({
       text,
-      frameWidth
+      frameWidth,
+      measurementCache
     })
 
   return measureShapeTextFrameLayout({
     text,
     frameWidth,
-    splitByGrapheme: resolvedSplitByGrapheme
+    splitByGrapheme: resolvedSplitByGrapheme,
+    requiresGraphemeSplit: resolvedSplitByGrapheme,
+    measurementCache
   }).measuredHeight
 }
 
@@ -1213,17 +1379,30 @@ function measureTextboxHeightForFrame({
  * Возвращает минимальную ширину текстового фрейма, достаточную для отображения одного символа.
  */
 function resolveMinimumTextFrameWidth({
-  text
+  text,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
+  measurementCache?: ShapeTextMeasurementCache
 }): number {
+  if (measurementCache?.minimumTextFrameWidth !== null && measurementCache?.minimumTextFrameWidth !== undefined) {
+    return measurementCache.minimumTextFrameWidth
+  }
+
   const minimumFrameWidth = measureTextboxLongestLineWidthForFrame({
     text,
     frameWidth: MIN_TEXT_FRAME_SIZE,
-    splitByGrapheme: true
+    splitByGrapheme: true,
+    measurementCache
   })
 
-  return Math.max(MIN_TEXT_FRAME_SIZE, minimumFrameWidth)
+  const resolvedMinimumTextFrameWidth = Math.max(MIN_TEXT_FRAME_SIZE, minimumFrameWidth)
+
+  if (measurementCache) {
+    measurementCache.minimumTextFrameWidth = resolvedMinimumTextFrameWidth
+  }
+
+  return resolvedMinimumTextFrameWidth
 }
 
 /**
@@ -1232,18 +1411,31 @@ function resolveMinimumTextFrameWidth({
 function measureTextboxLongestLineWidthForFrame({
   text,
   frameWidth,
-  splitByGrapheme
+  splitByGrapheme,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
   frameWidth: number
   splitByGrapheme: boolean
+  measurementCache?: ShapeTextMeasurementCache
 }): number {
+  const cachedMeasurement = measurementCache?.measurementsByKey.get(resolveMeasurementCacheKey({
+    frameWidth,
+    splitByGrapheme
+  }))
+
+  if (cachedMeasurement) {
+    return cachedMeasurement.longestLineWidth
+  }
+
   const previousState = captureTextboxMeasurementState({ text })
 
   text.set({
     autoExpand: false,
     width: Math.max(MIN_TEXT_FRAME_SIZE, frameWidth),
-    splitByGrapheme
+    splitByGrapheme,
+    scaleX: 1,
+    scaleY: 1
   })
 
   text.initDimensions()
@@ -1284,18 +1476,31 @@ function resolveVerticalTop({
  */
 function resolveSplitByGraphemeForFrame({
   text,
-  frameWidth
+  frameWidth,
+  measurementCache
 }: {
   text: ShapeLayoutInput['text']
   frameWidth: number
+  measurementCache?: ShapeTextMeasurementCache
 }): boolean {
   const safeFrameWidth = Math.max(MIN_TEXT_FRAME_SIZE, frameWidth)
+  const frameWidthCacheKey = resolveMeasurementFrameWidthCacheKey({
+    frameWidth: safeFrameWidth
+  })
+  const cachedSplitByGrapheme = measurementCache?.splitByGraphemeByFrameWidth.get(frameWidthCacheKey)
+
+  if (typeof cachedSplitByGrapheme === 'boolean') {
+    return cachedSplitByGrapheme
+  }
+
   const previousState = captureTextboxMeasurementState({ text })
 
   text.set({
     autoExpand: false,
     width: safeFrameWidth,
-    splitByGrapheme: false
+    splitByGrapheme: false,
+    scaleX: 1,
+    scaleY: 1
   })
   text.initDimensions()
 
@@ -1306,6 +1511,8 @@ function resolveSplitByGraphemeForFrame({
     text,
     state: previousState
   })
+
+  measurementCache?.splitByGraphemeByFrameWidth.set(frameWidthCacheKey, shouldSplitByGrapheme)
 
   return shouldSplitByGrapheme
 }
@@ -1401,13 +1608,17 @@ function captureTextboxMeasurementState({
   const {
     autoExpand,
     splitByGrapheme,
-    width
+    width,
+    scaleX,
+    scaleY
   } = text
 
   return {
     autoExpand,
     splitByGrapheme,
-    width: typeof width === 'number' ? width : undefined
+    width: typeof width === 'number' ? width : undefined,
+    scaleX: typeof scaleX === 'number' ? scaleX : undefined,
+    scaleY: typeof scaleY === 'number' ? scaleY : undefined
   }
 }
 
@@ -1424,7 +1635,9 @@ function restoreTextboxMeasurementState({
   const {
     autoExpand,
     splitByGrapheme,
-    width
+    width,
+    scaleX,
+    scaleY
   } = state
 
   const updates: TextboxMeasurementState = {}
@@ -1438,6 +1651,14 @@ function restoreTextboxMeasurementState({
 
   if (typeof width === 'number') {
     updates.width = width
+  }
+
+  if (typeof scaleX === 'number') {
+    updates.scaleX = scaleX
+  }
+
+  if (typeof scaleY === 'number') {
+    updates.scaleY = scaleY
   }
 
   const hasUpdates = Object.keys(updates).length > 0

--- a/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-active-selection-scaling.ts
@@ -163,11 +163,14 @@ export default class ShapeActiveSelectionScalingController {
     })
     const isShiftPressed = Boolean(event && 'shiftKey' in event && event.shiftKey)
     const isProportionalCornerScale = isCornerScaleAction && !isShiftPressed
-    const proportionalLayoutResults = isProportionalCornerScale
-      ? this._resolveProportionalLayoutResults({ items })
-      : null
     const scaleX = Math.abs(selection.scaleX ?? 1) || 1
     const scaleY = Math.abs(selection.scaleY ?? 1) || 1
+    const shouldResolveProportionalLayoutResults = isProportionalCornerScale
+      && (scaleX < 1 - SCALE_EPSILON || scaleY < 1 - SCALE_EPSILON)
+    const proportionalLayoutResults = isProportionalCornerScale
+      && shouldResolveProportionalLayoutResults
+      ? this._resolveProportionalLayoutResults({ items })
+      : null
     let selectionScale = this._resolveSelectionScale({
       items,
       session,
@@ -231,7 +234,8 @@ export default class ShapeActiveSelectionScalingController {
           constraintPadding,
           startDimensions: state,
           appliedScaleX: layoutScale.scaleX,
-          appliedScaleY: layoutScale.scaleY
+          appliedScaleY: layoutScale.scaleY,
+          measurementCache: state.previewTextMeasurementCache
         }).previewHeight
       }
 
@@ -542,22 +546,27 @@ export default class ShapeActiveSelectionScalingController {
     let appliedScaleY = scaleY
 
     if (isProportionalCornerScale) {
+      const proportionalScale = Math.max(scaleX, scaleY)
+
       if (!proportionalLayoutResults) {
-        throw new Error('proportional layout results are required for ActiveSelection proportional scaling')
+        return {
+          scaleX: proportionalScale,
+          scaleY: proportionalScale
+        }
       }
 
-      const proportionalScale = this._resolveProportionalSelectionScale({
+      const resolvedProportionalScale = this._resolveProportionalSelectionScale({
         items,
         session,
         proportionalLayoutResults,
-        scale: Math.max(scaleX, scaleY),
+        scale: proportionalScale,
         allowGrowthX: canScaleHeight,
         allowGrowthY: canScaleWidth
       })
 
       return {
-        scaleX: proportionalScale,
-        scaleY: proportionalScale
+        scaleX: resolvedProportionalScale,
+        scaleY: resolvedProportionalScale
       }
     }
 
@@ -951,6 +960,7 @@ export default class ShapeActiveSelectionScalingController {
     return resolveMinimumShapeWidthForText({
       text,
       padding: constraintPadding,
+      measurementCache: state.previewTextMeasurementCache ?? undefined,
       resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
         group,
         width,
@@ -994,7 +1004,8 @@ export default class ShapeActiveSelectionScalingController {
       group,
       text,
       width: attemptedWidth,
-      padding: constraintPadding
+      padding: constraintPadding,
+      measurementCache: state.previewTextMeasurementCache
     })
   }
 

--- a/src/editor/shape-manager/scaling/shape-scaling-layout.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling-layout.ts
@@ -1,5 +1,6 @@
 import type { Transform } from 'fabric'
 import {
+  applyFixedWidthShapeTextLayout,
   applyShapeTextLayout,
   measureShapeTextFrameLayout,
   resolveShapeTextFixedWidthLayout,
@@ -22,6 +23,7 @@ import type {
   ShapeHorizontalAlign,
   ShapeNode,
   ShapePadding,
+  ShapeScalingProportionalTextConstraintCacheEntry,
   ShapeScalingState,
   ShapeTextNode,
   ShapeVerticalAlign
@@ -84,12 +86,19 @@ type ShapePreviewDimensions = {
 
 type ShapePreviewLayout = ResolvedShapeTextLayout
 
-export type ShapeScalingProportionalTextConstraint = {
-  measuredHeight: number
-  renderedLineCount: number
-  longestLineWidth: number
-  requiresGraphemeSplit: boolean
-  isValid: boolean
+export type ShapeScalingProportionalTextConstraint = ShapeScalingProportionalTextConstraintCacheEntry
+
+function resolveShapeScalingSizeCacheKey({
+  width,
+  height
+}: {
+  width: number
+  height: number
+}): string {
+  const normalizedWidth = Math.round(Math.max(SHAPE_SCALING_MIN_SIZE, width) * 1_000_000) / 1_000_000
+  const normalizedHeight = Math.round(Math.max(SHAPE_SCALING_MIN_SIZE, height) * 1_000_000) / 1_000_000
+
+  return `${normalizedWidth}:${normalizedHeight}`
 }
 
 function resolveShapeScalingTextFrameWidth({
@@ -200,15 +209,27 @@ export function validateShapeTextLayoutForProportionalScaling({
   group,
   text,
   width,
-  height
+  height,
+  measurementCache,
+  constraintCache
 }: {
   group: ShapeGroup
   text: ShapeTextNode
   width: number
   height: number
+  measurementCache?: ShapeScalingState['previewTextMeasurementCache']
+  constraintCache?: ShapeScalingState['proportionalTextConstraintCache']
 }): ShapeScalingProportionalTextConstraint {
   const safeWidth = Math.max(SHAPE_SCALING_MIN_SIZE, width)
   const safeHeight = Math.max(SHAPE_SCALING_MIN_SIZE, height)
+  const constraintCacheKey = resolveShapeScalingSizeCacheKey({
+    width: safeWidth,
+    height: safeHeight
+  })
+  const cachedConstraint = constraintCache?.get(constraintCacheKey)
+
+  if (cachedConstraint) return cachedConstraint
+
   const constraintPadding = resolveShapeScalingConstraintPadding({
     group,
     width: safeWidth,
@@ -225,14 +246,19 @@ export function validateShapeTextLayoutForProportionalScaling({
   const measurement = measureShapeTextFrameLayout({
     text,
     frameWidth,
-    splitByGrapheme: false
+    splitByGrapheme: false,
+    measurementCache: measurementCache ?? undefined
   })
 
-  return {
+  const constraint = {
     ...measurement,
     isValid: !measurement.requiresGraphemeSplit
       && measurement.measuredHeight <= frameHeight + SHAPE_SCALING_SIZE_EPSILON
   }
+
+  constraintCache?.set(constraintCacheKey, constraint)
+
+  return constraint
 }
 
 /**
@@ -276,7 +302,9 @@ export function resolveMinimumProportionalShapeScale({
       group,
       text,
       width: attemptedWidth,
-      height: attemptedHeight
+      height: attemptedHeight,
+      measurementCache: state.previewTextMeasurementCache,
+      constraintCache: state.proportionalTextConstraintCache
     })
 
     return {
@@ -329,18 +357,21 @@ export function resolveMinimumTextFitHeight({
   group,
   text,
   width,
-  padding
+  padding,
+  measurementCache
 }: {
   group: ShapeGroup
   text: ShapeTextNode
   width: number
   padding: ShapePadding
+  measurementCache?: ShapeScalingState['previewTextMeasurementCache']
 }): number {
   return resolveRequiredShapeHeightForText({
     text,
     width,
     height: SHAPE_SCALING_MIN_SIZE,
     padding,
+    measurementCache: measurementCache ?? undefined,
     resolvePaddingForSize: ({ width: nextWidth, height: nextHeight }) => {
       return resolveShapeScalingConstraintPadding({
         group,
@@ -361,7 +392,8 @@ export function resolveShapeScalingPreviewDimensions({
   startDimensions,
   appliedScaleX,
   appliedScaleY,
-  minimumHeight
+  minimumHeight,
+  measurementCache
 }: {
   group: ShapeGroup
   text: ShapeTextNode
@@ -370,6 +402,7 @@ export function resolveShapeScalingPreviewDimensions({
   appliedScaleX: number
   appliedScaleY: number
   minimumHeight?: number | null
+  measurementCache?: ShapeScalingState['previewTextMeasurementCache']
 }): ShapePreviewDimensions {
   const previewWidth = startDimensions.canScaleWidth
     ? Math.max(SHAPE_SCALING_MIN_SIZE, startDimensions.startWidth * appliedScaleX)
@@ -382,6 +415,7 @@ export function resolveShapeScalingPreviewDimensions({
     width: previewWidth,
     height: scaledPreviewHeight,
     padding: constraintPadding,
+    measurementCache: measurementCache ?? undefined,
     resolvePaddingForSize: ({ width, height }) => resolveShapeScalingConstraintPadding({
       group,
       width,
@@ -436,6 +470,7 @@ export function resolveShapeScalingPreviewLayout({
     alignV: group.shapeAlignVertical ?? SHAPE_DEFAULT_VERTICAL_ALIGN,
     padding: resolveShapeScalingUserPadding({ group }),
     expandShapeHeightToFitText,
+    measurementCache: state.previewTextMeasurementCache ?? undefined,
     resolveInternalShapeTextInset: ({ width, height }) => resolveShapeScalingInternalTextInset({
       group,
       width,
@@ -545,11 +580,19 @@ export function ensureShapeScalingState({
     originX: startTransformOriginX,
     originY: startTransformOriginY
   })
+  const isFixedWidthVerticalScaling = !startDimensions.canScaleWidth && startDimensions.canScaleHeight
+  const previewTextMeasurementCache = {
+    measurementsByKey: new Map(),
+    splitByGraphemeByFrameWidth: new Map(),
+    minimumTextFrameWidth: null
+  }
+  const proportionalTextConstraintCache = new Map<string, ShapeScalingProportionalTextConstraintCacheEntry>()
   const minimumHeightAtStart = resolveMinimumTextFitHeight({
     group,
     text,
     width: startDimensions.startWidth,
-    padding: constraintPadding
+    padding: constraintPadding,
+    measurementCache: previewTextMeasurementCache
   })
 
   state = {
@@ -581,7 +624,10 @@ export function ensureShapeScalingState({
     lastAllowedLeft: startLeft,
     lastAllowedTop: startTop,
     scaleDirectionX: null,
-    scaleDirectionY: null
+    scaleDirectionY: null,
+    fixedWidthMinimumTextFitHeight: isFixedWidthVerticalScaling ? minimumHeightAtStart : null,
+    previewTextMeasurementCache,
+    proportionalTextConstraintCache
   }
 
   scalingState.set(group, state)
@@ -708,27 +754,47 @@ export function commitResolvedShapeScalingLayout({
     height
   })
   const expandShapeHeightToFitText = !canScaleHeight
+  const resolveInternalShapeTextInsetForSize = ({ width: nextWidth, height: nextHeight }: {
+    width: number
+    height: number
+  }) => {
+    return resolveShapeScalingInternalTextInset({
+      group,
+      width: nextWidth,
+      height: nextHeight
+    })
+  }
 
-  applyShapeTextLayout({
-    group,
-    shape,
-    text,
-    width,
-    height,
-    alignH,
-    alignV,
-    padding: userPadding,
-    shapeTextAutoExpandEnabled: group.shapeTextAutoExpand !== false,
-    internalShapeTextInset,
-    expandShapeHeightToFitText,
-    resolveInternalShapeTextInset: ({ width: nextWidth, height: nextHeight }) => {
-      return resolveShapeScalingInternalTextInset({
-        group,
-        width: nextWidth,
-        height: nextHeight
-      })
-    }
-  })
+  if (!canScaleWidth && canScaleHeight) {
+    applyFixedWidthShapeTextLayout({
+      group,
+      shape,
+      text,
+      width,
+      height,
+      alignH,
+      alignV,
+      padding: userPadding,
+      internalShapeTextInset,
+      expandShapeHeightToFitText,
+      resolveInternalShapeTextInset: resolveInternalShapeTextInsetForSize
+    })
+  } else {
+    applyShapeTextLayout({
+      group,
+      shape,
+      text,
+      width,
+      height,
+      alignH,
+      alignV,
+      padding: userPadding,
+      shapeTextAutoExpandEnabled: group.shapeTextAutoExpand !== false,
+      internalShapeTextInset,
+      expandShapeHeightToFitText,
+      resolveInternalShapeTextInset: resolveInternalShapeTextInsetForSize
+    })
+  }
 
   group.shapeReplaceBoxWidth = Math.max(1, width)
   group.shapeReplaceBoxHeight = Math.max(1, height)

--- a/src/editor/shape-manager/scaling/shape-scaling.ts
+++ b/src/editor/shape-manager/scaling/shape-scaling.ts
@@ -6,10 +6,10 @@ import {
   Transform
 } from 'fabric'
 import {
+  applyFixedWidthShapeTextLayout,
   applyShapeTextLayout,
   resolveMinimumShapeWidthForText
 } from '../layout/shape-layout'
-import { resizeShapeNode } from '../shape-factory'
 import {
   ShapeGroup,
   ShapePadding,
@@ -70,7 +70,6 @@ type ShapeModifiedEvent = {
 type ShapeScalingDecision = {
   appliedScaleX: number
   appliedScaleY: number
-  previewWidth: number
   previewHeight: number
   shouldHandleAsNoop: boolean
   shouldRestoreLastAllowedTransform: boolean
@@ -160,9 +159,7 @@ export default class ShapeScalingController {
       constraintPadding,
       transform
     })
-    const { isCornerScaleAction } = resolveShapeScaleActionAxes({
-      transform
-    })
+    const isCornerScaleAction = state.canScaleWidth && state.canScaleHeight
     const isShiftPressed = Boolean(event.e && 'shiftKey' in event.e && event.e.shiftKey)
     const isProportionalCornerScale = isCornerScaleAction && !isShiftPressed
 
@@ -185,6 +182,17 @@ export default class ShapeScalingController {
       state,
       transform
     })
+
+    if (scalingDecision.shouldHandleAsNoop) {
+      this._restoreBlockedScalingAttempt({
+        group,
+        shape,
+        text,
+        state
+      })
+      return
+    }
+
     const previewLayout = resolveShapeScalingPreviewLayout({
       group,
       text,
@@ -193,10 +201,9 @@ export default class ShapeScalingController {
       appliedScaleY: scalingDecision.appliedScaleY,
       minimumHeight: scalingDecision.previewHeight
     })
-    const currentScaleX = Math.abs(group.scaleX ?? 1) || 1
-    const currentScaleY = Math.abs(group.scaleY ?? 1) || 1
-    const shouldApplyResolvedTransform = scalingDecision.shouldHandleAsNoop
-      || scalingDecision.shouldRestoreLastAllowedTransform
+    const currentScaleX = Math.abs(group.scaleX ?? state.startScaleX) || state.startScaleX
+    const currentScaleY = Math.abs(group.scaleY ?? state.startScaleY) || state.startScaleY
+    const shouldApplyResolvedTransform = scalingDecision.shouldRestoreLastAllowedTransform
       || Math.abs(scalingDecision.appliedScaleX - currentScaleX) > SCALE_EPSILON
       || Math.abs(scalingDecision.appliedScaleY - currentScaleY) > SCALE_EPSILON
 
@@ -204,7 +211,7 @@ export default class ShapeScalingController {
       this._applyResolvedScalingState({
         group,
         state,
-        shouldHandleAsNoop: scalingDecision.shouldHandleAsNoop,
+        shouldHandleAsNoop: false,
         scaleX: scalingDecision.appliedScaleX,
         scaleY: scalingDecision.appliedScaleY
       })
@@ -231,8 +238,8 @@ export default class ShapeScalingController {
       this._storeLastAllowedTransform({
         group,
         state,
-        scaleX: group.scaleX ?? 1,
-        scaleY: group.scaleY ?? 1,
+        scaleX: scalingDecision.appliedScaleX,
+        scaleY: scalingDecision.appliedScaleY,
         currentLeft,
         currentTop,
         currentFlipX,
@@ -262,9 +269,15 @@ export default class ShapeScalingController {
     // Сначала нормализуем текущий transform и фиксируем состояние, после которого drag больше нельзя продолжать в обратную сторону.
     const scaleXRaw = group.scaleX ?? 1
     const scaleYRaw = group.scaleY ?? 1
-    const scaleX = Math.abs(scaleXRaw) || 1
-    const scaleY = Math.abs(scaleYRaw) || 1
-    const hasNegativeScale = scaleXRaw < 0 || scaleYRaw < 0
+    const {
+      scaleX,
+      scaleY
+    } = this._resolveCurrentDragScales({
+      group,
+      state
+    })
+    const hasNegativeScale = (state.canScaleWidth && scaleXRaw < 0)
+      || (state.canScaleHeight && scaleYRaw < 0)
     const hasTransformOriginChange = isShapeTransformOriginChanged({
       state,
       transform
@@ -284,14 +297,13 @@ export default class ShapeScalingController {
       text,
       constraintPadding,
       state,
-      transform,
       scaleX,
       scaleY
     })
 
     // После решения о блокировке считаем именно те размеры preview, которые реально будут применены в этом кадре drag.
-    const currentScaleX = Math.abs(group.scaleX ?? 1) || 1
-    const currentScaleY = Math.abs(group.scaleY ?? 1) || 1
+    const currentScaleX = scaleX
+    const currentScaleY = scaleY
     let appliedScaleX = constraintState.clampedScaleX ?? currentScaleX
     let appliedScaleY = constraintState.clampedScaleY ?? currentScaleY
 
@@ -305,26 +317,32 @@ export default class ShapeScalingController {
       appliedScaleY = state.startScaleY
     }
 
-    const resolvedPreviewMinimumHeight = constraintState.shouldHandleAsNoop
-      || constraintState.shouldRestoreLastAllowedTransform
-      ? null
-      : constraintState.resolvedMinimumHeight
+    let resolvedPreviewMinimumHeight = constraintState.resolvedMinimumHeight
+    const fixedWidthMinimumTextFitHeight = !state.canScaleWidth && state.canScaleHeight
+      ? state.fixedWidthMinimumTextFitHeight
+      : null
 
-    const previewDimensions = resolveShapeScalingPreviewDimensions({
+    if (constraintState.shouldHandleAsNoop) {
+      resolvedPreviewMinimumHeight = state.startHeight
+    } else if (resolvedPreviewMinimumHeight === null || resolvedPreviewMinimumHeight === undefined) {
+      resolvedPreviewMinimumHeight = fixedWidthMinimumTextFitHeight
+    }
+
+    const { previewHeight } = resolveShapeScalingPreviewDimensions({
       group,
       text,
       constraintPadding,
       startDimensions: state,
       appliedScaleX,
       appliedScaleY,
-      minimumHeight: resolvedPreviewMinimumHeight
+      minimumHeight: resolvedPreviewMinimumHeight,
+      measurementCache: state.previewTextMeasurementCache
     })
 
     return {
       appliedScaleX,
       appliedScaleY,
-      previewWidth: previewDimensions.previewWidth,
-      previewHeight: previewDimensions.previewHeight,
+      previewHeight,
       shouldHandleAsNoop: constraintState.shouldHandleAsNoop,
       shouldRestoreLastAllowedTransform: constraintState.shouldRestoreLastAllowedTransform
     }
@@ -338,7 +356,6 @@ export default class ShapeScalingController {
     text,
     constraintPadding,
     state,
-    transform,
     scaleX,
     scaleY
   }: {
@@ -346,11 +363,12 @@ export default class ShapeScalingController {
     text: ShapeTextNode
     constraintPadding: ShapePadding
     state: ShapeScalingState
-    transform?: Transform | null
     scaleX: number
     scaleY: number
   }): ShapeScalingConstraintState {
     const {
+      canScaleHeight,
+      canScaleWidth,
       startHeight,
       startWidth,
       cannotScaleDownAtStart,
@@ -361,24 +379,25 @@ export default class ShapeScalingController {
       startScaleY
     } = state
 
-    const attemptedWidth = Math.max(MIN_SIZE, startWidth * scaleX)
-    const attemptedHeight = Math.max(MIN_SIZE, startHeight * scaleY)
+    const isVerticalOnlyScale = canScaleHeight && !canScaleWidth
+    const attemptedWidth = canScaleWidth
+      ? Math.max(MIN_SIZE, startWidth * scaleX)
+      : startWidth
+    const attemptedHeight = canScaleHeight
+      ? Math.max(MIN_SIZE, startHeight * scaleY)
+      : startHeight
     const isShrinkingX = scaleX < lastAllowedScaleX - SCALE_EPSILON
     const isShrinkingY = scaleY < lastAllowedScaleY - SCALE_EPSILON
     const isBelowStartScaleY = scaleY < startScaleY - SCALE_EPSILON
-
-    const {
-      canScaleHeight,
-      canScaleWidth,
-      isVerticalOnlyScale
-    } = resolveShapeScaleActionAxes({
-      transform
-    })
+    const fixedWidthMinimumTextFitHeight = isVerticalOnlyScale
+      ? state.fixedWidthMinimumTextFitHeight
+      : null
 
     const minimumWidth = canScaleWidth && isShrinkingX
       ? resolveMinimumShapeWidthForText({
         text,
         padding: constraintPadding,
+        measurementCache: state.previewTextMeasurementCache ?? undefined,
         resolvePaddingForWidth: ({ width }) => resolveShapeScalingConstraintPadding({
           group,
           width,
@@ -387,11 +406,12 @@ export default class ShapeScalingController {
       })
       : null
     const minimumHeight = canScaleHeight && isShrinkingY
-      ? resolveMinimumTextFitHeight({
+      ? fixedWidthMinimumTextFitHeight ?? resolveMinimumTextFitHeight({
         group,
         text,
         width: attemptedWidth,
-        padding: constraintPadding
+        padding: constraintPadding,
+        measurementCache: state.previewTextMeasurementCache
       })
       : null
 
@@ -408,7 +428,9 @@ export default class ShapeScalingController {
         group,
         text,
         width: attemptedWidth,
-        height: attemptedHeight
+        height: attemptedHeight,
+        measurementCache: state.previewTextMeasurementCache,
+        constraintCache: state.proportionalTextConstraintCache
       })
 
       if (!candidateConstraint.isValid) {
@@ -484,6 +506,59 @@ export default class ShapeScalingController {
   }
 
   /**
+   * Восстанавливает стартовое состояние, когда текущий drag заблокирован minimum-ограничением.
+   */
+  private _restoreBlockedScalingAttempt({
+    group,
+    shape,
+    text,
+    state
+  }: {
+    group: ShapeGroup
+    shape: ShapeNode
+    text: ShapeTextNode
+    state: ShapeScalingState
+  }): void {
+    const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
+
+    this._applyResolvedScalingState({
+      group,
+      state,
+      shouldHandleAsNoop: true,
+      scaleX: state.startScaleX,
+      scaleY: state.startScaleY
+    })
+
+    const previewLayout = resolveShapeScalingPreviewLayout({
+      group,
+      text,
+      state,
+      appliedScaleX: state.startScaleX,
+      appliedScaleY: state.startScaleY,
+      minimumHeight: state.startHeight
+    })
+
+    applyShapeScalingPreviewLayout({
+      group,
+      shape,
+      text,
+      layout: previewLayout,
+      alignH,
+      scaleX: state.startScaleX,
+      scaleY: state.startScaleY,
+      minSize: MIN_SIZE,
+      scaleEpsilon: SCALE_EPSILON
+    })
+
+    this._restoreScalingAnchorPosition({
+      group,
+      state
+    })
+
+    this.canvas.requestRenderAll()
+  }
+
+  /**
    * Применяет скорректированное состояние transform, когда текущий drag нужно ограничить или откатить.
    */
   private _applyResolvedScalingState({
@@ -549,14 +624,6 @@ export default class ShapeScalingController {
 
     if (!isShapeGroup(target)) return
 
-    const {
-      canScaleHeight,
-      canScaleWidth
-    } = resolveShapeScaleActionAxes({
-      transform
-    })
-    if (!canScaleWidth && !canScaleHeight) return
-
     const group = target
     const state = this.scalingState.get(group)
     if (!state) return
@@ -570,8 +637,21 @@ export default class ShapeScalingController {
 
     const constraintPadding = resolveShapeScalingConstraintPadding({ group })
     const alignH = group.shapeAlignHorizontal ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
-    const currentScaleX = Math.abs(group.scaleX ?? state.lastAllowedScaleX ?? 1) || 1
-    const currentScaleY = Math.abs(group.scaleY ?? state.lastAllowedScaleY ?? 1) || 1
+    const {
+      canScaleWidth,
+      canScaleHeight
+    } = state
+    if (!canScaleWidth && !canScaleHeight) return
+
+    const rawScaleX = Math.abs(group.scaleX ?? state.startScaleX) || state.startScaleX
+    const rawScaleY = Math.abs(group.scaleY ?? state.startScaleY) || state.startScaleY
+    const {
+      scaleX: currentScaleX,
+      scaleY: currentScaleY
+    } = this._resolveCurrentDragScales({
+      group,
+      state
+    })
     const eventWithTransform = {
       ...event,
       transform
@@ -581,6 +661,11 @@ export default class ShapeScalingController {
     let resolvedMinimumHeight: number | null = null
     let didClampWidth = false
     let shouldApplyClamp = false
+    const shouldNormalizeInactiveAxis = (!canScaleWidth && Math.abs(rawScaleX - currentScaleX) > SCALE_EPSILON)
+      || (!canScaleHeight && Math.abs(rawScaleY - currentScaleY) > SCALE_EPSILON)
+    const fixedWidthMinimumTextFitHeight = !canScaleWidth && canScaleHeight
+      ? state.fixedWidthMinimumTextFitHeight
+      : null
 
     if (state.isProportionalScaling) {
       const pointerReachedOrPassedOriginX = canScaleWidth && this._hasPointerReachedScaleOrigin({
@@ -643,11 +728,22 @@ export default class ShapeScalingController {
         axis: 'y'
       })
       if (pointerReachedOrPassedOriginY) {
-        resolvedMinimumHeight = resolveMinimumTextFitHeight({
+        if (!canScaleWidth && state.cannotScaleDownAtStart) {
+          this._restoreBlockedScalingAttempt({
+            group,
+            shape,
+            text,
+            state
+          })
+          return
+        }
+
+        resolvedMinimumHeight = fixedWidthMinimumTextFitHeight ?? resolveMinimumTextFitHeight({
           group,
           text,
           width: Math.max(MIN_SIZE, state.startWidth * nextScaleX),
-          padding: constraintPadding
+          padding: constraintPadding,
+          measurementCache: state.previewTextMeasurementCache
         })
         const minimumScaleY = Math.max(MIN_SIZE / state.startHeight, resolvedMinimumHeight / state.startHeight)
         if (state.lastAllowedScaleY > minimumScaleY + SCALE_EPSILON) {
@@ -657,7 +753,11 @@ export default class ShapeScalingController {
       }
     }
 
-    if (!shouldApplyClamp) return
+    if (!shouldApplyClamp && !shouldNormalizeInactiveAxis) return
+
+    if (resolvedMinimumHeight === null || resolvedMinimumHeight === undefined) {
+      resolvedMinimumHeight = fixedWidthMinimumTextFitHeight
+    }
 
     const previewDimensions = resolveShapeScalingPreviewDimensions({
       group,
@@ -666,7 +766,8 @@ export default class ShapeScalingController {
       startDimensions: state,
       appliedScaleX: nextScaleX,
       appliedScaleY: nextScaleY,
-      minimumHeight: didClampWidth ? null : resolvedMinimumHeight
+      minimumHeight: didClampWidth ? null : resolvedMinimumHeight,
+      measurementCache: state.previewTextMeasurementCache
     })
     const previewLayout = resolveShapeScalingPreviewLayout({
       group,
@@ -789,11 +890,22 @@ export default class ShapeScalingController {
         text
       } = getShapeNodes({ group })
 
-      this._restoreGroupTransformOnly({
+      if (!shape || !text) {
+        group.shapeScalingNoopTransform = false
+        this.scalingState.delete(group)
+        return
+      }
+
+      this._restoreShapeStateWithoutResize({
         group,
         shape,
         text,
-        state
+        state,
+        startWidth,
+        startHeight,
+        alignH: group.shapeAlignHorizontal,
+        alignV: group.shapeAlignVertical,
+        userPadding: resolveShapeScalingUserPadding({ group })
       })
 
       group.shapeScalingNoopTransform = false
@@ -995,6 +1107,28 @@ export default class ShapeScalingController {
       scaleY,
       transform
     })
+  }
+
+  /**
+   * Возвращает текущие scale-значения drag-сессии и отсекает случайные изменения по неактивной оси.
+   */
+  private _resolveCurrentDragScales({
+    group,
+    state
+  }: {
+    group: ShapeGroup
+    state: ShapeScalingState
+  }): {
+    scaleX: number
+    scaleY: number
+  } {
+    const rawScaleX = Math.abs(group.scaleX ?? state.startScaleX) || state.startScaleX
+    const rawScaleY = Math.abs(group.scaleY ?? state.startScaleY) || state.startScaleY
+
+    return {
+      scaleX: state.canScaleWidth ? rawScaleX : state.startScaleX,
+      scaleY: state.canScaleHeight ? rawScaleY : state.startScaleY
+    }
   }
 
   /**
@@ -1273,7 +1407,7 @@ export default class ShapeScalingController {
 
   /**
    * Восстанавливает стабильное состояние объекта, когда масштабирование не привело к изменению ручных размеров,
-   * сохраняя текущий laid-out размер shape после auto-fit текста.
+   * сохраняя текущий laid-out размер shape по тому же layout-контракту, что и финальный commit-path scaling.
    */
   private _restoreShapeStateWithoutResize({
     group,
@@ -1311,23 +1445,42 @@ export default class ShapeScalingController {
     })
     const horizontalAlign = alignH ?? SHAPE_DEFAULT_HORIZONTAL_ALIGN
     const verticalAlign = alignV ?? SHAPE_DEFAULT_VERTICAL_ALIGN
-
-    applyShapeTextLayout({
+    const resolveInternalShapeTextInsetForSize = ({ width, height }: {
+      width: number
+      height: number
+    }) => resolveShapeScalingInternalTextInset({
       group,
-      shape,
-      text,
-      width: layoutWidth,
-      height: layoutHeight,
-      alignH: horizontalAlign,
-      alignV: verticalAlign,
-      padding: userPadding,
-      internalShapeTextInset,
-      resolveInternalShapeTextInset: ({ width, height }) => resolveShapeScalingInternalTextInset({
-        group,
-        width,
-        height
-      })
+      width,
+      height
     })
+
+    if (!state.canScaleWidth && state.canScaleHeight) {
+      applyFixedWidthShapeTextLayout({
+        group,
+        shape,
+        text,
+        width: layoutWidth,
+        height: layoutHeight,
+        alignH: horizontalAlign,
+        alignV: verticalAlign,
+        padding: userPadding,
+        internalShapeTextInset,
+        resolveInternalShapeTextInset: resolveInternalShapeTextInsetForSize
+      })
+    } else {
+      applyShapeTextLayout({
+        group,
+        shape,
+        text,
+        width: layoutWidth,
+        height: layoutHeight,
+        alignH: horizontalAlign,
+        alignV: verticalAlign,
+        padding: userPadding,
+        internalShapeTextInset,
+        resolveInternalShapeTextInset: resolveInternalShapeTextInsetForSize
+      })
+    }
 
     group.set({
       left: state.lastAllowedLeft,
@@ -1336,66 +1489,6 @@ export default class ShapeScalingController {
       flipY: state.lastAllowedFlipY,
       scaleX: 1,
       scaleY: 1
-    })
-
-    this._restoreScalingAnchorPosition({
-      group,
-      state
-    })
-  }
-
-  /**
-   * Восстанавливает transform группы без пересчета layout, если масштабирование было полностью заблокировано,
-   * возвращая текущий laid-out размер, а не ручную базовую высоту/ширину.
-   */
-  private _restoreGroupTransformOnly({
-    group,
-    shape,
-    text,
-    state
-  }: {
-    group: ShapeGroup
-    shape: ShapeNode | null
-    text: ShapeTextNode | null
-    state: ShapeScalingState
-  }): void {
-    const layoutWidth = Math.max(
-      MIN_SIZE,
-      group.shapeBaseWidth ?? group.width ?? state.startWidth
-    )
-    const layoutHeight = Math.max(
-      MIN_SIZE,
-      group.shapeBaseHeight ?? group.height ?? state.startHeight
-    )
-
-    if (shape) {
-      resizeShapeNode({
-        shape,
-        width: layoutWidth,
-        height: layoutHeight,
-        rounding: group.shapeRounding,
-        strokeWidth: group.shapeStrokeWidth
-      })
-      shape.setCoords()
-    }
-
-    if (text) {
-      text.set({
-        scaleX: 1 / Math.max(SCALE_EPSILON, state.startScaleX),
-        scaleY: 1 / Math.max(SCALE_EPSILON, state.startScaleY)
-      })
-      text.setCoords()
-    }
-
-    group.set({
-      width: layoutWidth,
-      height: layoutHeight,
-      left: state.startLeft,
-      top: state.startTop,
-      flipX: state.lastAllowedFlipX,
-      flipY: state.lastAllowedFlipY,
-      scaleX: state.startScaleX,
-      scaleY: state.startScaleY
     })
 
     this._restoreScalingAnchorPosition({

--- a/src/editor/shape-manager/shape-presets.ts
+++ b/src/editor/shape-manager/shape-presets.ts
@@ -277,9 +277,9 @@ const shapePresetsList: ShapePreset[] = [
       { x: 0, y: 62 }
     ],
     internalTextInset: {
-      top: 0.3,
+      top: 0.34,
       right: 0.42,
-      bottom: 0.3,
+      bottom: 0.34,
       left: 0.16
     }
   },

--- a/src/editor/shape-manager/types.ts
+++ b/src/editor/shape-manager/types.ts
@@ -315,6 +315,23 @@ export type ShapeLayoutInput = {
   changedPadding?: ShapePaddingChangeMap
 }
 
+export type ShapeTextFrameMeasurementCacheEntry = {
+  measuredHeight: number
+  renderedLineCount: number
+  longestLineWidth: number
+  requiresGraphemeSplit: boolean
+}
+
+export type ShapeTextMeasurementCache = {
+  measurementsByKey: Map<string, ShapeTextFrameMeasurementCacheEntry>
+  splitByGraphemeByFrameWidth: Map<string, boolean>
+  minimumTextFrameWidth: number | null
+}
+
+export type ShapeScalingProportionalTextConstraintCacheEntry = ShapeTextFrameMeasurementCacheEntry & {
+  isValid: boolean
+}
+
 export type ShapeScalingState = {
   startWidth: number
   startHeight: number
@@ -345,6 +362,9 @@ export type ShapeScalingState = {
   lastAllowedTop: number
   scaleDirectionX: -1 | 1 | null
   scaleDirectionY: -1 | 1 | null
+  fixedWidthMinimumTextFitHeight: number | null
+  previewTextMeasurementCache: ShapeTextMeasurementCache | null
+  proportionalTextConstraintCache: Map<string, ShapeScalingProportionalTextConstraintCacheEntry> | null
 }
 
 export type ShapeEditingOptions = {


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить шейп arrow-right-bold с многострочным текстом "TEST \nTEST\nTEST\nTEST" (скрин 1)

<img width="1337" height="846" alt="image" src="https://github.com/user-attachments/assets/d2bf83f7-e01b-4398-95d7-2b8cd7352003" />

2. Пыпытаться уменьшить высоту шейпа сверху вниз путём вертикального скейлинга

Ожидаемый результат.

Уменьшить фигуру не получится. Ничего не произойдёт, потому что фигура уже имеет минимальную высоту чтобы вмещать текст.

Фактический результат.

В пункте после попытки вертикального скейлинга для уменьшения шейп расфигачивает и его ширина становится 11000 пикселей, а высота около 700 (скрин 2)

<img width="1430" height="830" alt="image" src="https://github.com/user-attachments/assets/ee02ecc6-40b6-43d9-a111-4e910219d1d6" />

---

FIXED. 
Плюс добавлено кеширование для скейлинга многострочных объектов шейпов с пресетом, чтобы оно не тормозило так сильно.
