### PR TITLE
TemplateManager. Правим баг когда при применении шаблона с длинным текстом он может смещаться

### DIFF
--- a/e2e/fixtures/data/template-manager.data.ts
+++ b/e2e/fixtures/data/template-manager.data.ts
@@ -62,6 +62,134 @@ export const TEMPLATE_RELATIVE_TOLERANCE = 0.025
 /** Допуск для проверок выравнивания блоков в одной линии. */
 export const TEMPLATE_ALIGNMENT_TOLERANCE = 4
 
+/** Базовое разрешение для шаблона с standalone text у верхней границы. */
+export const TEMPLATE_STANDALONE_TEXT_BASE_RESOLUTION = {
+  width: 810,
+  height: 1080
+} as const
+
+/** Квадратное разрешение для regression-проверки standalone text из шаблона. */
+export const TEMPLATE_STANDALONE_TEXT_SQUARE_RESOLUTION = {
+  width: 1000,
+  height: 1000
+} as const
+
+/** Уменьшенное квадратное разрешение для проверки standalone text после scale down. */
+export const TEMPLATE_STANDALONE_TEXT_COMPACT_RESOLUTION = {
+  width: 512,
+  height: 512
+} as const
+
+/** Высокое разрешение с горизонтальными полями для regression-проверки centered standalone text. */
+export const TEMPLATE_STANDALONE_TEXT_TALL_RESOLUTION = {
+  width: 910,
+  height: 1200
+} as const
+
+/** Количество объектов в шаблоне со standalone text. */
+export const TEMPLATE_STANDALONE_TEXT_OBJECT_COUNT = 1
+
+/** Шаблон со standalone text, который должен оставаться по центру сверху на разных разрешениях. */
+export const TEMPLATE_STANDALONE_TEXT_TEMPLATE: TemplateDefinition = {
+  id: 'template-standalone-text-alignment',
+  meta: {
+    baseWidth: 810,
+    baseHeight: 1080,
+    positionsNormalized: true
+  },
+  objects: [
+    {
+      fontSize: 72,
+      fontWeight: 'normal',
+      fontFamily: 'Open Sans',
+      fontStyle: 'normal',
+      lineHeight: 1.16,
+      text: 'ЖЕНСКАЯ СУМКА ИЗ КОЖИ БЛА БЛА БЛА БЛА БЛАБЛА БЛА БЛА БЛА',
+      charSpacing: 0,
+      textAlign: 'center',
+      styles: [],
+      pathStartOffset: 0,
+      pathSide: 'left',
+      pathAlign: 'baseline',
+      underline: false,
+      overline: false,
+      linethrough: false,
+      textBackgroundColor: null,
+      direction: 'ltr',
+      textDecorationThickness: 66.667,
+      minWidth: 20,
+      splitByGrapheme: false,
+      id: 'background-textbox-iPaS7YLnTRKxLVc_2hpMt',
+      customData: {
+        handle: 'title',
+        template: '{{text}}',
+        variables: [
+          {
+            name: 'text',
+            description: 'Заголовок товара',
+            maxChars: 30
+          }
+        ]
+      },
+      width: 758,
+      height: 364,
+      originX: 'left',
+      originY: 'top',
+      editable: true,
+      evented: true,
+      selectable: true,
+      lockMovementX: false,
+      lockMovementY: false,
+      lockRotation: false,
+      lockScalingX: false,
+      lockScalingY: false,
+      lockSkewingX: false,
+      lockSkewingY: false,
+      textCaseRaw: 'женская сумка из кожи',
+      uppercase: true,
+      autoExpand: false,
+      backgroundOpacity: 1,
+      paddingTop: 0,
+      paddingRight: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      radiusTopLeft: 0,
+      radiusTopRight: 0,
+      radiusBottomRight: 0,
+      radiusBottomLeft: 0,
+      type: 'background-textbox',
+      version: '7.2.0',
+      left: 0.03209876543209877,
+      top: 0.04351851851851852,
+      fill: '#333333',
+      stroke: null,
+      strokeWidth: 0,
+      strokeDashArray: null,
+      strokeLineCap: 'butt',
+      strokeDashOffset: 0,
+      strokeLineJoin: 'miter',
+      strokeUniform: true,
+      strokeMiterLimit: 4,
+      scaleX: 1,
+      scaleY: 1,
+      angle: 0,
+      flipX: false,
+      flipY: false,
+      opacity: 1,
+      shadow: null,
+      visible: true,
+      backgroundColor: null,
+      fillRule: 'nonzero',
+      paintFirst: 'fill',
+      globalCompositeOperation: 'source-over',
+      skewX: 0,
+      skewY: 0,
+      _templateAnchorX: 'center',
+      _templateAnchorY: 'start'
+    }
+  ]
+}
+
 /** Новый заголовок для проверки редактирования текста после применения шаблона. */
 export const PRODUCT_CARD_TEMPLATE_UPDATED_TITLE = 'НАУШНИКИ SONY'
 
@@ -223,11 +351,35 @@ export const PRODUCT_CARD_TEMPLATE: TemplateDefinition = {
           height="609"
           viewBox="0 0 715 609">
             <g transform="matrix(1 0 0 1 0 31.473)" id="rect-AaC1NbVQpxv910CTixQ4J"  >
-<linearGradient id="SVGID_10" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 1 -357 -304)"  x1="0" y1="0" x2="541.132" y2="735.231">
+<linearGradient
+  id="SVGID_10"
+  gradientUnits="userSpaceOnUse"
+  gradientTransform="matrix(1 0 0 1 -357 -304)"
+  x1="0"
+  y1="0"
+  x2="541.132"
+  y2="735.231">
 <stop offset="0%" style="stop-color:rgb(130,29,252);stop-opacity: 1"/>
 <stop offset="100%" style="stop-color:rgb(181,29,252);stop-opacity: 1"/>
 </linearGradient>
-<rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: url(#SVGID_10); fill-rule: nonzero; opacity: 1;"  x="-357" y="-304" rx="36" ry="36" width="714" height="608" />
+<rect
+  style="
+    stroke: none;
+    stroke-width: 1;
+    stroke-dasharray: none;
+    stroke-linecap: butt;
+    stroke-dashoffset: 0;
+    stroke-linejoin: miter;
+    stroke-miterlimit: 4;
+    fill: url(#SVGID_10);
+    fill-rule: nonzero;
+    opacity: 1;"
+  x="-357"
+  y="-304"
+  rx="36"
+  ry="36"
+  width="714"
+  height="608" />
 </g>
 
         </svg>

--- a/e2e/tests/template-manager/index.spec.ts
+++ b/e2e/tests/template-manager/index.spec.ts
@@ -14,6 +14,7 @@ import {
   PRODUCT_CARD_TEMPLATE_UPDATED_TITLE,
   TEMPLATE_ALIGNMENT_TOLERANCE,
   TEMPLATE_BOUNDS_TOLERANCE,
+  TEMPLATE_RELATIVE_TOLERANCE,
   TEMPLATE_SHAPE_LONG_TEXT_OPTIONS,
   TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION,
   TEMPLATE_SHAPE_TEXT_LARGE_SCALE,
@@ -27,7 +28,13 @@ import {
   TEMPLATE_ROUNDTRIP_MIXED_TEXT,
   TEMPLATE_ROUNDTRIP_POSITION_TOLERANCE,
   TEMPLATE_ROUNDTRIP_RELATIVE_TOLERANCE,
-  TEMPLATE_ROUNDTRIP_RIGHT_SHAPE
+  TEMPLATE_ROUNDTRIP_RIGHT_SHAPE,
+  TEMPLATE_STANDALONE_TEXT_BASE_RESOLUTION,
+  TEMPLATE_STANDALONE_TEXT_COMPACT_RESOLUTION,
+  TEMPLATE_STANDALONE_TEXT_OBJECT_COUNT,
+  TEMPLATE_STANDALONE_TEXT_SQUARE_RESOLUTION,
+  TEMPLATE_STANDALONE_TEXT_TALL_RESOLUTION,
+  TEMPLATE_STANDALONE_TEXT_TEMPLATE
 } from '../../fixtures/data/template-manager.data'
 
 test.describe('Готовый шаблон', () => {
@@ -178,10 +185,10 @@ test.describe('Готовый шаблон', () => {
       expect((title.boundsTop - montageBounds.top) / montageBounds.height).toBeLessThan(0.1)
       expect(subtitle.boundsTop).toBeGreaterThan(title.boundsTop)
       expect(subtitle.boundsBottom).toBeLessThan(card.boundsTop)
-      expect(((featureLeft.centerX - montageBounds.left) / montageBounds.width)).toBeLessThan(0.3)
-      expect(((featureCenter.centerX - montageBounds.left) / montageBounds.width)).toBeGreaterThan(0.45)
-      expect(((featureCenter.centerX - montageBounds.left) / montageBounds.width)).toBeLessThan(0.55)
-      expect(((featureRight.centerX - montageBounds.left) / montageBounds.width)).toBeGreaterThan(0.7)
+      expect((featureLeft.centerX - montageBounds.left) / montageBounds.width).toBeLessThan(0.3)
+      expect((featureCenter.centerX - montageBounds.left) / montageBounds.width).toBeGreaterThan(0.45)
+      expect((featureCenter.centerX - montageBounds.left) / montageBounds.width).toBeLessThan(0.55)
+      expect((featureRight.centerX - montageBounds.left) / montageBounds.width).toBeGreaterThan(0.7)
       expect(Math.abs(featureLeft.boundsBottom - featureCenter.boundsBottom)).toBeLessThanOrEqual(
         TEMPLATE_ALIGNMENT_TOLERANCE
       )
@@ -233,6 +240,81 @@ test.describe('Готовый шаблон', () => {
       expect(titleObject.text).toBe(PRODUCT_CARD_TEMPLATE_UPDATED_TITLE)
       expect(subtitleObject.text).toBe('Новый подзаголовок товара')
     })
+  })
+})
+
+test.describe('Standalone text из шаблона', () => {
+  test('на разных размерах standalone text из шаблона остаётся по центру сверху', async({
+    canvas,
+    editorModel,
+    template
+  }) => {
+    const targetResolutions = [
+      {
+        label: 'уменьшенный квадратный размер',
+        resolution: TEMPLATE_STANDALONE_TEXT_COMPACT_RESOLUTION
+      },
+      {
+        label: 'увеличенный квадратный размер',
+        resolution: TEMPLATE_STANDALONE_TEXT_SQUARE_RESOLUTION
+      },
+      {
+        label: 'высокий размер с горизонтальными полями',
+        resolution: TEMPLATE_STANDALONE_TEXT_TALL_RESOLUTION
+      }
+    ] as const
+    const referencePlacement = await test.step(
+      'Применить шаблон на исходном размере и зафиксировать относительное положение текста',
+      async() => {
+        await canvas.setMontageResolution(TEMPLATE_STANDALONE_TEXT_BASE_RESOLUTION)
+
+        const insertedCount = await template.applyTemplate({
+          template: TEMPLATE_STANDALONE_TEXT_TEMPLATE
+        })
+
+        expect(insertedCount).toBe(TEMPLATE_STANDALONE_TEXT_OBJECT_COUNT)
+        await editorModel.checkObjectCount({ count: TEMPLATE_STANDALONE_TEXT_OBJECT_COUNT })
+
+        const montageBounds = await editorModel.getMontageAreaBounds()
+        const snapshot = await editorModel.getObjectSnapshot({ objectIndex: 0 })
+
+        return {
+          relativeCenterX: (snapshot.centerX - montageBounds.left) / montageBounds.width,
+          relativeTop: (snapshot.boundsTop - montageBounds.top) / montageBounds.height
+        }
+      }
+    )
+
+    for (const { resolution } of targetResolutions) {
+      await test.step(`Очистить canvas и заново применить тот же шаблон на размере ${resolution.width}x${resolution.height}`, async() => {
+        await canvas.clearCanvas()
+        await editorModel.checkObjectCount({ count: 0 })
+        await canvas.setMontageResolution(resolution)
+
+        const insertedCount = await template.applyTemplate({
+          template: TEMPLATE_STANDALONE_TEXT_TEMPLATE
+        })
+
+        expect(insertedCount).toBe(TEMPLATE_STANDALONE_TEXT_OBJECT_COUNT)
+        await editorModel.checkObjectCount({ count: TEMPLATE_STANDALONE_TEXT_OBJECT_COUNT })
+      })
+
+      await test.step(`Проверить что на размере ${resolution.width}x${resolution.height} текст остаётся по центру сверху`, async() => {
+        const montageBounds = await editorModel.getMontageAreaBounds()
+        const snapshot = await editorModel.getObjectSnapshot({ objectIndex: 0 })
+        const relativeCenterX = (snapshot.centerX - montageBounds.left) / montageBounds.width
+        const relativeTop = (snapshot.boundsTop - montageBounds.top) / montageBounds.height
+
+        expect(Math.abs(relativeCenterX - referencePlacement.relativeCenterX)).toBeLessThanOrEqual(
+          TEMPLATE_RELATIVE_TOLERANCE
+        )
+        expect(Math.abs(relativeTop - referencePlacement.relativeTop)).toBeLessThanOrEqual(
+          TEMPLATE_RELATIVE_TOLERANCE
+        )
+        expect(snapshot.boundsTop).toBeGreaterThanOrEqual(montageBounds.top - TEMPLATE_BOUNDS_TOLERANCE)
+        expect(snapshot.boundsBottom).toBeLessThanOrEqual(montageBounds.bottom + TEMPLATE_BOUNDS_TOLERANCE)
+      })
+    }
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/template-manager/index.spec.ts
+++ b/specs/src/editor/template-manager/index.spec.ts
@@ -6,12 +6,19 @@ import {
   createRevivedTemplateObject,
   getScenePointByOrigin
 } from '../../../test-utils/placement-helpers'
-import { createRestoredTemplateLikeTextbox } from '../../../test-utils/editor-helpers'
+import {
+  createRestoredStandaloneTemplateTextbox,
+  createRestoredTemplateLikeTextbox
+} from '../../../test-utils/editor-helpers'
 import {
   createMockShapeNode,
   createMockShapeTextbox
 } from '../../../test-utils/shape-helpers'
-import { createShapeTemplateDefinition, createTemplateManagerTestSetup } from '../../../test-utils/template-manager-helpers'
+import {
+  createShapeTemplateDefinition,
+  createStandaloneTextTemplateDefinition,
+  createTemplateManagerTestSetup
+} from '../../../test-utils/template-manager-helpers'
 import { BackgroundTextbox, registerBackgroundTextbox } from '../../../../src/editor/text-manager/background-textbox'
 
 describe('TemplateManager', () => {
@@ -247,6 +254,103 @@ describe('TemplateManager', () => {
     expect(editor.errorManager.emitError).not.toHaveBeenCalled()
   })
 
+  it('centered standalone text из шаблона сохраняет относительное положение на размере с горизонтальными полями', async() => {
+    const template = createStandaloneTextTemplateDefinition()
+    const baseMontageBounds = {
+      left: 100,
+      top: 50,
+      width: 810,
+      height: 1080
+    }
+    const targetMontageBounds = {
+      left: 100,
+      top: 50,
+      width: 1000,
+      height: 1000
+    }
+    const sourceSetup = createTemplateManagerTestSetup({
+      montageBounds: baseMontageBounds
+    })
+    const targetSetup = createTemplateManagerTestSetup({
+      montageBounds: targetMontageBounds
+    })
+    const sourceTextbox = Object.assign(
+      createRestoredStandaloneTemplateTextbox(),
+      {
+        _templateAnchorX: 'center' as const,
+        _templateAnchorY: 'start' as const
+      }
+    )
+    const targetTextbox = Object.assign(
+      createRestoredStandaloneTemplateTextbox(),
+      {
+        _templateAnchorX: 'center' as const,
+        _templateAnchorY: 'start' as const
+      }
+    )
+
+    jest.spyOn(util, 'enlivenObjects')
+      .mockResolvedValueOnce([sourceTextbox])
+      .mockResolvedValueOnce([targetTextbox])
+
+    const sourceResult = await sourceSetup.manager.applyTemplate({ template })
+    const targetResult = await targetSetup.manager.applyTemplate({ template })
+
+    sourceTextbox.setCoords()
+    targetTextbox.setCoords()
+
+    const sourceRect = sourceTextbox.getBoundingRect()
+    const targetRect = targetTextbox.getBoundingRect()
+    const sourceRelativeCenterX = ((sourceRect.left + (sourceRect.width / 2)) - baseMontageBounds.left)
+      / baseMontageBounds.width
+    const sourceRelativeTop = (sourceRect.top - baseMontageBounds.top) / baseMontageBounds.height
+    const targetRelativeCenterX = ((targetRect.left + (targetRect.width / 2)) - targetMontageBounds.left)
+      / targetMontageBounds.width
+    const targetRelativeTop = (targetRect.top - targetMontageBounds.top) / targetMontageBounds.height
+
+    expect(sourceResult).toEqual([sourceTextbox])
+    expect(targetResult).toEqual([targetTextbox])
+    expect(Math.abs(targetRelativeCenterX - sourceRelativeCenterX)).toBeLessThanOrEqual(0.03)
+    expect(Math.abs(targetRelativeTop - sourceRelativeTop)).toBeLessThanOrEqual(0.02)
+    expect(targetRect.top).toBeGreaterThanOrEqual(targetMontageBounds.top)
+    expect(targetRect.top + targetRect.height).toBeLessThanOrEqual(
+      targetMontageBounds.top + targetMontageBounds.height
+    )
+  })
+
+  it('после применения шаблона эмитит editor:template-applied с вставленными объектами и bounds монтажной области', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup()
+    const text = createMockShapeTextbox({ text: 'Template text' })
+    const group = new ShapeGroupObject([
+      createMockShapeNode() as never,
+      text
+    ], {
+      left: 100,
+      top: 100,
+      shapePresetKey: 'square'
+    })
+    const template = createShapeTemplateDefinition()
+
+    jest.spyOn(util, 'enlivenObjects').mockResolvedValue([group])
+
+    const result = await manager.applyTemplate({ template })
+
+    expect(result).toEqual([group])
+    expect(editor.canvas.fire).toHaveBeenCalledWith('editor:template-applied', {
+      template,
+      objects: [group],
+      bounds: {
+        left: 100,
+        top: 50,
+        width: 400,
+        height: 300
+      }
+    })
+  })
+
   // eslint-disable-next-line max-len
   it('длинный текст из шаблона получает стиль по всей строке из lineFontDefaults, а не только для тех символов что указаны в styles', async() => {
     const {
@@ -353,8 +457,10 @@ describe('TemplateManager', () => {
       manager,
       editor
     } = createTemplateManagerTestSetup()
-    const backgroundObject = createMockShapeNode() as never
-    backgroundObject.id = 'background'
+    const backgroundObject = createMockShapeNode({ id: 'background' }) as ReturnType<typeof createMockShapeNode> & {
+      backgroundType?: 'color' | 'gradient' | 'image' | null
+      fill?: string
+    }
     backgroundObject.backgroundType = 'color'
     backgroundObject.fill = '#ff0055'
     const contentObject = new ShapeGroupObject([

--- a/specs/test-utils/editor-helpers.ts
+++ b/specs/test-utils/editor-helpers.ts
@@ -1302,6 +1302,54 @@ export const createRestoredTemplateLikeTextbox = ({
 }
 
 /**
+ * Создаёт standalone background-textbox, близкий к реальному template-path кейсу
+ * с длинным верхним заголовком и center-anchor по ширине.
+ */
+export const createRestoredStandaloneTemplateTextbox = ({
+  left = 0.03209876543209877,
+  top = 0.04351851851851852,
+  width = 758,
+  originX = 'left',
+  originY = 'top'
+}: {
+  left?: number
+  top?: number
+  width?: number
+  originX?: 'left' | 'center' | 'right'
+  originY?: 'top' | 'center' | 'bottom'
+} = {}): BackgroundTextbox => {
+  const textbox = new BackgroundTextbox('ЖЕНСКАЯ СУМКА ИЗ КОЖИ БЛА БЛА БЛА БЛА БЛАБЛА БЛА БЛА БЛА', {
+    width,
+    left,
+    top,
+    originX,
+    originY,
+    fontFamily: 'Open Sans',
+    fontSize: 72,
+    fontWeight: 'normal',
+    lineHeight: 1.16,
+    textAlign: 'center',
+    fill: '#333333',
+    backgroundOpacity: 1,
+    autoExpand: false,
+    paddingTop: 0,
+    paddingRight: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+    radiusTopLeft: 0,
+    radiusTopRight: 0,
+    radiusBottomRight: 0,
+    radiusBottomLeft: 0
+  })
+
+  textbox.textCaseRaw = 'женская сумка из кожи'
+  textbox.uppercase = true
+  textbox.setCoords()
+
+  return textbox
+}
+
+/**
  * Создаёт template-подобный background-textbox с разными стилями по строкам и фоновыми отступами.
  * Используется для тестов reflow/resizing регрессии.
  */

--- a/specs/test-utils/template-manager-helpers.ts
+++ b/specs/test-utils/template-manager-helpers.ts
@@ -99,3 +99,27 @@ export const createShapeTemplateDefinition = (): TemplateDefinition => ({
     }
   ]
 })
+
+/**
+ * Создаёт минимальный template definition для centered standalone text с top-anchor.
+ */
+export const createStandaloneTextTemplateDefinition = (): TemplateDefinition => ({
+  id: 'template-standalone-text',
+  meta: {
+    baseWidth: 810,
+    baseHeight: 1080,
+    positionsNormalized: true
+  },
+  objects: [
+    {
+      type: 'background-textbox',
+      left: 0.03209876543209877,
+      top: 0.04351851851851852,
+      width: 758,
+      originX: 'left',
+      originY: 'top',
+      _templateAnchorX: 'center',
+      _templateAnchorY: 'start'
+    }
+  ]
+})

--- a/src/editor/template-manager/index.ts
+++ b/src/editor/template-manager/index.ts
@@ -53,6 +53,11 @@ const TEMPLATE_ANCHOR_Y_KEY = '_templateAnchorY'
 
 type TemplateAnchor = 'start' | 'center' | 'end'
 
+type TemplateAnchors = {
+  _templateAnchorX?: TemplateAnchor
+  _templateAnchorY?: TemplateAnchor
+}
+
 type TemplateCustomData = Record<string, unknown> & {
   templateField?: string
   text?: string
@@ -86,6 +91,10 @@ export type SerializeTemplateOptions = {
 export type ApplyTemplateOptions = {
   template: TemplateDefinition
   data?: Record<string, string>
+}
+
+type BoundingRectReadableObject = FabricObject & {
+  getBoundingRect: (absolute?: boolean, calculate?: boolean) => Bounds
 }
 
 export default class TemplateManager {
@@ -142,13 +151,16 @@ export default class TemplateManager {
         baseWidth,
         baseHeight
       }))
+    const inheritedPreviewId = typeof meta.previewId === 'string'
+      ? meta.previewId
+      : undefined
 
     const templateMeta: TemplateMeta = {
       ...meta,
       baseWidth,
       baseHeight,
       positionsNormalized: true,
-      previewId: previewId ?? meta.previewId
+      previewId: previewId ?? inheritedPreviewId
     }
 
     const template: TemplateDefinition = {
@@ -336,7 +348,7 @@ export default class TemplateManager {
     try {
       // Принудительно пересчитываем координаты перед получением bounds
       object.setCoords()
-      const rect = object.getBoundingRect(false, true)
+      const rect = TemplateManager._getBoundingRect(object)
       return {
         left: rect.left,
         top: rect.top,
@@ -349,8 +361,17 @@ export default class TemplateManager {
   }
 
   /**
-    * Превращает plain-описание объектов в Fabric объекты.
-    */
+   * Возвращает scene bounds объекта через runtime-сигнатуру Fabric.
+   */
+  private static _getBoundingRect(object: FabricObject): Bounds {
+    const readableObject = object as BoundingRectReadableObject
+
+    return readableObject.getBoundingRect(false, true)
+  }
+
+  /**
+   * Превращает plain-описание объектов в Fabric объекты.
+   */
   private static async _enlivenObjects(objects: TemplateObjectData[]): Promise<FabricObject[]> {
     const revivedList = await Promise.all(objects.map(async(serialized) => {
       if (TemplateManager._hasSerializedSvgMarkup(serialized)) {
@@ -549,7 +570,7 @@ export default class TemplateManager {
    * Определяет, что объект представляет SVG.
    */
   private static _isSvgObject(object: FabricObject): boolean {
-    return (object as Record<string, unknown>).format === 'svg'
+    return object.format === 'svg'
   }
 
   /**
@@ -566,7 +587,7 @@ export default class TemplateManager {
       const hasRoot = /<svg[\s>]/i.test(svgContent)
       if (hasRoot) return svgContent
 
-      const { width, height } = object.getBoundingRect(false, true)
+      const { width, height } = TemplateManager._getBoundingRect(object)
       const safeWidth = width || object.width || 0
       const safeHeight = height || object.height || 0
 
@@ -602,7 +623,7 @@ export default class TemplateManager {
     baseHeight: number
     useRelativePositions: boolean
   }): void {
-    const objectRecord = object as Record<string, unknown>
+    const objectWithTemplateAnchors = object as FabricObject & TemplateAnchors
     const { x: normalizedX, y: normalizedY } = resolveNormalizedPlacement({
       object,
       baseWidth,
@@ -619,8 +640,8 @@ export default class TemplateManager {
       baseHeight,
       scale,
       useRelativePositions,
-      anchorX: TemplateManager._resolveAnchor(objectRecord, TEMPLATE_ANCHOR_X_KEY),
-      anchorY: TemplateManager._resolveAnchor(objectRecord, TEMPLATE_ANCHOR_Y_KEY)
+      anchorX: TemplateManager._resolveAnchor(objectWithTemplateAnchors, TEMPLATE_ANCHOR_X_KEY),
+      anchorY: TemplateManager._resolveAnchor(objectWithTemplateAnchors, TEMPLATE_ANCHOR_Y_KEY)
     })
 
     const absolutePlacement = denormalizePlacement({
@@ -649,8 +670,8 @@ export default class TemplateManager {
       }
     })
 
-    delete objectRecord[TEMPLATE_ANCHOR_X_KEY]
-    delete objectRecord[TEMPLATE_ANCHOR_Y_KEY]
+    delete objectWithTemplateAnchors._templateAnchorX
+    delete objectWithTemplateAnchors._templateAnchorY
   }
 
   /**
@@ -699,8 +720,11 @@ export default class TemplateManager {
     return 0
   }
 
-  private static _resolveAnchor(objectRecord: Record<string, unknown>, key: string): TemplateAnchor {
-    const value = objectRecord[key]
+  private static _resolveAnchor(
+    objectWithTemplateAnchors: TemplateAnchors,
+    key: typeof TEMPLATE_ANCHOR_X_KEY | typeof TEMPLATE_ANCHOR_Y_KEY
+  ): TemplateAnchor {
+    const value = objectWithTemplateAnchors[key]
     if (value === 'center' || value === 'end' || value === 'start') return value
     return 'start'
   }
@@ -794,7 +818,8 @@ export default class TemplateManager {
   }
 
   /**
-   * Подгоняет ширину текстового объекта под фактическую длину строк, сохраняя выравнивание по якорю.
+   * Подгоняет ширину текстового объекта под фактическую длину строк
+   * в координатах исходного template-base и сохраняет выравнивание по якорю.
    */
   private _adaptTextboxWidth({
     object,
@@ -808,30 +833,24 @@ export default class TemplateManager {
     const textValue = typeof object.text === 'string' ? object.text : ''
     if (!textValue) return
 
-    const montageAreaWidth = toNumber({
-      value: this.editor?.montageArea?.width,
-      fallback: 0
-    })
-    const {
-      width: storedWidth = 0
-    } = object
-    const normalizedBaseWidth = toNumber({ value: baseWidth, fallback: 0 })
-    const textWidth = toNumber({ value: storedWidth, fallback: 0 })
-    if (!montageAreaWidth || !textWidth || !normalizedBaseWidth) return
+    const templateBaseWidth = toNumber({ value: baseWidth, fallback: 0 })
+    const textWidth = toNumber({ value: object.width, fallback: 0 })
+    if (!templateBaseWidth || !textWidth) return
 
     object.setCoords()
-    const objectRecord = object as Record<string, unknown>
-    const anchorX = TemplateManager._resolveAnchor(objectRecord, TEMPLATE_ANCHOR_X_KEY)
-    const storedPlacementX = typeof objectRecord.left === 'number'
-      ? objectRecord.left
+    const textboxWithTemplateAnchors = object as Textbox & TemplateAnchors
+    const anchorX = TemplateManager._resolveAnchor(textboxWithTemplateAnchors, TEMPLATE_ANCHOR_X_KEY)
+    const storedPlacementX = typeof object.left === 'number'
+      ? object.left
       : null
     const originX = object.originX ?? 'center'
     const originY = object.originY ?? 'center'
     const originalPlacement = object.getPointByOrigin(originX, originY)
-    const originalRect = object.getBoundingRect(false, true)
+    const originalRect = TemplateManager._getBoundingRect(object)
+    const originalCenterX = originalRect.left + (originalRect.width / 2)
     const originalRight = originalRect.left + originalRect.width
 
-    object.set('width', montageAreaWidth)
+    object.set('width', templateBaseWidth)
     object.initDimensions()
 
     const longestLineWidth = TemplateManager._getLongestLineWidth({
@@ -847,17 +866,20 @@ export default class TemplateManager {
 
     if (storedPlacementX === null) return
 
-    const finalRect = object.getBoundingRect(false, true)
+    const finalRect = TemplateManager._getBoundingRect(object)
+    const finalCenterX = finalRect.left + (finalRect.width / 2)
     const finalRight = finalRect.left + finalRect.width
     let nextPlacementX = storedPlacementX
 
     if (anchorX === 'start') {
-      nextPlacementX += (originalRect.left - finalRect.left) / normalizedBaseWidth
+      nextPlacementX += (originalRect.left - finalRect.left) / templateBaseWidth
+    } else if (anchorX === 'center') {
+      nextPlacementX += (originalCenterX - finalCenterX) / templateBaseWidth
     } else if (anchorX === 'end') {
-      nextPlacementX += (originalRight - finalRight) / normalizedBaseWidth
+      nextPlacementX += (originalRight - finalRight) / templateBaseWidth
     }
 
-    objectRecord.left = nextPlacementX
+    object.left = nextPlacementX
   }
 
   /**
@@ -922,7 +944,7 @@ export default class TemplateManager {
       width: boundsWidth,
       height: boundsHeight
     } = bounds
-    const rect = object.getBoundingRect(false, true)
+    const rect = TemplateManager._getBoundingRect(object)
     const safeWidth = baseWidth || boundsWidth || 1
     const safeHeight = baseHeight || boundsHeight || 1
     const placement = this.editor.canvasManager.getObjectPlacement({ object })
@@ -1090,9 +1112,9 @@ export default class TemplateManager {
       }
     }
 
-    const asRecord = image as Record<string, unknown>
-    if (typeof asRecord.src === 'string') {
-      return asRecord.src as string
+    const imageWithSource = image as FabricObject & { src?: unknown }
+    if (typeof imageWithSource.src === 'string') {
+      return imageWithSource.src
     }
 
     return null

--- a/src/editor/types/events.d.ts
+++ b/src/editor/types/events.d.ts
@@ -154,6 +154,17 @@ export type ExternalImagePastePendingPayload = {
   }
 }
 
+export type TemplateAppliedPayload = {
+  template: import('../template-manager').TemplateDefinition
+  objects: FabricObject[]
+  bounds: {
+    left: number
+    top: number
+    width: number
+    height: number
+  }
+}
+
 declare module 'fabric' {
   interface CanvasEvents {
     /**
@@ -451,5 +462,10 @@ declare module 'fabric' {
      * Срабатывает при удалении фона.
      */
     'editor:background:removed': void
+
+    /**
+     * Срабатывает после применения шаблона к текущей монтажной области.
+     */
+    'editor:template-applied': TemplateAppliedPayload
   }
 }


### PR DESCRIPTION

Порядок воспроизведения.

1. Ниже представлен темплейт с текстовым объектом с текстом "ЖЕНСКАЯ СУМКА ИЗ КОЖИ БЛА БЛА БЛА БЛА БЛАБЛА БЛА БЛА БЛА" созданный на разрешении 810х1080 (скрин 1)

<img width="1105" height="477" alt="image" src="https://github.com/user-attachments/assets/0c040fbe-a9fa-430e-aa1a-df282fec5dc6" />

```json
{
  "id": "template-cPnfp6DuAz8FcBntVXxxQ",
  "meta": {
    "baseWidth": 810,
    "baseHeight": 1080,
    "positionsNormalized": true
  },
  "objects": [
    {
      "fontSize": 72,
      "fontWeight": "normal",
      "fontFamily": "Open Sans",
      "fontStyle": "normal",
      "lineHeight": 1.16,
      "text": "ЖЕНСКАЯ СУМКА ИЗ КОЖИ БЛА БЛА БЛА БЛА БЛАБЛА БЛА БЛА БЛА",
      "charSpacing": 0,
      "textAlign": "center",
      "styles": [],
      "pathStartOffset": 0,
      "pathSide": "left",
      "pathAlign": "baseline",
      "underline": false,
      "overline": false,
      "linethrough": false,
      "textBackgroundColor": null,
      "direction": "ltr",
      "textDecorationThickness": 66.667,
      "minWidth": 20,
      "splitByGrapheme": false,
      "id": "background-textbox-iPaS7YLnTRKxLVc_2hpMt",
      "customData": {
        "handle": "title",
        "template": "{{text}}",
        "variables": [
          {
            "name": "text",
            "description": "Заголовок товара",
            "maxChars": 30
          }
        ]
      },
      "width": 758,
      "height": 364,
      "originX": "left",
      "originY": "top",
      "editable": true,
      "evented": true,
      "selectable": true,
      "lockMovementX": false,
      "lockMovementY": false,
      "lockRotation": false,
      "lockScalingX": false,
      "lockScalingY": false,
      "lockSkewingX": false,
      "lockSkewingY": false,
      "textCaseRaw": "женская сумка из кожи",
      "uppercase": true,
      "autoExpand": false,
      "backgroundOpacity": 1,
      "paddingTop": 0,
      "paddingRight": 0,
      "paddingBottom": 0,
      "paddingLeft": 0,
      "radiusTopLeft": 0,
      "radiusTopRight": 0,
      "radiusBottomRight": 0,
      "radiusBottomLeft": 0,
      "type": "background-textbox",
      "version": "7.2.0",
      "left": 0.03209876543209877,
      "top": 0.04351851851851852,
      "fill": "#333333",
      "stroke": null,
      "strokeWidth": 0,
      "strokeDashArray": null,
      "strokeLineCap": "butt",
      "strokeDashOffset": 0,
      "strokeLineJoin": "miter",
      "strokeUniform": true,
      "strokeMiterLimit": 4,
      "scaleX": 1,
      "scaleY": 1,
      "angle": 0,
      "flipX": false,
      "flipY": false,
      "opacity": 1,
      "shadow": null,
      "visible": true,
      "backgroundColor": null,
      "fillRule": "nonzero",
      "paintFirst": "fill",
      "globalCompositeOperation": "source-over",
      "skewX": 0,
      "skewY": 0,
      "_templateAnchorX": "center",
      "_templateAnchorY": "start"
    }
  ]
}
```

2. Если применить этот объект на разрешении 512х512 или 810х1080, то вроде всё ок, объект всегда появляется посередине (скрины 2-3)

<img width="1251" height="473" alt="image" src="https://github.com/user-attachments/assets/3b852e29-819b-4d30-b293-24cce81a728e" />

<img width="1137" height="514" alt="image" src="https://github.com/user-attachments/assets/b9c8123b-0b8f-4b02-9791-9988ab434cd7" />

3. Если применить этот объект на разрешении 1000х1000 или 900х1200, то он почему-то смещается вправо хотя должен отображаться посередине сверху аналогично тому как это работает в пункте 2 (скрин 4-5)

<img width="1194" height="524" alt="image" src="https://github.com/user-attachments/assets/6fe457ee-c834-4a33-99a6-7d214e9713a6" />

<img width="1227" height="503" alt="image" src="https://github.com/user-attachments/assets/0b86e02b-9337-4dc1-ac50-b96e57a4e1f4" />

Ожидаемое и фактическое поведение описано в 3 пункте.

---

FIXED.