### PR TITLE
ToolbarManager. Фиксим баг когда не срабатывает удаление массового выделения с шейпами при нажатии на кнопку корзины в тулбаре

### DIFF
--- a/e2e/tests/shape-manager/shape-toolbar.spec.ts
+++ b/e2e/tests/shape-manager/shape-toolbar.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+
+test.describe('Удаление шейпов через тулбар', () => {
+  test('кнопка "Удалить" под массовым выделением удаляет оба шейпа', async({
+    editorModel,
+    shapes,
+    toolbar
+  }) => {
+    await test.step('Добавить два шейпа на canvas', async() => {
+      const firstShape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          id: 'toolbar-delete-selection-first',
+          left: 120,
+          top: 120
+        }
+      })
+      const secondShape = await shapes.add({
+        presetKey: 'circle',
+        options: {
+          id: 'toolbar-delete-selection-second',
+          left: 280,
+          top: 240
+        }
+      })
+
+      expect(firstShape).not.toBeNull()
+      expect(secondShape).not.toBeNull()
+    })
+
+    await test.step('Создать массовое выделение из двух шейпов', async() => {
+      await editorModel.selectAllObjects()
+      await editorModel.checkObjectCount({ count: 2 })
+      await toolbar.waitUntilVisible()
+
+      const activeObject = await editorModel.getActiveObject()
+
+      expect(activeObject?.type).toBe('activeselection')
+      expect(activeObject?.id ?? null).toBeNull()
+    })
+
+    await test.step('Нажать кнопку "Удалить" в тулбаре', async() => {
+      await toolbar.clickAction({
+        name: 'Удалить'
+      })
+    })
+
+    await test.step('Проверить что оба шейпа удалены и выделение снято', async() => {
+      const activeObject = await editorModel.getActiveObject()
+
+      expect(activeObject).toBeNull()
+      await editorModel.checkObjectCount({ count: 0 })
+    })
+  })
+
+  test('в режиме редактирования текста внутри фигуры кнопка "Удалить" удаляет всю фигуру', async({
+    editorModel,
+    shapes,
+    toolbar
+  }) => {
+    const shape = await test.step('Добавить фигуру с текстом', async() => {
+      return shapes.add({
+        presetKey: 'square',
+        options: {
+          id: 'toolbar-delete-editing-shape',
+          text: 'TEST'
+        }
+      })
+    })
+
+    expect(shape).not.toBeNull()
+    expect(typeof shape?.id).toBe('string')
+
+    const shapeId = shape!.id as string
+
+    await test.step('Открыть редактирование текста через реальный двойной клик', async() => {
+      const textNode = await shapes.openTextEditingFromCanvas({ id: shapeId })
+
+      expect(textNode?.isEditing).toBe(true)
+      expect(textNode?.text).toBe('TEST')
+      await toolbar.waitUntilVisible()
+    })
+
+    await test.step('Нажать кнопку "Удалить" в тулбаре', async() => {
+      await toolbar.clickAction({
+        name: 'Удалить'
+      })
+    })
+
+    await test.step('Проверить что фигура удалена целиком', async() => {
+      const activeObject = await editorModel.getActiveObject()
+      const deletedShape = await shapes.getObject({ id: shapeId })
+
+      expect(activeObject).toBeNull()
+      expect(deletedShape).toBeNull()
+      await editorModel.checkObjectCount({ count: 0 })
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.13",
+      "version": "0.8.14",
       "license": "MIT",
       "dependencies": {
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/ui/toolbar-manager/default-config.spec.ts
+++ b/specs/src/editor/ui/toolbar-manager/default-config.spec.ts
@@ -1,0 +1,54 @@
+import defaultConfig from '../../../../../src/editor/ui/toolbar-manager/default-config'
+import {
+  createManagerTestMocks,
+  createMockActiveSelection,
+  createMockFabricObject
+} from '../../../../test-utils/editor-helpers'
+
+describe('ToolbarManager default delete handler', () => {
+  it('при массовом выделении передаёт в удаление все объекты из activeSelection', () => {
+    const { mockEditor } = createManagerTestMocks()
+    const deleteSelectedObjectsMock = mockEditor.deletionManager.deleteSelectedObjects as jest.Mock
+    const firstObject = createMockFabricObject({
+      id: 'toolbar-delete-first'
+    })
+    const secondObject = createMockFabricObject({
+      id: 'toolbar-delete-second'
+    })
+    const selection = createMockActiveSelection([firstObject, secondObject])
+
+    defaultConfig.handlers.delete(mockEditor, selection)
+
+    expect(selection.getObjects()).toEqual([firstObject, secondObject])
+    expect(deleteSelectedObjectsMock).toHaveBeenCalledTimes(1)
+    expect(deleteSelectedObjectsMock).toHaveBeenCalledWith({
+      objects: [firstObject, secondObject]
+    })
+  })
+
+  it('без target использует текущее выделение canvas через DeletionManager', () => {
+    const { mockEditor } = createManagerTestMocks()
+    const deleteSelectedObjectsMock = mockEditor.deletionManager.deleteSelectedObjects as jest.Mock
+
+    defaultConfig.handlers.delete(mockEditor)
+
+    expect(deleteSelectedObjectsMock).toHaveBeenCalledTimes(1)
+    expect(deleteSelectedObjectsMock).toHaveBeenCalledWith()
+  })
+
+  it('для обычного объекта передаёт в удаление только этот объект', () => {
+    const { mockEditor } = createManagerTestMocks()
+    const deleteSelectedObjectsMock = mockEditor.deletionManager.deleteSelectedObjects as jest.Mock
+    const targetObject = createMockFabricObject({
+      id: 'toolbar-delete-target'
+    })
+
+    defaultConfig.handlers.delete(mockEditor, targetObject)
+
+    expect(targetObject.id).toBe('toolbar-delete-target')
+    expect(deleteSelectedObjectsMock).toHaveBeenCalledTimes(1)
+    expect(deleteSelectedObjectsMock).toHaveBeenCalledWith({
+      objects: [targetObject]
+    })
+  })
+})

--- a/src/editor/ui/toolbar-manager/default-config.ts
+++ b/src/editor/ui/toolbar-manager/default-config.ts
@@ -1,4 +1,4 @@
-import { FabricObject } from 'fabric'
+import { ActiveSelection, FabricObject } from 'fabric'
 import { ImageEditor } from '../..'
 import {
   copyPasteIcon,
@@ -101,8 +101,20 @@ export default {
     },
 
     delete: (editor: ImageEditor, target?: FabricObject | null) => {
+      if (target instanceof ActiveSelection) {
+        editor.deletionManager.deleteSelectedObjects({
+          objects: target.getObjects()
+        })
+        return
+      }
+
+      if (!target) {
+        editor.deletionManager.deleteSelectedObjects()
+        return
+      }
+
       editor.deletionManager.deleteSelectedObjects({
-        objects: target ? [target] : undefined
+        objects: [target]
       })
     },
 


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить 2 любых шейпа и выделить их (скрин 1)

<img width="377" height="376" alt="image" src="https://github.com/user-attachments/assets/0c5d23ca-71a5-451f-a345-a20adb1a1ce1" />


2. Нажать на кнопку корзины в тулбаре под массовым выделением

Ожидаемое поведение.

Оба объекта удалены.

Фактический результат.

Выделение сбросилось, объекты не были удалены. При этом, если нажать на кнопку Delete или нажать на кнопку удалить в панели справа, где вызывается DeletionManager, то всё отработает. Проблема именно с кнопкой в тулбаре.

---

FIXED.