### PR TITLE
GrouppingManager. При разгруппировке шейпов материализуем их, чтобы они не схлопывались после изменений сделанных в состоянии группы

### DIFF
--- a/e2e/fixtures/data/grouping-manager.data.ts
+++ b/e2e/fixtures/data/grouping-manager.data.ts
@@ -1,0 +1,104 @@
+import type { ShapeAddAtBoundsParams } from '../../types'
+
+type GroupingResizeShapeSeed = {
+  id: string
+  leftOffset: number
+  topOffset: number
+  width: number
+  height: number
+  text: string
+}
+
+type GroupingHorizontalEditingScenario = {
+  title: string
+  side: 'left' | 'right'
+  scaleX: number
+  targetShapeId: string
+}
+
+type GroupingVerticalMoveScenario = {
+  title: string
+  side: 'top' | 'bottom'
+  scaleY: number
+  targetShapeId: string
+  moveLeftOffset: number
+  moveTopOffset: number
+}
+
+export const GROUPING_LEFT_SHAPE_ID = 'group-resize-left-shape'
+export const GROUPING_RIGHT_SHAPE_ID = 'group-resize-right-shape'
+export const GROUPING_EDITED_TEXT = 'TEXT'
+export const GROUPING_SIZE_TOLERANCE = 1.5
+export const GROUPING_RESIZE_DELTA = 10
+
+export const GROUPING_SHAPE_SEEDS: GroupingResizeShapeSeed[] = [
+  {
+    id: GROUPING_LEFT_SHAPE_ID,
+    leftOffset: 80,
+    topOffset: 120,
+    width: 120,
+    height: 120,
+    text: 'TEST'
+  },
+  {
+    id: GROUPING_RIGHT_SHAPE_ID,
+    leftOffset: 260,
+    topOffset: 120,
+    width: 120,
+    height: 120,
+    text: 'TEST'
+  }
+]
+
+export const GROUPING_HORIZONTAL_UNGROUP_EDITING_SCENARIOS: GroupingHorizontalEditingScenario[] = [
+  {
+    title: 'после сужения группы справа и ungroup шейп не теряет ширину при редактировании',
+    side: 'right',
+    scaleX: 0.72,
+    targetShapeId: GROUPING_RIGHT_SHAPE_ID
+  },
+  {
+    title: 'после сужения группы слева и ungroup шейп не теряет ширину при редактировании',
+    side: 'left',
+    scaleX: 0.72,
+    targetShapeId: GROUPING_LEFT_SHAPE_ID
+  }
+]
+
+export const GROUPING_VERTICAL_UNGROUP_MOVE_SCENARIOS: GroupingVerticalMoveScenario[] = [
+  {
+    title: 'после сужения группы сверху и ungroup шейп не теряет высоту при перетаскивании',
+    side: 'top',
+    scaleY: 0.74,
+    targetShapeId: GROUPING_LEFT_SHAPE_ID,
+    moveLeftOffset: 24,
+    moveTopOffset: 42
+  },
+  {
+    title: 'после сужения группы снизу и ungroup шейп не теряет высоту при перетаскивании',
+    side: 'bottom',
+    scaleY: 0.74,
+    targetShapeId: GROUPING_RIGHT_SHAPE_ID,
+    moveLeftOffset: -24,
+    moveTopOffset: -42
+  }
+]
+
+export const resolveGroupingShapeOptions = ({
+  montageLeft,
+  montageTop,
+  shape
+}: {
+  montageLeft: number
+  montageTop: number
+  shape: GroupingResizeShapeSeed
+}): ShapeAddAtBoundsParams['options'] => {
+  return {
+    id: shape.id,
+    left: montageLeft + shape.leftOffset,
+    top: montageTop + shape.topOffset,
+    width: shape.width,
+    height: shape.height,
+    text: shape.text
+  }
+}

--- a/e2e/fixtures/editor.fixture.ts
+++ b/e2e/fixtures/editor.fixture.ts
@@ -14,6 +14,7 @@ import { InteractionBlockerModel } from '../models/interaction-blocker.model'
 import { ImageModel } from '../models/image.model'
 import { ToolbarModel } from '../models/toolbar.model'
 import { SelectionModel } from '../models/selection.model'
+import { GroupingModel } from '../models/grouping.model'
 import { bypassCertificateWarning } from '../helpers/certificate.helper'
 import { injectEditorBrowserHelpers } from '../helpers/editor-browser-helpers.helper'
 import { resolveHeadedBrowserHoldMs } from '../helpers/headed-browser-hold.helper'
@@ -36,6 +37,7 @@ interface EditorFixtures {
   images: ImageModel
   toolbar: ToolbarModel
   selection: SelectionModel
+  grouping: GroupingModel
 }
 
 interface EditorInternalFixtures {
@@ -155,6 +157,10 @@ export const test = base.extend<EditorFixtures & EditorInternalFixtures>({
 
   selection: async({ editorModel }, use) => {
     await use(editorModel.selection)
+  },
+
+  grouping: async({ editorModel }, use) => {
+    await use(editorModel.grouping)
   }
 })
 

--- a/e2e/models/editor.model.ts
+++ b/e2e/models/editor.model.ts
@@ -23,6 +23,7 @@ import { InteractionBlockerModel } from './interaction-blocker.model'
 import { ImageModel } from './image.model'
 import { ToolbarModel } from './toolbar.model'
 import { SelectionModel } from './selection.model'
+import { GroupingModel } from './grouping.model'
 
 export class EditorModel {
   readonly shapes: ShapeModel
@@ -49,6 +50,8 @@ export class EditorModel {
 
   readonly selection: SelectionModel
 
+  readonly grouping: GroupingModel
+
   constructor(readonly page: Page) {
     this.shapes = new ShapeModel(page)
     this.canvas = new CanvasModel(page)
@@ -62,6 +65,7 @@ export class EditorModel {
     this.images = new ImageModel(page)
     this.toolbar = new ToolbarModel(page)
     this.selection = new SelectionModel(page)
+    this.grouping = new GroupingModel(page)
   }
 
   /** Ожидает финальное состояние редактора после завершения init(), а не раннее появление window.editor. */

--- a/e2e/models/grouping.model.ts
+++ b/e2e/models/grouping.model.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { type Page, expect } from '@playwright/test'
+import type { EditorObjectInfo } from '../types'
+import { waitForCanvasRender } from '../helpers/canvas-render.helper'
+
+type UngroupedObjectsInfo = {
+  activeObjectType?: string
+  objectIds: string[]
+}
+
+export class GroupingModel {
+  private readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /** Группирует текущее выделение через публичный API GroupingManager. */
+  async groupActiveSelection(): Promise<EditorObjectInfo> {
+    const group = await this.page.evaluate(() => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+
+      const result = editor.groupingManager.group()
+      if (!result) return null
+
+      return helpers.serializeEditorObject(result.group)
+    })
+
+    expect(group, 'должна создаться группа из текущего выделения').not.toBeNull()
+    expect(group?.type, 'активный объект после группировки должен быть group').toBe('group')
+
+    await waitForCanvasRender({ page: this.page })
+
+    return group as EditorObjectInfo
+  }
+
+  /** Разгруппировывает текущую группу через публичный API GroupingManager. */
+  async ungroupActiveGroup(): Promise<UngroupedObjectsInfo> {
+    const ungrouped = await this.page.evaluate(() => {
+      const { editor } = window as any
+
+      const result = editor.groupingManager.ungroup()
+      if (!result) return null
+
+      return {
+        activeObjectType: editor.canvas.getActiveObject()?.type,
+        objectIds: result.ungroupedObjects
+          .map((object: { id?: unknown }) => object.id)
+          .filter((id: unknown) => typeof id === 'string')
+      }
+    })
+
+    expect(ungrouped, 'текущая группа должна разгруппироваться').not.toBeNull()
+    expect(ungrouped?.objectIds.length, 'после ungroup должны вернуться дочерние объекты').toBeGreaterThan(0)
+
+    await waitForCanvasRender({ page: this.page })
+
+    return ungrouped as UngroupedObjectsInfo
+  }
+}

--- a/e2e/models/selection.model.ts
+++ b/e2e/models/selection.model.ts
@@ -77,6 +77,19 @@ export class SelectionModel {
     })
   }
 
+  /** Масштабирует текущее общее выделение слева и возвращает live-состояние. */
+  async scaleHorizontallyFromLeft(
+    params: {
+      scaleX: number
+    }
+  ): Promise<SnappingObjectSnapshot> {
+    return this._scaleFromControl({
+      startControl: 'ml',
+      oppositeControl: 'mr',
+      scaleX: params.scaleX
+    })
+  }
+
   /** Масштабирует текущее общее выделение снизу и возвращает live-состояние. */
   async scaleVerticallyFromBottom(
     params: {

--- a/e2e/models/snapping.model.ts
+++ b/e2e/models/snapping.model.ts
@@ -178,6 +178,15 @@ export class SnappingModel {
     return this.getObjectSnapshot(params)
   }
 
+  /** Выполняет полный drag объекта до нужной позиции bounding box и завершает его через mouseup. */
+  async moveObjectBoundsTo(params: SnappingDragBoundsParams): Promise<SnappingObjectSnapshot> {
+    await this.startObjectDrag(params)
+    await this.dragObjectBoundsTo(params)
+    await this.finishPointerInteraction()
+
+    return this.getObjectSnapshot(params)
+  }
+
   /** Перемещает объект в live drag-сессии так, чтобы центр его bounding box пришёл в нужную позицию. */
   async dragObjectCenterTo(params: SnappingDragCenterParams): Promise<SnappingObjectSnapshot> {
     const dragInfo = await this._getDragTransformInfo(params)

--- a/e2e/tests/grouping-manager/index.spec.ts
+++ b/e2e/tests/grouping-manager/index.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import {
+  GROUPING_EDITED_TEXT,
+  GROUPING_HORIZONTAL_UNGROUP_EDITING_SCENARIOS,
+  GROUPING_RESIZE_DELTA,
+  GROUPING_SHAPE_SEEDS,
+  GROUPING_SIZE_TOLERANCE,
+  GROUPING_VERTICAL_UNGROUP_MOVE_SCENARIOS,
+  resolveGroupingShapeOptions
+} from '../../fixtures/data/grouping-manager.data'
+
+test.describe('Группировка шейпов', () => {
+  test.beforeEach(async({ editorModel, shapes }) => {
+    const montageBounds = await editorModel.getMontageAreaBounds()
+
+    for (const shape of GROUPING_SHAPE_SEEDS) {
+      const createdShape = await shapes.addAtBounds({
+        presetKey: 'square',
+        options: resolveGroupingShapeOptions({
+          montageLeft: montageBounds.left,
+          montageTop: montageBounds.top,
+          shape
+        })
+      })
+
+      shapes.checkCreation({
+        shape: createdShape,
+        presetKey: 'square'
+      })
+    }
+  })
+
+  for (const scenario of GROUPING_HORIZONTAL_UNGROUP_EDITING_SCENARIOS) {
+    test(scenario.title, async({
+      editorModel,
+      grouping,
+      selection,
+      shapes
+    }) => {
+      const initialShape = await shapes.getScaleSnapshot({ id: scenario.targetShapeId })
+
+      await test.step('Сгруппировать оба шейпа и сузить группу по горизонтали', async() => {
+        await editorModel.selectAllObjects()
+        await grouping.groupActiveSelection()
+
+        if (scenario.side === 'right') {
+          await selection.scaleHorizontallyFromRight({
+            scaleX: scenario.scaleX
+          })
+        } else {
+          await selection.scaleHorizontallyFromLeft({
+            scaleX: scenario.scaleX
+          })
+        }
+
+        await selection.finishScale()
+      })
+
+      await test.step('Разгруппировать изменённую группу', async() => {
+        const ungrouped = await grouping.ungroupActiveGroup()
+
+        expect(ungrouped.activeObjectType).toBe('activeselection')
+        expect(ungrouped.objectIds).toHaveLength(GROUPING_SHAPE_SEEDS.length)
+        expect(ungrouped.objectIds).toContain(scenario.targetShapeId)
+      })
+
+      const resizedShape = await shapes.getScaleSnapshot({ id: scenario.targetShapeId })
+
+      await test.step('Открыть редактирование текста внутри нужного шейпа', async() => {
+        await shapes.select({ id: scenario.targetShapeId })
+        await shapes.enterTextEditing({ id: scenario.targetShapeId })
+        await shapes.updateEditingText({
+          id: scenario.targetShapeId,
+          text: GROUPING_EDITED_TEXT
+        })
+      })
+
+      const editingShape = await shapes.getScaleSnapshot({ id: scenario.targetShapeId })
+
+      await test.step('Проверить что после редактирования шейп не возвращается к исходной ширине', () => {
+        expect(initialShape.groupBoundsWidth - resizedShape.groupBoundsWidth)
+          .toBeGreaterThan(GROUPING_RESIZE_DELTA)
+        expect(Math.abs(editingShape.groupBoundsWidth - resizedShape.groupBoundsWidth))
+          .toBeLessThanOrEqual(GROUPING_SIZE_TOLERANCE)
+        expect(Math.abs(editingShape.groupBoundsHeight - resizedShape.groupBoundsHeight))
+          .toBeLessThanOrEqual(GROUPING_SIZE_TOLERANCE)
+
+        shapes.checkNodeInsideGroup({
+          snapshot: editingShape,
+          kind: 'shape'
+        })
+        shapes.checkNodeInsideGroup({
+          snapshot: editingShape,
+          kind: 'text'
+        })
+      })
+    })
+  }
+
+  for (const scenario of GROUPING_VERTICAL_UNGROUP_MOVE_SCENARIOS) {
+    test(scenario.title, async({
+      editorModel,
+      grouping,
+      selection,
+      shapes,
+      snapping
+    }) => {
+      const initialShape = await shapes.getScaleSnapshot({ id: scenario.targetShapeId })
+
+      await test.step('Сгруппировать оба шейпа и сузить группу по вертикали', async() => {
+        await editorModel.selectAllObjects()
+        await grouping.groupActiveSelection()
+
+        if (scenario.side === 'top') {
+          await selection.scaleVerticallyFromTop({
+            scaleY: scenario.scaleY
+          })
+        } else {
+          await selection.scaleVerticallyFromBottom({
+            scaleY: scenario.scaleY
+          })
+        }
+
+        await selection.finishScale()
+      })
+
+      await test.step('Разгруппировать изменённую группу', async() => {
+        const ungrouped = await grouping.ungroupActiveGroup()
+
+        expect(ungrouped.activeObjectType).toBe('activeselection')
+        expect(ungrouped.objectIds).toHaveLength(GROUPING_SHAPE_SEEDS.length)
+        expect(ungrouped.objectIds).toContain(scenario.targetShapeId)
+      })
+
+      const resizedShape = await shapes.getScaleSnapshot({ id: scenario.targetShapeId })
+      const resizedObject = await snapping.getObjectSnapshot({ id: scenario.targetShapeId })
+
+      const movedObject = await test.step('Передвинуть нужный шейп после ungroup', async() => {
+        await shapes.select({ id: scenario.targetShapeId })
+
+        return snapping.moveObjectBoundsTo({
+          id: scenario.targetShapeId,
+          left: resizedObject.boundsLeft + scenario.moveLeftOffset,
+          top: resizedObject.boundsTop + scenario.moveTopOffset
+        })
+      })
+
+      const movedShape = await shapes.getScaleSnapshot({ id: scenario.targetShapeId })
+
+      await test.step('Проверить что после перемещения шейп не возвращается к исходной высоте', () => {
+        expect(initialShape.groupBoundsHeight - resizedShape.groupBoundsHeight)
+          .toBeGreaterThan(GROUPING_RESIZE_DELTA)
+        expect(Math.abs(movedShape.groupBoundsWidth - resizedShape.groupBoundsWidth))
+          .toBeLessThanOrEqual(GROUPING_SIZE_TOLERANCE)
+        expect(Math.abs(movedShape.groupBoundsHeight - resizedShape.groupBoundsHeight))
+          .toBeLessThanOrEqual(GROUPING_SIZE_TOLERANCE)
+        expect(Math.abs(movedObject.boundsLeft - resizedObject.boundsLeft))
+          .toBeGreaterThan(1)
+        expect(Math.abs(movedObject.boundsTop - resizedObject.boundsTop))
+          .toBeGreaterThan(1)
+
+        shapes.checkNodeInsideGroup({
+          snapshot: movedShape,
+          kind: 'shape'
+        })
+        shapes.checkNodeInsideGroup({
+          snapshot: movedShape,
+          kind: 'text'
+        })
+      })
+    })
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/deletion-manager/index.spec.ts
+++ b/specs/src/editor/deletion-manager/index.spec.ts
@@ -1,5 +1,9 @@
 import DeletionManager from '../../../../src/editor/deletion-manager'
-import { createManagerTestMocks } from '../../../test-utils/editor-helpers'
+import {
+  createManagerTestMocks,
+  createMockFabricObject,
+  createMockGroup
+} from '../../../test-utils/editor-helpers'
 
 describe('DeletionManager', () => {
   let deletionManager: DeletionManager
@@ -11,6 +15,9 @@ describe('DeletionManager', () => {
 
     mockCanvas = mocks.mockCanvas
     mockEditor = mocks.mockEditor
+    mockEditor.groupingManager = {
+      ungroup: jest.fn()
+    }
     deletionManager = new DeletionManager({ editor: mockEditor })
   })
 
@@ -54,6 +61,39 @@ describe('DeletionManager', () => {
     expect(result).toEqual({
       objects: [objectToDelete],
       withoutSave: true
+    })
+  })
+
+  it('при удалении группы разгруппировывает её через groupingManager и удаляет дочерние объекты', () => {
+    const childRect = createMockFabricObject({
+      type: 'rect',
+      id: 'child-rect'
+    })
+    const childCircle = createMockFabricObject({
+      type: 'circle',
+      id: 'child-circle'
+    })
+    const groupToDelete = createMockGroup([], {
+      id: 'group-1'
+    })
+
+    mockCanvas.getActiveObjects.mockReturnValue([groupToDelete])
+    mockEditor.groupingManager.ungroup.mockReturnValue({
+      ungroupedObjects: [childRect, childCircle]
+    })
+
+    const result = deletionManager.deleteSelectedObjects()
+
+    expect(mockEditor.groupingManager.ungroup).toHaveBeenCalledWith({
+      target: groupToDelete,
+      withoutSave: true
+    })
+    expect(mockCanvas.remove).toHaveBeenCalledWith(childRect)
+    expect(mockCanvas.remove).toHaveBeenCalledWith(childCircle)
+    expect(mockEditor.historyManager.saveState).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      objects: [groupToDelete, childRect, childCircle],
+      withoutSave: false
     })
   })
 })

--- a/specs/src/editor/grouping-manager/index.spec.ts
+++ b/specs/src/editor/grouping-manager/index.spec.ts
@@ -1,4 +1,3 @@
-import { Group, ActiveSelection } from 'fabric'
 import {
   createManagerTestMocks,
   createMockFabricObject,
@@ -276,6 +275,91 @@ describe('GroupingManager', () => {
   })
 
   describe('ungroup', () => {
+    it('перед добавлением на canvas запекает scale standalone-textbox через textManager', () => {
+      const commitStandaloneTextScaleMock = mockEditor.textManager.commitStandaloneTextScale as jest.Mock
+      const commitRehydratedShapeLayoutMock = mockEditor.shapeManager.commitRehydratedShapeLayout as jest.Mock
+      const textObject = createMockFabricObject({
+        type: 'textbox',
+        id: 'text-1',
+        scaleX: 0.8,
+        scaleY: 1
+      })
+      const mockGroup = createMockGroup([textObject], { id: 'group-1' })
+
+      commitStandaloneTextScaleMock.mockReturnValue(true)
+      commitRehydratedShapeLayoutMock.mockReturnValue(false)
+
+      const result = groupingManager.ungroup({ target: mockGroup })
+
+      expect(result?.ungroupedObjects).toEqual([textObject])
+      expect(commitStandaloneTextScaleMock).toHaveBeenCalledWith({
+        target: textObject
+      })
+      expect(commitRehydratedShapeLayoutMock).toHaveBeenCalledWith({
+        target: textObject
+      })
+      expect(commitStandaloneTextScaleMock.mock.invocationCallOrder[0]).toBeLessThan(
+        mockCanvas.add.mock.invocationCallOrder[0]
+      )
+      expect(textObject.setCoords).not.toHaveBeenCalled()
+    })
+
+    it('перед добавлением на canvas передаёт scale shape-группы в её materialization-контракт', () => {
+      const commitStandaloneTextScaleMock = mockEditor.textManager.commitStandaloneTextScale as jest.Mock
+      const commitRehydratedShapeLayoutMock = mockEditor.shapeManager.commitRehydratedShapeLayout as jest.Mock
+      const shapeObject = createMockGroup([], {
+        id: 'shape-child',
+        shapeComposite: true,
+        scaleX: 1.6,
+        scaleY: 1.6
+      })
+      const parentGroup = createMockGroup([shapeObject], { id: 'parent-group' })
+
+      commitStandaloneTextScaleMock.mockReturnValue(false)
+      commitRehydratedShapeLayoutMock.mockReturnValue(true)
+
+      const result = groupingManager.ungroup({ target: parentGroup })
+
+      expect(result?.ungroupedObjects).toEqual([shapeObject])
+      expect(commitStandaloneTextScaleMock).toHaveBeenCalledWith({
+        target: shapeObject
+      })
+      expect(commitRehydratedShapeLayoutMock).toHaveBeenCalledWith({
+        target: shapeObject,
+        textScale: 1.6
+      })
+      expect(commitRehydratedShapeLayoutMock.mock.invocationCallOrder[0]).toBeLessThan(
+        mockCanvas.add.mock.invocationCallOrder[0]
+      )
+    })
+
+    it('если объекту нечего материализовать, перед добавлением обновляет только его координаты', () => {
+      const commitStandaloneTextScaleMock = mockEditor.textManager.commitStandaloneTextScale as jest.Mock
+      const commitRehydratedShapeLayoutMock = mockEditor.shapeManager.commitRehydratedShapeLayout as jest.Mock
+      const genericObject = createMockFabricObject({
+        type: 'rect',
+        id: 'rect-1'
+      })
+      const mockGroup = createMockGroup([genericObject], { id: 'group-1' })
+
+      commitStandaloneTextScaleMock.mockReturnValue(false)
+      commitRehydratedShapeLayoutMock.mockReturnValue(false)
+
+      const result = groupingManager.ungroup({ target: mockGroup })
+
+      expect(result?.ungroupedObjects).toEqual([genericObject])
+      expect(commitStandaloneTextScaleMock).toHaveBeenCalledWith({
+        target: genericObject
+      })
+      expect(commitRehydratedShapeLayoutMock).toHaveBeenCalledWith({
+        target: genericObject
+      })
+      expect(genericObject.setCoords).toHaveBeenCalledTimes(1)
+      expect(genericObject.setCoords.mock.invocationCallOrder[0]).toBeLessThan(
+        mockCanvas.add.mock.invocationCallOrder[0]
+      )
+    })
+
     it('должен разгруппировать одну группу', () => {
       const mockRect = createMockFabricObject({ type: 'rect', id: 'rect-1' })
       const mockCircle = createMockFabricObject({ type: 'circle', id: 'circle-1' })

--- a/src/editor/deletion-manager/index.ts
+++ b/src/editor/deletion-manager/index.ts
@@ -1,4 +1,4 @@
-import { FabricObject } from 'fabric'
+import { FabricObject, Group } from 'fabric'
 import { ImageEditor } from '../index'
 import { ObjectsDeletedPayload } from '../types/events'
 
@@ -23,8 +23,8 @@ export default class DeletionManager {
    * @param obj - объект для проверки
    * @returns true, если объект является группой и не является SVG
    */
-  private static _isUngroupableGroup(obj: FabricObject): boolean {
-    return obj.type === 'group' && obj.format !== 'svg'
+  private static _isUngroupableGroup(obj: FabricObject): obj is Group {
+    return obj instanceof Group && obj.format !== 'svg'
   }
 
   /**
@@ -32,12 +32,12 @@ export default class DeletionManager {
    * @param group - группа для обработки
    * @returns массив всех удаленных объектов (включая саму группу)
    */
-  private _handleGroupDeletion(group: FabricObject): FabricObject[] {
+  private _handleGroupDeletion(group: Group): FabricObject[] {
     const { groupingManager } = this.editor
 
     // Разгруппировываем и получаем объекты
     const { ungroupedObjects = [] } = groupingManager.ungroup({
-      object: group,
+      target: group,
       withoutSave: true
     }) ?? {}
 

--- a/src/editor/grouping-manager/index.ts
+++ b/src/editor/grouping-manager/index.ts
@@ -90,6 +90,35 @@ export default class GroupingManager {
   }
 
   /**
+   * Запекает transient scale объекта после выхода из Fabric-группы в его доменную модель.
+   */
+  private _materializeUngroupedObject({ object }: { object: FabricObject }): void {
+    const {
+      shapeManager,
+      textManager
+    } = this.editor
+    const shapeLayoutParams: {
+      target: FabricObject
+      textScale?: number
+    } = {
+      target: object
+    }
+
+    if (object.shapeComposite === true) {
+      shapeLayoutParams.textScale = Math.abs(object.scaleX ?? 1) || 1
+    }
+
+    const standaloneTextScaleCommitted = textManager.commitStandaloneTextScale({
+      target: object
+    })
+    const shapeLayoutCommitted = shapeManager.commitRehydratedShapeLayout(shapeLayoutParams)
+
+    if (!standaloneTextScaleCommitted && !shapeLayoutCommitted) {
+      object.setCoords()
+    }
+  }
+
+  /**
  * Группировка объектов
  * @param options
  * @param options.target - объект ActiveSelection или массив объектов для группировки
@@ -167,6 +196,9 @@ export default class GroupingManager {
         const ungroupedObjects = group.removeAll()
         canvas.remove(group)
         ungroupedObjects.forEach((groupedObj) => {
+          this._materializeUngroupedObject({
+            object: groupedObj
+          })
           canvas.add(groupedObj)
           allUngroupedObjects.push(groupedObj)
         })


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить 2 шейпа с текстом "TEST" (Скрин 1)

<img width="496" height="512" alt="image" src="https://github.com/user-attachments/assets/1d1b86f3-1c53-4a10-8003-f6c00e667bd7" />

2. Сгруппировать оба шейпа и выполнить ресайз (скрин 2)

<img width="594" height="530" alt="image" src="https://github.com/user-attachments/assets/f65ce967-9191-44f5-9124-1f7b521d9163" />

3. Выделить группу и разгруппировать её
4. Начать редактировать один из шейпов или передвинуть его 

Ожидаемое поведение.

При редактировании шейпа объект останется тех же размеров которые получил в пункте 2

Фактический результат.

При любом взаимодействии с шейпом он схлопывается до тех размеров которые были в пункте 1 (скрин 3)

<img width="608" height="564" alt="image" src="https://github.com/user-attachments/assets/cf7ab69f-7f1a-4965-9b7a-060d1cbcd63e" />

Такая же проблема была когда мы вписывали объект шейпа или массовое выделение с шейпом с помощью `editor.transformManager.fitObject({ fitAsOneObject: true, type: 'contain' })`, которую мы исправили. В том случае после применения fitObject объект не материализовался и при любом взаимодействии свойства объекта сбрасывались до исходных.

---

FIXED.
