### PR TITLE
ShapeManager. Правим баг когда не работает авторасширение при применении шаблона с шейпом у которого задано свойство shapeTextAutoExpand true

### DIFF
--- a/e2e/models/template.model.ts
+++ b/e2e/models/template.model.ts
@@ -13,6 +13,55 @@ export class TemplateModel {
     this.page = page
   }
 
+  /**
+   * Обновляет текст первого shape-объекта в шаблоне.
+   * Используется в regression-сценариях, где нужно проверить materialization
+   * уже изменённого serialized template.
+   */
+  setFirstShapeText({
+    template,
+    text,
+    shapeTextAutoExpand
+  }: {
+    template: TemplateDefinition
+    text: string
+    shapeTextAutoExpand?: boolean
+  }): TemplateDefinition {
+    const firstShapeObject = template.objects.find((object) => {
+      return object.type === 'shape-group'
+    })
+
+    if (!firstShapeObject) {
+      throw new Error('Template должен содержать хотя бы один shape-group')
+    }
+
+    if (shapeTextAutoExpand !== undefined) {
+      firstShapeObject.shapeTextAutoExpand = shapeTextAutoExpand
+    }
+
+    const nestedObjects = firstShapeObject.objects
+
+    if (!Array.isArray(nestedObjects)) {
+      throw new Error('shape-group в шаблоне должен содержать вложенные объекты')
+    }
+
+    const textObject = nestedObjects.find((object) => {
+      return object.shapeNodeType === 'text'
+    })
+
+    if (!textObject) {
+      throw new Error('shape-group в шаблоне должен содержать текстовый узел')
+    }
+
+    textObject.text = text
+
+    if (typeof textObject.textCaseRaw === 'string') {
+      textObject.textCaseRaw = text
+    }
+
+    return template
+  }
+
   /** Сериализует текущее выделение редактора в описание шаблона. */
   async serializeSelection(params: SerializeTemplateParams = {}): Promise<TemplateDefinition | null> {
     return this.page.evaluate((payload) => {

--- a/e2e/tests/shape-manager/shape-auto-expand.spec.ts
+++ b/e2e/tests/shape-manager/shape-auto-expand.spec.ts
@@ -1144,6 +1144,170 @@ test.describe('Авторасширение текста внутри фигур
   })
 
   test.describe('после применения шаблона (TemplateManager), копирования и истории', () => {
+    test('если длинный текст уже сохранён в шаблоне, то фигура сразу расширяется и не прыгает при входе в редактирование', async({
+      editorModel,
+      shapes,
+      template
+    }) => {
+      const sourceShape = await test.step('Добавить исходную фигуру с включённым авторасширением', async() => {
+        return shapes.add({
+          presetKey: 'square',
+          options: {
+            ...SHAPE_AUTO_EXPAND_BASE_OPTIONS,
+            id: 'shape-template-serialized-long-text-source',
+            text: 'TEST',
+            shapeTextAutoExpand: true
+          }
+        })
+      })
+
+      shapes.checkCreation({
+        shape: sourceShape,
+        presetKey: 'square'
+      })
+
+      await test.step('Сериализовать исходную фигуру в шаблон', async() => {
+        await shapes.select({ id: 'shape-template-serialized-long-text-source' })
+      })
+
+      const serializedTemplate = await test.step('Подменить текст прямо в serialized template', async() => {
+        const currentTemplate = await template.serializeSelection()
+
+        expect(currentTemplate).not.toBeNull()
+
+        return template.setFirstShapeText({
+          template: currentTemplate!,
+          text: SHAPE_AUTO_EXPAND_VERY_LONG_TEXT,
+          shapeTextAutoExpand: true
+        })
+      })
+
+      const templateShapeId = await test.step('Применить шаблон и определить новую фигуру', async() => {
+        const insertedCount = await template.applyTemplate({
+          template: serializedTemplate
+        })
+
+        expect(insertedCount).toBe(1)
+        await editorModel.checkObjectCount({ count: 2 })
+
+        const objects = await shapes.getShapeObjects()
+        const appliedShape = objects.find((shape) => shape.id !== 'shape-template-serialized-long-text-source')
+
+        expect(appliedShape).toBeDefined()
+        expect(appliedShape?.id).toBeDefined()
+
+        return appliedShape?.id as string
+      })
+
+      const appliedShape = await test.step('Получить состояние фигуры сразу после применения шаблона', () => {
+        return shapes.getObject({ id: templateShapeId })
+      })
+      const appliedText = await test.step('Получить текст фигуры сразу после применения шаблона', () => {
+        return shapes.getTextNode({ id: templateShapeId })
+      })
+      const appliedSnapshot = await test.step('Получить ширину фигуры сразу после применения шаблона', () => {
+        return shapes.getScaleSnapshot({ id: templateShapeId })
+      })
+
+      await test.step('Войти в редактирование текста фигуры из шаблона', async() => {
+        await shapes.enterTextEditing({ id: templateShapeId })
+      })
+
+      const editingText = await test.step('Получить текст фигуры после входа в редактирование', () => {
+        return shapes.getTextNode({ id: templateShapeId })
+      })
+      const editingSnapshot = await test.step('Получить ширину фигуры после входа в редактирование', () => {
+        return shapes.getScaleSnapshot({ id: templateShapeId })
+      })
+
+      await test.step('Проверить что фигура сразу расширилась и не изменила ширину при входе в редактирование', () => {
+        expect(appliedShape?.shapeTextAutoExpand).toBe(true)
+        expect(appliedText?.lineCount).toBe(2)
+        expect(appliedSnapshot.groupBoundsWidth)
+          .toBeGreaterThan((SHAPE_AUTO_EXPAND_BASE_OPTIONS.width ?? 0) + SHAPE_AUTO_EXPAND_WIDTH_TOLERANCE)
+        expect(editingText?.lineCount).toBe(2)
+        expect(Math.abs(editingSnapshot.groupBoundsWidth - appliedSnapshot.groupBoundsWidth))
+          .toBeLessThanOrEqual(SHAPE_AUTO_EXPAND_WIDTH_TOLERANCE)
+      })
+    })
+
+    test('если длинный текст уже сохранён в шаблоне с выключенным авторасширением, то фигура сохраняет переносы и ширину', async({
+      editorModel,
+      shapes,
+      template
+    }) => {
+      const sourceShape = await test.step('Добавить исходную фигуру с выключенным авторасширением', async() => {
+        return shapes.add({
+          presetKey: 'square',
+          options: {
+            ...SHAPE_AUTO_EXPAND_BASE_OPTIONS,
+            id: 'shape-template-serialized-wrapped-text-source',
+            text: 'TEST',
+            shapeTextAutoExpand: false
+          }
+        })
+      })
+
+      shapes.checkCreation({
+        shape: sourceShape,
+        presetKey: 'square'
+      })
+
+      const sourceSnapshot = await test.step('Получить исходную ширину фигуры', () => {
+        return shapes.getScaleSnapshot({ id: 'shape-template-serialized-wrapped-text-source' })
+      })
+
+      await test.step('Сериализовать исходную фигуру в шаблон', async() => {
+        await shapes.select({ id: 'shape-template-serialized-wrapped-text-source' })
+      })
+
+      const serializedTemplate = await test.step('Подменить текст прямо в serialized template', async() => {
+        const currentTemplate = await template.serializeSelection()
+
+        expect(currentTemplate).not.toBeNull()
+
+        return template.setFirstShapeText({
+          template: currentTemplate!,
+          text: SHAPE_AUTO_EXPAND_VERY_LONG_TEXT,
+          shapeTextAutoExpand: false
+        })
+      })
+
+      const templateShapeId = await test.step('Применить шаблон и определить новую фигуру', async() => {
+        const insertedCount = await template.applyTemplate({
+          template: serializedTemplate
+        })
+
+        expect(insertedCount).toBe(1)
+        await editorModel.checkObjectCount({ count: 2 })
+
+        const objects = await shapes.getShapeObjects()
+        const appliedShape = objects.find((shape) => shape.id !== 'shape-template-serialized-wrapped-text-source')
+
+        expect(appliedShape).toBeDefined()
+        expect(appliedShape?.id).toBeDefined()
+
+        return appliedShape?.id as string
+      })
+
+      const appliedShape = await test.step('Получить состояние фигуры сразу после применения шаблона', () => {
+        return shapes.getObject({ id: templateShapeId })
+      })
+      const appliedText = await test.step('Получить текст фигуры сразу после применения шаблона', () => {
+        return shapes.getTextNode({ id: templateShapeId })
+      })
+      const appliedSnapshot = await test.step('Получить ширину фигуры сразу после применения шаблона', () => {
+        return shapes.getScaleSnapshot({ id: templateShapeId })
+      })
+
+      await test.step('Проверить что фигура сохранила выключенный режим и осталась в fixed-width состоянии', () => {
+        expect(appliedShape?.shapeTextAutoExpand).toBe(false)
+        expect(appliedText?.lineCount).toBeGreaterThan(1)
+        expect(Math.abs(appliedSnapshot.groupBoundsWidth - sourceSnapshot.groupBoundsWidth))
+          .toBeLessThanOrEqual(SHAPE_AUTO_EXPAND_WIDTH_TOLERANCE)
+      })
+    })
+
     test('объект из шаблона ведёт себя так же, как созданный напрямую', async({
       editorModel,
       shapes,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/shape-manager/shape-manager-rehydration.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-rehydration.spec.ts
@@ -9,13 +9,16 @@ import {
 
 describe('восстановленная фигура', () => {
   const mocks = getShapeManagerUnitMocks()
-  const { applyShapeTextLayoutMock } = mocks
+  const {
+    applyShapeTextLayoutMock,
+    resolveShapeTextAutoExpandWidthForTextMock
+  } = mocks
 
   beforeEach(() => {
     resetShapeManagerUnitMocks(mocks)
   })
 
-  it('получает итоговый размер до пересчёта текста', () => {
+  it('при включённом авторасширении заново вычисляет ширину через общий materialization-контракт', () => {
     const editor = createShapeManagerEditorStub()
     const manager = new ShapeManager({
       editor: editor as never
@@ -31,6 +34,8 @@ describe('восстановленная фигура', () => {
       replaceBoxHeight: 120
     })
 
+    resolveShapeTextAutoExpandWidthForTextMock.mockReturnValue(360)
+
     const result = manager.commitRehydratedShapeLayout({
       target: group
     })
@@ -38,12 +43,16 @@ describe('восстановленная фигура', () => {
     const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
 
     expect(result).toBe(true)
+    expect(resolveShapeTextAutoExpandWidthForTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      currentWidth: 300,
+      minimumWidth: 270
+    }))
     expect(layoutCall).toEqual(expect.objectContaining({
       group,
-      width: 300,
+      width: 360,
       height: 200
     }))
-    expect(group.shapeBaseWidth).toBe(300)
+    expect(group.shapeBaseWidth).toBe(360)
     expect(group.shapeBaseHeight).toBe(200)
     expect(group.shapeManualBaseWidth).toBe(270)
     expect(group.shapeManualBaseHeight).toBe(180)
@@ -129,6 +138,10 @@ describe('восстановленная фигура', () => {
     const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
 
     expect(result).toBe(true)
+    expect(resolveShapeTextAutoExpandWidthForTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      currentWidth: 250,
+      minimumWidth: 250
+    }))
     expect(layoutCall).toEqual(expect.objectContaining({
       width: 250,
       height: 150
@@ -148,7 +161,9 @@ describe('восстановленная фигура', () => {
       width: 200,
       height: 100,
       scaleX: 1.25,
-      scaleY: 1.5
+      scaleY: 1.5,
+      manualWidth: 200,
+      manualHeight: 100
     })
 
     group.shapeTextAutoExpand = true
@@ -161,6 +176,7 @@ describe('восстановленная фигура', () => {
     const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
 
     expect(result).toBe(true)
+    expect(resolveShapeTextAutoExpandWidthForTextMock).not.toHaveBeenCalled()
     expect(layoutCall).toEqual(expect.objectContaining({
       width: 250,
       height: 150,
@@ -178,7 +194,9 @@ describe('восстановленная фигура', () => {
       width: 200,
       height: 100,
       scaleX: 1.25,
-      scaleY: 1.5
+      scaleY: 1.5,
+      manualWidth: 200,
+      manualHeight: 100
     })
 
     group.shapeTextAutoExpand = true
@@ -190,6 +208,10 @@ describe('восстановленная фигура', () => {
     const layoutCall = layoutCallCalls[layoutCallCalls.length - 1]?.[0]
 
     expect(result).toBe(true)
+    expect(resolveShapeTextAutoExpandWidthForTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      currentWidth: 250,
+      minimumWidth: 250
+    }))
     expect(layoutCall).toEqual(expect.objectContaining({
       width: 250,
       height: 150,

--- a/src/editor/shape-manager/index.ts
+++ b/src/editor/shape-manager/index.ts
@@ -1387,12 +1387,14 @@ export default class ShapeManager {
     group.shapeManualBaseWidth = manualDimensions.width
     group.shapeManualBaseHeight = manualDimensions.height
 
+    // Width здесь должен пройти через тот же auto-expand контракт, что и add/update path.
+    // Если передать уже зафиксированную current width, materialization обойдет этот шаг
+    // и shape с длинным текстом восстановится в wrapped state до первого text mutation.
     this._applyCurrentLayout({
       group,
       shape,
       text,
       placement,
-      width: currentDimensions.width,
       height: currentDimensions.height,
       alignH: shapeAlignHorizontal,
       alignV: shapeAlignVertical


### PR DESCRIPTION
Порядок воспроизведения:

1. Добавить шейп с текстом "TEST" с включенным shapeTextAutoExpand (скрин 1)

<img width="347" height="323" alt="image" src="https://github.com/user-attachments/assets/71f373ac-12bf-4cf5-a7af-fc1685e22229" />

2. Сделать сериализацию этого шейпа
3. В полученном шаблоне в свойство text дописать более длинный текст "TEST TEST TEST"

На выходе из 3 пункта получаем вот такой темплейт:

```json
{
  "id": "template-fbzPUgclBro8JeIZMY231",
  "meta": {
    "baseWidth": 512,
    "baseHeight": 512,
    "positionsNormalized": true
  },
  "objects": [
    {
      "subTargetCheck": true,
      "interactive": true,
      "id": "shape-ERfN0yNGcAerqt2x0oqw2",
      "width": 180,
      "height": 180,
      "originX": "center",
      "originY": "center",
      "evented": true,
      "selectable": true,
      "lockMovementX": false,
      "lockMovementY": false,
      "lockRotation": false,
      "lockScalingX": false,
      "lockScalingY": false,
      "lockSkewingX": false,
      "lockSkewingY": false,
      "shapeComposite": true,
      "shapePresetKey": "square",
      "shapeBaseWidth": 180,
      "shapeBaseHeight": 180,
      "shapeManualBaseWidth": 180,
      "shapeManualBaseHeight": 180,
      "shapeReplaceBoxWidth": 180,
      "shapeReplaceBoxHeight": 180,
      "shapeTextAutoExpand": true,
      "shapeAlignHorizontal": "center",
      "shapeAlignVertical": "middle",
      "shapePaddingTop": 0,
      "shapePaddingRight": 0,
      "shapePaddingBottom": 0,
      "shapePaddingLeft": 0,
      "shapeFill": "#B0B5BF",
      "shapeStroke": "#000000",
      "shapeStrokeWidth": 0,
      "shapeStrokeDashArray": null,
      "shapeOpacity": 1,
      "shapeRounding": 0,
      "type": "shape-group",
      "version": "7.2.0",
      "left": 0.5,
      "top": 0.5,
      "fill": "rgb(0,0,0)",
      "stroke": null,
      "strokeWidth": 0,
      "strokeDashArray": null,
      "strokeLineCap": "butt",
      "strokeDashOffset": 0,
      "strokeLineJoin": "miter",
      "strokeUniform": false,
      "strokeMiterLimit": 4,
      "scaleX": 1,
      "scaleY": 1,
      "angle": 0,
      "flipX": false,
      "flipY": false,
      "opacity": 1,
      "shadow": null,
      "visible": true,
      "backgroundColor": "",
      "fillRule": "nonzero",
      "paintFirst": "fill",
      "globalCompositeOperation": "source-over",
      "skewX": 0,
      "skewY": 0,
      "layoutManager": {
        "type": "layoutManager",
        "strategy": "fit-content"
      },
      "objects": [
        {
          "rx": 0,
          "ry": 0,
          "id": "rect-W3WD5WvvT7J1Hw6569fMe",
          "width": 180,
          "height": 180,
          "originX": "center",
          "originY": "center",
          "evented": false,
          "selectable": false,
          "lockMovementX": false,
          "lockMovementY": false,
          "lockRotation": false,
          "lockScalingX": false,
          "lockScalingY": false,
          "lockSkewingX": false,
          "lockSkewingY": false,
          "shapeNodeType": "shape",
          "type": "Rect",
          "version": "7.2.0",
          "left": 0,
          "top": 0,
          "fill": "#B0B5BF",
          "stroke": "#000000",
          "strokeWidth": 0,
          "strokeDashArray": null,
          "strokeLineCap": "round",
          "strokeDashOffset": 0,
          "strokeLineJoin": "round",
          "strokeUniform": true,
          "strokeMiterLimit": 4,
          "scaleX": 1,
          "scaleY": 1,
          "angle": 0,
          "flipX": false,
          "flipY": false,
          "opacity": 1,
          "shadow": null,
          "visible": true,
          "backgroundColor": "",
          "fillRule": "nonzero",
          "paintFirst": "fill",
          "globalCompositeOperation": "source-over",
          "skewX": 0,
          "skewY": 0
        },
        {
          "fontSize": 48,
          "fontWeight": "normal",
          "fontFamily": "Arial",
          "fontStyle": "normal",
          "lineHeight": 1.16,
          "text": "TEST TEST TEST",
          "charSpacing": 0,
          "textAlign": "center",
          "styles": [],
          "pathStartOffset": 0,
          "pathSide": "left",
          "pathAlign": "baseline",
          "underline": false,
          "overline": false,
          "linethrough": false,
          "textBackgroundColor": "",
          "direction": "ltr",
          "textDecorationThickness": 66.667,
          "minWidth": 20,
          "splitByGrapheme": false,
          "id": "background-textbox-QyYU7WdOo9BkUA7k4GWil",
          "width": 180,
          "height": 54,
          "originX": "left",
          "originY": "top",
          "editable": true,
          "evented": false,
          "selectable": false,
          "lockMovementX": false,
          "lockMovementY": false,
          "lockRotation": false,
          "lockScalingX": false,
          "lockScalingY": false,
          "lockSkewingX": false,
          "lockSkewingY": false,
          "lineFontDefaults": {
            "0": {
              "fontFamily": "Arial",
              "fontSize": 48,
              "fontWeight": "normal",
              "fontStyle": "normal",
              "underline": false,
              "linethrough": false,
              "fill": "#000000"
            }
          },
          "textCaseRaw": "TEST",
          "uppercase": false,
          "autoExpand": false,
          "backgroundOpacity": 1,
          "paddingTop": 0,
          "paddingRight": 0,
          "paddingBottom": 0,
          "paddingLeft": 0,
          "radiusTopLeft": 0,
          "radiusTopRight": 0,
          "radiusBottomRight": 0,
          "radiusBottomLeft": 0,
          "shapeNodeType": "text",
          "type": "background-textbox",
          "version": "7.2.0",
          "left": -90,
          "top": -27,
          "fill": "#000000",
          "stroke": null,
          "strokeWidth": 0,
          "strokeDashArray": null,
          "strokeLineCap": "butt",
          "strokeDashOffset": 0,
          "strokeLineJoin": "miter",
          "strokeUniform": true,
          "strokeMiterLimit": 4,
          "scaleX": 1,
          "scaleY": 1,
          "angle": 0,
          "flipX": false,
          "flipY": false,
          "opacity": 1,
          "shadow": null,
          "visible": true,
          "fillRule": "nonzero",
          "paintFirst": "fill",
          "globalCompositeOperation": "source-over",
          "skewX": 0,
          "skewY": 0
        }
      ],
      "_templateAnchorX": "center",
      "_templateAnchorY": "center"
    }
  ]
}
```

4. Применить полученный темплейт

Ожидаемое поведение.

Шаблон будет успешно применён. Шейп при добавлении будет автоматически расширен, так как флаг shapeTextAutoExpand имеет значение true.

Фактический результат.

Шаблон успешно применён. Шейп при добавлении не был расширен, вместо этого он был добавлен с переносами строк (скрин 2) несмотря на то что shapeTextAutoExpand имеет значение true. Если начать редактировать текст объекта, то тогда сработает авторасширение и текст перепрыгнет в одну строку (скрин 3).

<img width="392" height="368" alt="image" src="https://github.com/user-attachments/assets/fe54d263-8da1-4b8e-8dc9-89423c58718a" />

<img width="421" height="344" alt="image" src="https://github.com/user-attachments/assets/608196a7-df8c-4834-8d30-f88ada2b4cb4" />

---

FIXED.