### PR TITLE
TemplateManager & ShapeManager. При применении шаблона генерируем новые ID не только для shape-group, но и для объектов внутри, чтобы не было дублей

### DIFF
--- a/e2e/fixtures/data/template-identity.data.ts
+++ b/e2e/fixtures/data/template-identity.data.ts
@@ -1,0 +1,25 @@
+export const TEMPLATE_IDENTITY_MONTAGE_RESOLUTION = {
+  width: 810,
+  height: 1080
+} as const
+
+export const TEMPLATE_IDENTITY_SHAPE = {
+  id: 'template-identity-shape',
+  left: 116,
+  top: 196,
+  width: 180,
+  height: 180,
+  text: 'TEST',
+  fill: '#D1D5DB'
+} as const
+
+export const TEMPLATE_IDENTITY_TEXT = {
+  id: 'template-identity-text',
+  text: 'Standalone text',
+  left: 332,
+  top: 228,
+  originX: 'left',
+  originY: 'top',
+  fontSize: 48,
+  color: '#111827'
+} as const

--- a/e2e/tests/template-manager/template-identity.spec.ts
+++ b/e2e/tests/template-manager/template-identity.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  TEMPLATE_IDENTITY_MONTAGE_RESOLUTION,
+  TEMPLATE_IDENTITY_SHAPE,
+  TEMPLATE_IDENTITY_TEXT
+} from '../../fixtures/data/template-identity.data'
+
+test.describe('ID объектов после повторного применения шаблона', () => {
+  // eslint-disable-next-line max-len
+  test('после сохранения фигуры в шаблон и повторного применения на том же canvas новая фигура и объекты внутри неё получают другие id', async({
+    canvas,
+    editorModel,
+    shapes,
+    template
+  }) => {
+    await test.step('Подготовить монтажную область и добавить исходную фигуру', async() => {
+      await canvas.setMontageResolution(TEMPLATE_IDENTITY_MONTAGE_RESOLUTION)
+
+      shapes.checkCreation({
+        shape: await shapes.addAtBounds({
+          presetKey: 'square',
+          options: TEMPLATE_IDENTITY_SHAPE
+        }),
+        presetKey: 'square'
+      })
+    })
+
+    const sourceIds = await test.step('Получить id исходной фигуры и объектов внутри неё', async() => {
+      return shapes.getObjectTreeIds({ id: TEMPLATE_IDENTITY_SHAPE.id })
+    })
+
+    await test.step('Сохранить фигуру в шаблон и применить его на том же canvas', async() => {
+      await shapes.select({ id: TEMPLATE_IDENTITY_SHAPE.id })
+
+      const serializedTemplate = await template.serializeSelection()
+
+      expect(serializedTemplate).not.toBeNull()
+
+      const insertedCount = await template.applyTemplate({
+        template: serializedTemplate!
+      })
+
+      expect(insertedCount).toBe(1)
+      await editorModel.checkObjectCount({ count: 2 })
+    })
+
+    const appliedShapeId = await test.step('Найти новую фигуру после применения шаблона', async() => {
+      const shapeObjects = await shapes.getShapeObjects()
+      const appliedShape = shapeObjects.find((shape) => shape.id !== TEMPLATE_IDENTITY_SHAPE.id)
+
+      if (!appliedShape?.id) {
+        throw new Error('после применения шаблона должна появиться новая фигура с id')
+      }
+
+      return appliedShape.id
+    })
+
+    await test.step('Проверить что новая фигура и объекты внутри неё получили другие id', async() => {
+      const appliedIds = await shapes.getObjectTreeIds({ id: appliedShapeId })
+      const ids = [
+        sourceIds.groupId,
+        sourceIds.shapeId,
+        sourceIds.textId,
+        appliedIds.groupId,
+        appliedIds.shapeId,
+        appliedIds.textId
+      ]
+
+      expect(appliedIds.groupId).not.toBe(sourceIds.groupId)
+      expect(appliedIds.shapeId).not.toBe(sourceIds.shapeId)
+      expect(appliedIds.textId).not.toBe(sourceIds.textId)
+      expect(new Set(ids).size).toBe(ids.length)
+    })
+  })
+
+  test('после сохранения текста в шаблон и повторного применения на том же canvas новый текст получает другой id', async({
+    canvas,
+    editorModel,
+    template,
+    text
+  }) => {
+    await test.step('Подготовить монтажную область и добавить исходный текст', async() => {
+      await canvas.setMontageResolution(TEMPLATE_IDENTITY_MONTAGE_RESOLUTION)
+
+      text.checkCreation({
+        textObject: await text.add(TEMPLATE_IDENTITY_TEXT)
+      })
+    })
+
+    await test.step('Сохранить текст в шаблон и применить его на том же canvas', async() => {
+      await text.select({ id: TEMPLATE_IDENTITY_TEXT.id })
+
+      const serializedTemplate = await template.serializeSelection()
+
+      expect(serializedTemplate).not.toBeNull()
+
+      const insertedCount = await template.applyTemplate({
+        template: serializedTemplate!
+      })
+
+      expect(insertedCount).toBe(1)
+      await editorModel.checkObjectCount({ count: 2 })
+    })
+
+    await test.step('Проверить что применённый текст получил другой id', async() => {
+      const objects = await editorModel.getObjects()
+      const appliedText = objects.find((object) => {
+        return object.type === 'background-textbox' && object.id !== TEMPLATE_IDENTITY_TEXT.id
+      })
+
+      expect(appliedText?.id).toEqual(expect.any(String))
+      expect(appliedText?.id).not.toBe(TEMPLATE_IDENTITY_TEXT.id)
+    })
+  })
+
+  test('после сохранения общего выделения из фигуры и текста повторное применение даёт новые id и фигуре, и тексту', async({
+    canvas,
+    editorModel,
+    shapes,
+    template,
+    text
+  }) => {
+    await test.step('Подготовить монтажную область и добавить фигуру с текстом и standalone текст', async() => {
+      await canvas.setMontageResolution(TEMPLATE_IDENTITY_MONTAGE_RESOLUTION)
+
+      shapes.checkCreation({
+        shape: await shapes.addAtBounds({
+          presetKey: 'square',
+          options: TEMPLATE_IDENTITY_SHAPE
+        }),
+        presetKey: 'square'
+      })
+
+      text.checkCreation({
+        textObject: await text.add(TEMPLATE_IDENTITY_TEXT)
+      })
+    })
+
+    const sourceShapeIds = await test.step('Получить id исходной фигуры и объектов внутри неё', async() => {
+      return shapes.getObjectTreeIds({ id: TEMPLATE_IDENTITY_SHAPE.id })
+    })
+
+    await test.step('Сохранить общее выделение в шаблон и применить его на том же canvas', async() => {
+      await editorModel.selectAllObjects()
+
+      const serializedTemplate = await template.serializeSelection()
+
+      expect(serializedTemplate).not.toBeNull()
+
+      const insertedCount = await template.applyTemplate({
+        template: serializedTemplate!
+      })
+
+      expect(insertedCount).toBe(2)
+      await editorModel.checkObjectCount({ count: 4 })
+    })
+
+    const appliedObjects = await test.step('Найти новые объекты после применения смешанного шаблона', async() => {
+      const objects = await editorModel.getObjects()
+      const appliedShape = objects.find((object) => {
+        return object.type === 'shape-group' && object.id !== TEMPLATE_IDENTITY_SHAPE.id
+      })
+      const appliedText = objects.find((object) => {
+        return object.type === 'background-textbox' && object.id !== TEMPLATE_IDENTITY_TEXT.id
+      })
+
+      if (!appliedShape?.id || !appliedText?.id) {
+        throw new Error('после применения mixed template должны существовать новая фигура и новый текст')
+      }
+
+      return {
+        appliedShapeId: appliedShape.id,
+        appliedTextId: appliedText.id
+      }
+    })
+
+    await test.step('Проверить что новые id получили и фигура, и текст, и объекты внутри новой фигуры', async() => {
+      const appliedShapeIds = await shapes.getObjectTreeIds({ id: appliedObjects.appliedShapeId })
+      const ids = [
+        sourceShapeIds.groupId,
+        sourceShapeIds.shapeId,
+        sourceShapeIds.textId,
+        TEMPLATE_IDENTITY_TEXT.id,
+        appliedShapeIds.groupId,
+        appliedShapeIds.shapeId,
+        appliedShapeIds.textId,
+        appliedObjects.appliedTextId
+      ]
+
+      expect(appliedShapeIds.groupId).not.toBe(sourceShapeIds.groupId)
+      expect(appliedShapeIds.shapeId).not.toBe(sourceShapeIds.shapeId)
+      expect(appliedShapeIds.textId).not.toBe(sourceShapeIds.textId)
+      expect(appliedObjects.appliedTextId).not.toBe(TEMPLATE_IDENTITY_TEXT.id)
+      expect(new Set(ids).size).toBe(ids.length)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/template-manager/index.spec.ts
+++ b/specs/src/editor/template-manager/index.spec.ts
@@ -1,4 +1,5 @@
 import { Point, Textbox, util } from 'fabric'
+import { nanoid } from 'nanoid'
 import { ShapeGroupObject, registerShapeGroup } from '../../../../src/editor/shape-manager/shape-group'
 import {
   createPlacementSelection,
@@ -23,8 +24,17 @@ import { BackgroundTextbox, registerBackgroundTextbox } from '../../../../src/ed
 
 describe('TemplateManager', () => {
   beforeEach(() => {
+    const nanoidMock = nanoid as jest.MockedFunction<typeof nanoid>
+    let nanoidCallIndex = 0
+
     jest.restoreAllMocks()
     registerShapeGroup()
+    nanoidMock.mockReset()
+    nanoidMock.mockImplementation(() => {
+      nanoidCallIndex += 1
+
+      return `mock-nanoid-${nanoidCallIndex}`
+    })
     jest.clearAllMocks()
   })
 
@@ -520,6 +530,133 @@ describe('TemplateManager', () => {
 
     expect(result).toBeNull()
     expect(editor.errorManager.emitWarning).toHaveBeenCalled()
+  })
+
+  it('при применении шаблона фигура получает новые id у группы и внутренних объектов', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup()
+    const revivedShape = createMockShapeNode({ id: 'shape-node-source-id' })
+    const revivedText = createMockShapeTextbox({ text: 'Template text' })
+
+    revivedText.set({ id: 'shape-text-source-id' })
+
+    const revivedGroup = new ShapeGroupObject([
+      revivedShape as never,
+      revivedText
+    ], {
+      id: 'shape-group-source-id',
+      left: 100,
+      top: 100,
+      shapePresetKey: 'square'
+    })
+
+    jest.spyOn(util, 'enlivenObjects').mockResolvedValue([revivedGroup])
+
+    const result = await manager.applyTemplate({
+      template: createShapeTemplateDefinition()
+    })
+    const appliedIds = [
+      revivedGroup.id,
+      revivedShape.id,
+      revivedText.id
+    ]
+
+    expect(result).toEqual([revivedGroup])
+    expect(editor.errorManager.emitError).not.toHaveBeenCalled()
+    expect(revivedGroup.id).toEqual(expect.any(String))
+    expect(revivedGroup.id).not.toBe('shape-group-source-id')
+    expect(revivedShape.id).toEqual(expect.any(String))
+    expect(revivedShape.id).not.toBe('shape-node-source-id')
+    expect(revivedText.id).toEqual(expect.any(String))
+    expect(revivedText.id).not.toBe('shape-text-source-id')
+    expect(new Set(appliedIds).size).toBe(3)
+  })
+
+  it('при применении mixed template новые id получают и фигура с вложенными объектами, и отдельный текст', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup()
+    const revivedShape = createMockShapeNode({ id: 'mixed-shape-node-source-id' })
+    const revivedShapeText = createMockShapeTextbox({ text: 'Shape text' })
+
+    revivedShapeText.set({ id: 'mixed-shape-text-source-id' })
+
+    const revivedGroup = new ShapeGroupObject([
+      revivedShape as never,
+      revivedShapeText
+    ], {
+      id: 'mixed-shape-group-source-id',
+      left: 100,
+      top: 100,
+      shapePresetKey: 'square'
+    })
+    const revivedStandaloneText = new Textbox('Standalone text', {
+      left: 220,
+      top: 100,
+      width: 140,
+      originX: 'left',
+      originY: 'top'
+    }) as Textbox & {
+      id?: string
+    }
+
+    revivedStandaloneText.set({ id: 'mixed-standalone-text-source-id' })
+
+    jest.spyOn(util, 'enlivenObjects').mockImplementation(async(serializedObjects) => {
+      const [serialized] = serializedObjects as Array<Record<string, unknown>>
+
+      if (serialized.type === 'shape-group') return [revivedGroup] as never
+      if (serialized.type === 'textbox') return [revivedStandaloneText] as never
+
+      return [] as never
+    })
+
+    const result = await manager.applyTemplate({
+      template: {
+        id: 'mixed-template',
+        meta: {
+          baseWidth: 400,
+          baseHeight: 300,
+          positionsNormalized: true
+        },
+        objects: [
+          {
+            type: 'shape-group',
+            left: 100,
+            top: 100,
+            shapePresetKey: 'square'
+          },
+          {
+            type: 'textbox',
+            left: 220,
+            top: 100,
+            width: 140,
+            text: 'Standalone text'
+          }
+        ]
+      }
+    })
+    const appliedIds = [
+      revivedGroup.id,
+      revivedShape.id,
+      revivedShapeText.id,
+      revivedStandaloneText.id
+    ]
+
+    expect(result).toEqual([revivedGroup, revivedStandaloneText])
+    expect(editor.errorManager.emitError).not.toHaveBeenCalled()
+    expect(revivedGroup.id).toEqual(expect.any(String))
+    expect(revivedGroup.id).not.toBe('mixed-shape-group-source-id')
+    expect(revivedShape.id).toEqual(expect.any(String))
+    expect(revivedShape.id).not.toBe('mixed-shape-node-source-id')
+    expect(revivedShapeText.id).toEqual(expect.any(String))
+    expect(revivedShapeText.id).not.toBe('mixed-shape-text-source-id')
+    expect(revivedStandaloneText.id).toEqual(expect.any(String))
+    expect(revivedStandaloneText.id).not.toBe('mixed-standalone-text-source-id')
+    expect(new Set(appliedIds).size).toBe(4)
   })
 
   it('при сохранении двух выделенных объектов не теряет их места на канвасе', () => {

--- a/src/editor/clipboard-manager/index.ts
+++ b/src/editor/clipboard-manager/index.ts
@@ -1,9 +1,9 @@
-import { ActiveSelection, FabricObject, Group } from 'fabric'
-import { nanoid } from 'nanoid'
+import { ActiveSelection, FabricObject } from 'fabric'
 import { CLIPBOARD_DATA_PREFIX, CLIPBOARD_CLONE_OBJECT_KEYS } from '../constants'
 
 import { ImageEditor } from '../index'
 import type { ImportImageOptions } from '../image-manager'
+import { materializeObjectIdentity } from '../utils/object-identity'
 
 export default class ClipboardManager {
   /**
@@ -232,40 +232,6 @@ export default class ClipboardManager {
   }
 
   /**
-   * Назначает свежие id клону и всем вложенным объектам перед вставкой на canvas.
-   * `evented` восстанавливается только у объектов верхнего уровня, которые реально добавляются на canvas.
-   */
-  private _materializeCloneIdentity({
-    clonedObject,
-    enableEvented = true
-  }: {
-    clonedObject: FabricObject
-    enableEvented?: boolean
-  }): void {
-    clonedObject.set({
-      id: `${clonedObject.type}-${nanoid()}`
-    })
-
-    if (enableEvented) {
-      clonedObject.set({
-        evented: true
-      })
-    }
-
-    const shouldEnableChildEvented = clonedObject instanceof ActiveSelection
-    const isNestedContainer = shouldEnableChildEvented || clonedObject instanceof Group
-
-    if (!isNestedContainer) return
-
-    clonedObject.getObjects().forEach((object) => {
-      this._materializeCloneIdentity({
-        clonedObject: object,
-        enableEvented: shouldEnableChildEvented
-      })
-    })
-  }
-
-  /**
    * Обработка импорта изображения из буфера обмена
    * @param source - источник изображения (data URL или URL)
    */
@@ -315,6 +281,12 @@ export default class ClipboardManager {
 
     try {
       const importOptions = await deferredPromise
+
+      if (importOptions === null) {
+        await this._importExternalImage({ source })
+        return
+      }
+
       await this._importExternalImage({ source, importOptions })
     } catch (error) {
       errorManager.emitError({
@@ -373,8 +345,8 @@ export default class ClipboardManager {
       // Используем асинхронное клонирование для корректной работы с SVG и сложными объектами
       const clonedObject = await targetObject.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
 
-      this._materializeCloneIdentity({
-        clonedObject
+      materializeObjectIdentity({
+        rootObject: clonedObject
       })
 
       clonedObject.set({
@@ -494,8 +466,8 @@ export default class ClipboardManager {
 
       canvas.discardActiveObject()
 
-      this._materializeCloneIdentity({
-        clonedObject: clonedObj
+      materializeObjectIdentity({
+        rootObject: clonedObj
       })
 
       clonedObj.set({

--- a/src/editor/template-manager/index.ts
+++ b/src/editor/template-manager/index.ts
@@ -19,6 +19,7 @@ import {
   toNumber,
   type Dimensions
 } from '../utils/geometry'
+import { materializeObjectIdentity } from '../utils/object-identity'
 import {
   convertGradientToOptions
 } from '../utils/gradient'
@@ -278,9 +279,8 @@ export default class TemplateManager {
 
         snapObjectToPixelGrid({ object })
 
-        object.set({
-          id: `${object.type}-${nanoid()}`,
-          evented: true
+        materializeObjectIdentity({
+          rootObject: object
         })
 
         canvas.add(object)

--- a/src/editor/utils/object-identity.ts
+++ b/src/editor/utils/object-identity.ts
@@ -1,0 +1,60 @@
+import { ActiveSelection, FabricObject, Group } from 'fabric'
+import { nanoid } from 'nanoid'
+
+type IdentityMaterializationEntry = {
+  object: FabricObject
+  enableEvented: boolean
+}
+
+/**
+ * Назначает свежие id корневому объекту и всей вложенной ветке materialized-объектов.
+ * `evented` восстанавливается только у объектов верхнего уровня и у children ActiveSelection,
+ * которые реально становятся отдельными canvas-объектами.
+ */
+export const materializeObjectIdentity = ({
+  rootObject,
+  enableEvented = true
+}: {
+  rootObject: FabricObject
+  enableEvented?: boolean
+}): void => {
+  const pending: IdentityMaterializationEntry[] = [{
+    object: rootObject,
+    enableEvented
+  }]
+
+  for (let index = 0; index < pending.length; index += 1) {
+    const currentEntry = pending[index]
+    const updates: {
+      id: string
+      evented?: boolean
+    } = {
+      id: `${currentEntry.object.type}-${nanoid()}`
+    }
+
+    if (currentEntry.enableEvented) {
+      updates.evented = true
+    }
+
+    currentEntry.object.set(updates)
+
+    let childObjects: FabricObject[] | null = null
+    let shouldEnableChildEvented = false
+
+    if (currentEntry.object instanceof ActiveSelection) {
+      childObjects = currentEntry.object.getObjects()
+      shouldEnableChildEvented = true
+    } else if (currentEntry.object instanceof Group) {
+      childObjects = currentEntry.object.getObjects()
+    }
+
+    if (!childObjects) continue
+
+    for (let childIndex = 0; childIndex < childObjects.length; childIndex += 1) {
+      pending.push({
+        object: childObjects[childIndex],
+        enableEvented: shouldEnableChildEvented
+      })
+    }
+  }
+}


### PR DESCRIPTION
Порядок воспроизведения:

1. Добавить шейп с текстом "TEST" (Скрин 1)

<img width="350" height="331" alt="image" src="https://github.com/user-attachments/assets/2b032660-784d-46ac-82d5-e5bf63c2f694" />

2. Сделать его сериализацию через TemplateManager, а затем применить шаблон
3. Вызвать скрипт для логирования id каждого объекта на монтажной области включая вложенные:

```js
const editor = window.editor ?? window.myEditor

editor.canvasManager.getObjects().forEach((obj) => {
    console.log(obj.id)
    
    if (!obj._objects) {
        return
    }

    obj._objects.forEach((objInside) => console.log(objInside.id))
})
```

Ожидаемое поведение.

У каждого shape-group будут уникальные идентификаторы, а также уникальные идентификаторы во вложенных объектах.

Фактический результат:

У объекта добавленного из темплейта вложенные объекты имеют те же идентификаторы, что и у объекта из пункта 1 (скрин 2)

<img width="1184" height="814" alt="image" src="https://github.com/user-attachments/assets/76394058-f850-4e9d-8e0a-e907088f7757" />

---

FIXED. 