### PR TITLE
TemplateManager. При восстановлении изображения пересчитываем его размеры таким образом, чтобы оно распологалось по центру относительно исходного изображения темплейта

### DIFF
--- a/e2e/fixtures/data/template-manager.data.ts
+++ b/e2e/fixtures/data/template-manager.data.ts
@@ -217,6 +217,118 @@ export const TEMPLATE_SHAPE_TEXT_LARGE_SCALE = Math.min(
 /** Допуск для проверок масштаба текста внутри фигуры после применения шаблона. */
 export const TEMPLATE_SHAPE_TEXT_SCALE_TOLERANCE = 1.5
 
+const TEMPLATE_REPLACED_IMAGE_BASE_OBJECT = {
+  cropX: 0,
+  cropY: 0,
+  id: 'image-template-replaced-source',
+  customData: {
+    handle: 'main-image'
+  },
+  format: 'png',
+  width: 714,
+  height: 714,
+  originX: 'left',
+  originY: 'top',
+  evented: true,
+  selectable: true,
+  lockMovementX: false,
+  lockMovementY: false,
+  lockRotation: false,
+  lockScalingX: false,
+  lockScalingY: false,
+  lockSkewingX: false,
+  lockSkewingY: false,
+  type: 'Image',
+  version: '7.2.0',
+  left: 0.05925925925925926,
+  top: 0.15185185185185185,
+  fill: 'rgb(0,0,0)',
+  stroke: null,
+  strokeWidth: 0,
+  strokeDashArray: null,
+  strokeLineCap: 'butt',
+  strokeDashOffset: 0,
+  strokeLineJoin: 'miter',
+  strokeUniform: false,
+  strokeMiterLimit: 4,
+  scaleX: 1,
+  scaleY: 1,
+  angle: 0,
+  flipX: false,
+  flipY: false,
+  opacity: 1,
+  shadow: null,
+  visible: true,
+  backgroundColor: '',
+  fillRule: 'nonzero',
+  paintFirst: 'fill',
+  globalCompositeOperation: 'source-over',
+  skewX: 0,
+  skewY: 0,
+  src: 'https://static.insales-cdn.com/files/1/521/108380681/original/headphones.png',
+  crossOrigin: 'anonymous',
+  filters: [],
+  _templateAnchorX: 'center',
+  _templateAnchorY: 'center'
+} as const
+
+const TEMPLATE_REPLACED_IMAGE_META = {
+  baseWidth: 810,
+  baseHeight: 1080,
+  positionsNormalized: true
+} as const
+
+/** Ожидаемый центр исходной квадратной области изображения в координатах montage area. */
+export const TEMPLATE_REPLACED_IMAGE_CENTER = {
+  x: 0.5,
+  y: 0.4824074074074074
+} as const
+
+/** Размеры монтажной области для проверки заменённой картинки на базовом и изменённом масштабе шаблона. */
+export const TEMPLATE_REPLACED_IMAGE_RESOLUTIONS = [
+  {
+    label: 'уменьшенный размер с теми же пропорциями',
+    resolution: PRODUCT_CARD_TEMPLATE_COMPACT_RESOLUTION
+  },
+  {
+    label: 'квадратный размер с горизонтальными полями',
+    resolution: TEMPLATE_STANDALONE_TEXT_SQUARE_RESOLUTION
+  }
+] as const
+
+/** Шаблоны, где исходная квадратная картинка заменена картинкой с другим соотношением сторон. */
+export const TEMPLATE_REPLACED_IMAGE_CASES: {
+  label: string
+  template: TemplateDefinition
+}[] = [
+  {
+    label: 'вертикальная картинка 1:2',
+    template: {
+      id: 'template-image-replaced-with-vertical',
+      meta: TEMPLATE_REPLACED_IMAGE_META,
+      objects: [
+        {
+          ...TEMPLATE_REPLACED_IMAGE_BASE_OBJECT,
+          src: 'https://static.insales-cdn.com/files/1/3425/124923233/original/vertical_1_2.jpg'
+        }
+      ]
+    }
+  },
+  {
+    label: 'горизонтальная картинка 2:1',
+    template: {
+      id: 'template-image-replaced-with-horizontal',
+      meta: TEMPLATE_REPLACED_IMAGE_META,
+      objects: [
+        {
+          ...TEMPLATE_REPLACED_IMAGE_BASE_OBJECT,
+          src: 'https://static.insales-cdn.com/files/1/3417/124923225/original/horizontal_2_1.jpg'
+        }
+      ]
+    }
+  }
+]
+
 /** Фигура с длинным текстом для проверки сохранения и повторного применения шаблона. */
 export const TEMPLATE_SHAPE_LONG_TEXT_OPTIONS = {
   id: 'template-shape-long-text',

--- a/e2e/tests/template-manager/index.spec.ts
+++ b/e2e/tests/template-manager/index.spec.ts
@@ -14,6 +14,9 @@ import {
   PRODUCT_CARD_TEMPLATE_UPDATED_TITLE,
   TEMPLATE_ALIGNMENT_TOLERANCE,
   TEMPLATE_BOUNDS_TOLERANCE,
+  TEMPLATE_REPLACED_IMAGE_CASES,
+  TEMPLATE_REPLACED_IMAGE_CENTER,
+  TEMPLATE_REPLACED_IMAGE_RESOLUTIONS,
   TEMPLATE_RELATIVE_TOLERANCE,
   TEMPLATE_SHAPE_LONG_TEXT_OPTIONS,
   TEMPLATE_SHAPE_TEXT_BASE_RESOLUTION,
@@ -241,6 +244,70 @@ test.describe('Готовый шаблон', () => {
       expect(subtitleObject.text).toBe('Новый подзаголовок товара')
     })
   })
+})
+
+test.describe('Картинка из шаблона после замены src', () => {
+  for (const { label, template: imageTemplate } of TEMPLATE_REPLACED_IMAGE_CASES) {
+    test(`${label} остаётся в центре исходного места`, async({
+      canvas,
+      editorModel,
+      template
+    }) => {
+      await test.step('Применить шаблон с заменённой ссылкой на картинку', async() => {
+        await canvas.setMontageResolution(PRODUCT_CARD_TEMPLATE_BASE_RESOLUTION)
+
+        const insertedCount = await template.applyTemplate({
+          template: imageTemplate
+        })
+
+        expect(insertedCount).toBe(1)
+        await editorModel.checkObjectCount({ count: 1 })
+      })
+
+      await test.step('Проверить что центр картинки совпал с центром исходной квадратной области', async() => {
+        const montageBounds = await editorModel.getMontageAreaBounds()
+        const image = await editorModel.getObjectSnapshot({ objectIndex: 0 })
+        const expectedCenterX = montageBounds.left + (montageBounds.width * TEMPLATE_REPLACED_IMAGE_CENTER.x)
+        const expectedCenterY = montageBounds.top + (montageBounds.height * TEMPLATE_REPLACED_IMAGE_CENTER.y)
+
+        expect(Math.abs(image.centerX - expectedCenterX)).toBeLessThanOrEqual(TEMPLATE_BOUNDS_TOLERANCE)
+        expect(Math.abs(image.centerY - expectedCenterY)).toBeLessThanOrEqual(TEMPLATE_BOUNDS_TOLERANCE)
+      })
+    })
+  }
+
+  for (const { label, template: imageTemplate } of TEMPLATE_REPLACED_IMAGE_CASES) {
+    test(`${label} остаётся в центре исходного места на другом размере монтажной области`, async({
+      canvas,
+      editorModel,
+      template
+    }) => {
+      for (const { label: resolutionLabel, resolution } of TEMPLATE_REPLACED_IMAGE_RESOLUTIONS) {
+        await test.step(`Применить шаблон на размере ${resolution.width}x${resolution.height} для кейса "${resolutionLabel}"`, async() => {
+          await canvas.clearCanvas()
+          await canvas.setMontageResolution(resolution)
+
+          const insertedCount = await template.applyTemplate({
+            template: imageTemplate
+          })
+
+          expect(insertedCount).toBe(1)
+          await editorModel.checkObjectCount({ count: 1 })
+        })
+
+        // eslint-disable-next-line max-len
+        await test.step(`Проверить что на размере ${resolution.width}x${resolution.height} картинка остаётся по центру исходной области`, async() => {
+          const montageBounds = await editorModel.getMontageAreaBounds()
+          const image = await editorModel.getObjectSnapshot({ objectIndex: 0 })
+          const expectedCenterX = montageBounds.left + (montageBounds.width * TEMPLATE_REPLACED_IMAGE_CENTER.x)
+          const expectedCenterY = montageBounds.top + (montageBounds.height * TEMPLATE_REPLACED_IMAGE_CENTER.y)
+
+          expect(Math.abs(image.centerX - expectedCenterX)).toBeLessThanOrEqual(TEMPLATE_BOUNDS_TOLERANCE)
+          expect(Math.abs(image.centerY - expectedCenterY)).toBeLessThanOrEqual(TEMPLATE_BOUNDS_TOLERANCE)
+        })
+      }
+    })
+  }
 })
 
 test.describe('Standalone text из шаблона', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.22",
+      "version": "0.8.23",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/template-manager/index.spec.ts
+++ b/specs/src/editor/template-manager/index.spec.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import { ShapeGroupObject, registerShapeGroup } from '../../../../src/editor/shape-manager/domain/shape-group'
 import {
   createPlacementSelection,
+  createPlacementTestImage,
   createPlacementTestObject,
   createRevivedTemplateObject,
   getScenePointByOrigin
@@ -16,6 +17,7 @@ import {
   createMockShapeTextbox
 } from '../../../test-utils/shape-helpers'
 import {
+  createImageTemplateDefinition,
   createShapeTemplateDefinition,
   createStandaloneTextTemplateDefinition,
   createTemplateManagerTestSetup
@@ -326,6 +328,146 @@ describe('TemplateManager', () => {
     expect(targetRect.top + targetRect.height).toBeLessThanOrEqual(
       targetMontageBounds.top + targetMontageBounds.height
     )
+  })
+
+  it('изображение из шаблона с новой вертикальной картинкой сохраняет центр исходной области', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup({
+      useRealCanvasManager: true,
+      montageBounds: {
+        left: 100,
+        top: 50,
+        width: 810,
+        height: 1080
+      }
+    })
+    const revivedImage = createPlacementTestImage({
+      id: 'template-image',
+      left: 0.05925925925925926,
+      top: 0.15185185185185185,
+      width: 714,
+      height: 714,
+      intrinsicWidth: 400,
+      intrinsicHeight: 800
+    })
+
+    jest.spyOn(util, 'enlivenObjects').mockResolvedValue([revivedImage as never])
+
+    const result = await manager.applyTemplate({
+      template: createImageTemplateDefinition({
+        left: 0.05925925925925926,
+        top: 0.15185185185185185,
+        width: 714,
+        height: 714
+      })
+    })
+    const imageCenter = getScenePointByOrigin({
+      object: revivedImage,
+      originX: 'center',
+      originY: 'center'
+    })
+
+    expect(result).toEqual([revivedImage])
+    expect(imageCenter).toEqual(new Point(505, 571))
+    expect(revivedImage.scaleX).toBe(0.8925)
+    expect(revivedImage.scaleY).toBe(0.8925)
+    expect(editor.errorManager.emitError).not.toHaveBeenCalled()
+  })
+
+  it('legacy template без normalized positions сохраняет центр изображения после замены src', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup({
+      useRealCanvasManager: true,
+      montageBounds: {
+        left: 0,
+        top: 0,
+        width: 810,
+        height: 1080
+      }
+    })
+    const revivedImage = createPlacementTestImage({
+      id: 'template-image',
+      left: 148,
+      top: 164,
+      width: 240,
+      height: 240,
+      intrinsicWidth: 480,
+      intrinsicHeight: 120
+    })
+
+    jest.spyOn(util, 'enlivenObjects').mockResolvedValue([revivedImage as never])
+
+    const result = await manager.applyTemplate({
+      template: createImageTemplateDefinition({
+        left: 148,
+        top: 164,
+        width: 240,
+        height: 240,
+        positionsNormalized: false
+      })
+    })
+    const imageCenter = getScenePointByOrigin({
+      object: revivedImage,
+      originX: 'center',
+      originY: 'center'
+    })
+
+    expect(result).toEqual([revivedImage])
+    expect(imageCenter).toEqual(new Point(268, 284))
+    expect(revivedImage.originX).toBe('center')
+    expect(revivedImage.originY).toBe('center')
+    expect(editor.errorManager.emitError).not.toHaveBeenCalled()
+  })
+
+  it('изображение в stretch-режиме сохраняет центр и размер исходного бокса', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup({
+      useRealCanvasManager: true,
+      montageBounds: {
+        left: 100,
+        top: 50,
+        width: 810,
+        height: 1080
+      }
+    })
+    const revivedImage = createPlacementTestImage({
+      id: 'template-image',
+      left: 0.2,
+      top: 0.1,
+      width: 300,
+      height: 300,
+      intrinsicWidth: 100,
+      intrinsicHeight: 600
+    })
+
+    jest.spyOn(util, 'enlivenObjects').mockResolvedValue([revivedImage as never])
+
+    const result = await manager.applyTemplate({
+      template: createImageTemplateDefinition({
+        left: 0.2,
+        top: 0.1,
+        width: 300,
+        height: 300,
+        imageFit: 'stretch'
+      })
+    })
+    const imageCenter = getScenePointByOrigin({
+      object: revivedImage,
+      originX: 'center',
+      originY: 'center'
+    })
+
+    expect(result).toEqual([revivedImage])
+    expect(imageCenter).toEqual(new Point(412, 308))
+    expect(revivedImage.scaleX).toBe(3)
+    expect(revivedImage.scaleY).toBe(0.5)
+    expect(editor.errorManager.emitError).not.toHaveBeenCalled()
   })
 
   it('после применения шаблона эмитит editor:template-applied с вставленными объектами и bounds монтажной области', async() => {

--- a/specs/test-utils/placement-helpers.ts
+++ b/specs/test-utils/placement-helpers.ts
@@ -15,7 +15,7 @@ type PlacementPoint = {
   transform: (matrix: PlacementMatrix) => Point
 }
 
-type PlacementTestObject = {
+export type PlacementTestObject = {
   id: string
   type: string
   left: number
@@ -37,6 +37,10 @@ type PlacementTestObject = {
   getPointByOrigin: jest.Mock
   getBoundingRect: jest.Mock
   toDatalessObject: jest.Mock
+}
+
+export type PlacementImageTestObject = PlacementTestObject & {
+  getElement: jest.Mock
 }
 
 /**
@@ -203,7 +207,7 @@ export const createPlacementTestObject = ({
   strokeWidth?: number
   strokeUniform?: boolean
 }): PlacementTestObject => {
-  const object = {
+  const object: PlacementTestObject = {
     id,
     type,
     left,
@@ -269,7 +273,7 @@ export const createPlacementTestObject = ({
         height: scaledHeight
       }
     }),
-    toDatalessObject: jest.fn(() => ({
+    toDatalessObject: jest.fn((): Record<string, unknown> => ({
       id: object.id,
       type: object.type,
       left: object.left,
@@ -300,7 +304,7 @@ export const createPlacementSelection = ({
   offsetX: number
   offsetY: number
 }): PlacementGroup => {
-  const selection = new ActiveSelection(objects, {}) as PlacementGroup
+  const selection = new ActiveSelection(objects as never, {}) as PlacementGroup
   selection.calcTransformMatrix = jest.fn(() => [1, 0, 0, 1, offsetX, offsetY])
 
   for (let index = 0; index < objects.length; index += 1) {
@@ -332,4 +336,70 @@ export const createRevivedTemplateObject = ({
     strokeWidth: typeof serialized.strokeWidth === 'number' ? serialized.strokeWidth : 0,
     strokeUniform: typeof serialized.strokeUniform === 'boolean' ? serialized.strokeUniform : true
   })
+}
+
+/**
+ * Создаёт placement-aware image object c controllable intrinsic size.
+ */
+export const createPlacementTestImage = ({
+  id,
+  left,
+  top,
+  width,
+  height,
+  originX = 'left',
+  originY = 'top',
+  scaleX = 1,
+  scaleY = 1,
+  intrinsicWidth,
+  intrinsicHeight
+}: {
+  id: string
+  left: number
+  top: number
+  width: number
+  height: number
+  originX?: PlacementOriginX
+  originY?: PlacementOriginY
+  scaleX?: number
+  scaleY?: number
+  intrinsicWidth: number
+  intrinsicHeight: number
+}): PlacementImageTestObject => {
+  const image = createPlacementTestObject({
+    id,
+    type: 'image',
+    left,
+    top,
+    width,
+    height,
+    originX,
+    originY,
+    scaleX,
+    scaleY
+  }) as PlacementImageTestObject
+  const element = document.createElement('img')
+
+  Object.defineProperties(element, {
+    naturalWidth: {
+      configurable: true,
+      get: () => intrinsicWidth
+    },
+    naturalHeight: {
+      configurable: true,
+      get: () => intrinsicHeight
+    },
+    width: {
+      configurable: true,
+      get: () => intrinsicWidth
+    },
+    height: {
+      configurable: true,
+      get: () => intrinsicHeight
+    }
+  })
+
+  image.getElement = jest.fn(() => element)
+
+  return image
 }

--- a/specs/test-utils/template-manager-helpers.ts
+++ b/specs/test-utils/template-manager-helpers.ts
@@ -123,3 +123,48 @@ export const createStandaloneTextTemplateDefinition = (): TemplateDefinition => 
     }
   ]
 })
+
+/**
+ * Создаёт image template definition для проверок rehydration и placement.
+ */
+export const createImageTemplateDefinition = ({
+  left,
+  top,
+  width,
+  height,
+  positionsNormalized = true,
+  imageFit
+}: {
+  left: number
+  top: number
+  width: number
+  height: number
+  positionsNormalized?: boolean
+  imageFit?: 'contain' | 'stretch'
+}): TemplateDefinition => ({
+  id: 'template-image-placement',
+  meta: {
+    baseWidth: 810,
+    baseHeight: 1080,
+    positionsNormalized
+  },
+  objects: [
+    {
+      type: 'image',
+      id: 'template-image',
+      left,
+      top,
+      width,
+      height,
+      originX: 'left',
+      originY: 'top',
+      scaleX: 1,
+      scaleY: 1,
+      customData: imageFit
+        ? {
+          imageFit
+        }
+        : undefined
+    }
+  ]
+})

--- a/src/editor/template-manager/index.ts
+++ b/src/editor/template-manager/index.ts
@@ -3,6 +3,7 @@ import {
   Canvas,
   FabricImage,
   FabricObject,
+  Point,
   Textbox,
   loadSVGFromString,
   util
@@ -31,6 +32,11 @@ type Bounds = {
   height: number
 }
 
+type PointInfo = {
+  x: number
+  y: number
+}
+
 type TemplatePlaceholder = {
   id: string
   label?: string
@@ -38,6 +44,25 @@ type TemplatePlaceholder = {
 }
 
 type ImageFit = 'contain' | 'stretch'
+
+type ImageRestorePlan = {
+  nextProps: Record<string, number>
+  targetWidth: number
+  targetHeight: number
+  baseScaleX: number
+  baseScaleY: number
+  hasIntrinsicSize: boolean
+}
+
+type ImageRestorePropsParams = {
+  imageFit: ImageFit
+  intrinsicWidth: number
+  intrinsicHeight: number
+  targetWidth: number
+  targetHeight: number
+  baseScaleX: number
+  baseScaleY: number
+}
 
 export type TemplateMeta = {
   baseWidth: number
@@ -230,7 +255,12 @@ export default class TemplateManager {
 
     try {
       // Восстанавливаем Fabric-объекты из сохранённых данных шаблона
-      const enlivenedObjects = await TemplateManager._enlivenObjects(objects)
+      const enlivenedObjects = await TemplateManager._enlivenObjects({
+        objects,
+        baseWidth: meta.baseWidth,
+        baseHeight: meta.baseHeight,
+        useRelativePositions
+      })
 
       if (!enlivenedObjects.length) {
         errorManager.emitWarning({
@@ -372,12 +402,28 @@ export default class TemplateManager {
   /**
    * Превращает plain-описание объектов в Fabric объекты.
    */
-  private static async _enlivenObjects(objects: TemplateObjectData[]): Promise<FabricObject[]> {
+  private static async _enlivenObjects({
+    objects,
+    baseWidth,
+    baseHeight,
+    useRelativePositions
+  }: {
+    objects: TemplateObjectData[]
+    baseWidth: number
+    baseHeight: number
+    useRelativePositions: boolean
+  }): Promise<FabricObject[]> {
     const revivedList = await Promise.all(objects.map(async(serialized) => {
       if (TemplateManager._hasSerializedSvgMarkup(serialized)) {
         const revived = await TemplateManager._reviveSvgObject(serialized)
         if (revived) {
-          TemplateManager._restoreImageScale({ revived, serialized })
+          TemplateManager._restoreImageScale({
+            revived,
+            serialized,
+            baseWidth,
+            baseHeight,
+            useRelativePositions
+          })
           return revived
         }
       }
@@ -386,7 +432,13 @@ export default class TemplateManager {
       const revived = enlivened?.[0]
 
       if (revived) {
-        TemplateManager._restoreImageScale({ revived, serialized })
+        TemplateManager._restoreImageScale({
+          revived,
+          serialized,
+          baseWidth,
+          baseHeight,
+          useRelativePositions
+        })
         return revived
       }
 
@@ -401,12 +453,62 @@ export default class TemplateManager {
    */
   private static _restoreImageScale({
     revived,
-    serialized
-  }: { revived: FabricObject; serialized: TemplateObjectData }): void {
+    serialized,
+    baseWidth,
+    baseHeight,
+    useRelativePositions
+  }: {
+    revived: FabricObject
+    serialized: TemplateObjectData
+    baseWidth: number
+    baseHeight: number
+    useRelativePositions: boolean
+  }): void {
     const objectType = typeof revived.type === 'string' ? revived.type.toLowerCase() : ''
 
     if (objectType !== 'image') return
 
+    const image = revived as FabricImage
+    const plan = TemplateManager._createImageRestorePlan({ image, serialized })
+
+    if (!plan.hasIntrinsicSize) {
+      image.set(plan.nextProps)
+      return
+    }
+
+    const originalCenter = TemplateManager._resolveImageTemplateCenter({
+      image,
+      serialized,
+      plan,
+      baseWidth,
+      baseHeight,
+      useRelativePositions
+    })
+
+    image.set(plan.nextProps)
+    TemplateManager._restoreImageTemplateCenter({
+      image,
+      center: originalCenter,
+      baseWidth,
+      baseHeight,
+      useRelativePositions
+    })
+  }
+
+  /**
+   * Собирает план восстановления размера изображения по serialized box и новому intrinsic size.
+   */
+  private static _createImageRestorePlan({
+    image,
+    serialized
+  }: {
+    image: FabricImage
+    serialized: TemplateObjectData
+  }): ImageRestorePlan {
+    const {
+      width: intrinsicWidth,
+      height: intrinsicHeight
+    } = TemplateManager._getImageIntrinsicSize({ image })
     const {
       width: serializedWidth,
       height: serializedHeight,
@@ -414,8 +516,38 @@ export default class TemplateManager {
       scaleY: serializedScaleY,
       customData
     } = serialized
-    const image = revived as FabricImage
+    const targetWidth = toNumber({ value: serializedWidth, fallback: intrinsicWidth })
+    const targetHeight = toNumber({ value: serializedHeight, fallback: intrinsicHeight })
+    const baseScaleX = toNumber({ value: serializedScaleX, fallback: image.scaleX || 1 })
+    const baseScaleY = toNumber({ value: serializedScaleY, fallback: image.scaleY || 1 })
+    const imageFit = TemplateManager._resolveImageFit({ customData })
+    const nextProps = TemplateManager._resolveImageRestoreProps({
+      imageFit,
+      intrinsicWidth,
+      intrinsicHeight,
+      targetWidth,
+      targetHeight,
+      baseScaleX,
+      baseScaleY
+    })
 
+    const hasIntrinsicWidth = intrinsicWidth > 0
+    const hasIntrinsicHeight = intrinsicHeight > 0
+
+    return {
+      nextProps,
+      targetWidth,
+      targetHeight,
+      baseScaleX,
+      baseScaleY,
+      hasIntrinsicSize: hasIntrinsicWidth && hasIntrinsicHeight
+    }
+  }
+
+  /**
+   * Возвращает фактический размер нового изображения.
+   */
+  private static _getImageIntrinsicSize({ image }: { image: FabricImage }): Dimensions {
     const element = 'getElement' in image && typeof image.getElement === 'function'
       ? image.getElement()
       : null
@@ -434,23 +566,28 @@ export default class TemplateManager {
         height: 0
       }
 
-    const intrinsicWidth = toNumber({ value: naturalWidth || elementWidth || image.width, fallback: 0 })
-    const intrinsicHeight = toNumber({ value: naturalHeight || elementHeight || image.height, fallback: 0 })
+    return {
+      width: toNumber({ value: naturalWidth || elementWidth || image.width, fallback: 0 }),
+      height: toNumber({ value: naturalHeight || elementHeight || image.height, fallback: 0 })
+    }
+  }
 
-    const targetWidth = toNumber({ value: serializedWidth, fallback: intrinsicWidth })
-    const targetHeight = toNumber({ value: serializedHeight, fallback: intrinsicHeight })
-    const baseScaleX = toNumber({ value: serializedScaleX, fallback: image.scaleX || 1 })
-    const baseScaleY = toNumber({ value: serializedScaleY, fallback: image.scaleY || 1 })
-
+  /**
+   * Возвращает свойства размера и scale, которые должны быть применены к восстановленному изображению.
+   */
+  private static _resolveImageRestoreProps({
+    imageFit,
+    intrinsicWidth,
+    intrinsicHeight,
+    targetWidth,
+    targetHeight,
+    baseScaleX,
+    baseScaleY
+  }: ImageRestorePropsParams): Record<string, number> {
     const targetDisplayWidth = targetWidth * baseScaleX
     const targetDisplayHeight = targetHeight * baseScaleY
-
     const hasIntrinsicWidth = intrinsicWidth > 0
     const hasIntrinsicHeight = intrinsicHeight > 0
-    const hasTargetWidth = targetDisplayWidth > 0
-    const hasTargetHeight = targetDisplayHeight > 0
-    const imageFit = TemplateManager._resolveImageFit({ customData })
-
     const nextProps: Record<string, number> = {}
 
     if (hasIntrinsicWidth) {
@@ -462,30 +599,76 @@ export default class TemplateManager {
     }
 
     if (!hasIntrinsicWidth || !hasIntrinsicHeight) {
-      image.set(nextProps)
-      return
+      return nextProps
     }
 
     if (imageFit === 'stretch') {
-      const nextScaleX = hasTargetWidth ? targetDisplayWidth / intrinsicWidth : null
-      const nextScaleY = hasTargetHeight ? targetDisplayHeight / intrinsicHeight : null
-
-      if (nextScaleX && nextScaleX > 0) {
-        nextProps.scaleX = nextScaleX
-      }
-
-      if (nextScaleY && nextScaleY > 0) {
-        nextProps.scaleY = nextScaleY
-      }
-
-      image.set(nextProps)
-      return
+      TemplateManager._applyStretchedImageScale({
+        nextProps,
+        intrinsicWidth,
+        intrinsicHeight,
+        targetDisplayWidth,
+        targetDisplayHeight
+      })
+      return nextProps
     }
 
-    if (!hasTargetWidth || !hasTargetHeight) {
-      image.set(nextProps)
-      return
+    TemplateManager._applyContainedImageScale({
+      nextProps,
+      intrinsicWidth,
+      intrinsicHeight,
+      targetDisplayWidth,
+      targetDisplayHeight
+    })
+
+    return nextProps
+  }
+
+  /**
+   * Добавляет независимый scale по осям для stretch-режима.
+   */
+  private static _applyStretchedImageScale({
+    nextProps,
+    intrinsicWidth,
+    intrinsicHeight,
+    targetDisplayWidth,
+    targetDisplayHeight
+  }: {
+    nextProps: Record<string, number>
+    intrinsicWidth: number
+    intrinsicHeight: number
+    targetDisplayWidth: number
+    targetDisplayHeight: number
+  }): void {
+    const nextScaleX = targetDisplayWidth > 0 ? targetDisplayWidth / intrinsicWidth : null
+    const nextScaleY = targetDisplayHeight > 0 ? targetDisplayHeight / intrinsicHeight : null
+
+    if (nextScaleX && nextScaleX > 0) {
+      nextProps.scaleX = nextScaleX
     }
+
+    if (nextScaleY && nextScaleY > 0) {
+      nextProps.scaleY = nextScaleY
+    }
+  }
+
+  /**
+   * Добавляет единый scale для contain-режима.
+   */
+  private static _applyContainedImageScale({
+    nextProps,
+    intrinsicWidth,
+    intrinsicHeight,
+    targetDisplayWidth,
+    targetDisplayHeight
+  }: {
+    nextProps: Record<string, number>
+    intrinsicWidth: number
+    intrinsicHeight: number
+    targetDisplayWidth: number
+    targetDisplayHeight: number
+  }): void {
+    if (targetDisplayWidth <= 0 || targetDisplayHeight <= 0) return
 
     const containScale = Math.min(targetDisplayWidth / intrinsicWidth, targetDisplayHeight / intrinsicHeight)
 
@@ -493,8 +676,117 @@ export default class TemplateManager {
       nextProps.scaleX = containScale
       nextProps.scaleY = containScale
     }
+  }
 
-    image.set(nextProps)
+  /**
+   * Вычисляет центр исходной template-области изображения в координатах template-base.
+   */
+  private static _resolveImageTemplateCenter({
+    image,
+    serialized,
+    plan,
+    baseWidth,
+    baseHeight,
+    useRelativePositions
+  }: {
+    image: FabricImage
+    serialized: TemplateObjectData
+    plan: ImageRestorePlan
+    baseWidth: number
+    baseHeight: number
+    useRelativePositions: boolean
+  }): PointInfo {
+    const originalProps = {
+      left: image.left,
+      top: image.top,
+      width: image.width,
+      height: image.height,
+      scaleX: image.scaleX,
+      scaleY: image.scaleY
+    }
+    const placement = TemplateManager._resolveTemplatePlacement({
+      image,
+      serialized,
+      baseWidth,
+      baseHeight,
+      useRelativePositions
+    })
+
+    image.set({
+      left: placement.x,
+      top: placement.y,
+      width: plan.targetWidth,
+      height: plan.targetHeight,
+      scaleX: plan.baseScaleX,
+      scaleY: plan.baseScaleY
+    })
+
+    const center = image.getPointByOrigin('center', 'center')
+
+    image.set(originalProps)
+
+    return {
+      x: center.x,
+      y: center.y
+    }
+  }
+
+  /**
+   * Возвращает template-placement в координатах base-size, даже если в template он хранится нормализованным.
+   */
+  private static _resolveTemplatePlacement({
+    image,
+    serialized,
+    baseWidth,
+    baseHeight,
+    useRelativePositions
+  }: {
+    image: FabricImage
+    serialized: TemplateObjectData
+    baseWidth: number
+    baseHeight: number
+    useRelativePositions: boolean
+  }): PointInfo {
+    const left = toNumber({ value: serialized.left, fallback: image.left || 0 })
+    const top = toNumber({ value: serialized.top, fallback: image.top || 0 })
+
+    if (!useRelativePositions) {
+      return {
+        x: left,
+        y: top
+      }
+    }
+
+    return {
+      x: left * (baseWidth || 1),
+      y: top * (baseHeight || 1)
+    }
+  }
+
+  /**
+   * Возвращает восстановленное изображение в ту же систему координат, где его ждёт общий transform.
+   */
+  private static _restoreImageTemplateCenter({
+    image,
+    center,
+    baseWidth,
+    baseHeight,
+    useRelativePositions
+  }: {
+    image: FabricImage
+    center: PointInfo
+    baseWidth: number
+    baseHeight: number
+    useRelativePositions: boolean
+  }): void {
+    image.setPositionByOrigin(new Point(center.x, center.y), 'center', 'center')
+
+    if (!useRelativePositions) return
+
+    image.set({
+      left: toNumber({ value: image.left, fallback: 0 }) / (baseWidth || 1),
+      top: toNumber({ value: image.top, fallback: 0 }) / (baseHeight || 1)
+    })
   }
 
   /**


### PR DESCRIPTION

Предыстория.

Есть вот такой темплейт где изначально лежит квадратная картинка (скрин 1):

```json
{
  "id": "template-2",
  "meta": {
    "baseWidth": 810,
    "baseHeight": 1080,
    "positionsNormalized": true
  },
  "objects": [
    {
      "cropX": 0,
      "cropY": 0,
      "id": "image-K3f0IMCSpYfKXJEErsjMX",
      "customData": {
        "handle": "main-image"
      },
      "format": "png",
      "width": 714,
      "height": 714,
      "originX": "left",
      "originY": "top",
      "evented": true,
      "selectable": true,
      "lockMovementX": false,
      "lockMovementY": false,
      "lockRotation": false,
      "lockScalingX": false,
      "lockScalingY": false,
      "lockSkewingX": false,
      "lockSkewingY": false,
      "type": "Image",
      "version": "7.2.0",
      "left": 0.05925925925925926,
      "top": 0.15185185185185185,
      "fill": "rgb(0,0,0)",
      "stroke": null,
      "strokeWidth": 0,
      "strokeDashArray": null,
      "strokeLineCap": "butt",
      "strokeDashOffset": 0,
      "strokeLineJoin": "miter",
      "strokeUniform": false,
      "strokeMiterLimit": 4,
      "scaleX": 1,
      "scaleY": 1,
      "angle": 0,
      "flipX": false,
      "flipY": false,
      "opacity": 1,
      "shadow": null,
      "visible": true,
      "backgroundColor": "",
      "fillRule": "nonzero",
      "paintFirst": "fill",
      "globalCompositeOperation": "source-over",
      "skewX": 0,
      "skewY": 0,
      "src": "https://static.insales-cdn.com/files/1/521/108380681/original/headphones.png",
      "crossOrigin": "anonymous",
      "filters": [],
      "_templateAnchorX": "center",
      "_templateAnchorY": "center"
    }
  ]
}
```

<img width="367" height="463" alt="image" src="https://github.com/user-attachments/assets/8c412c42-b342-4516-befe-7f3d2f3f9f04" />

Порядок воспроизведения.

1. Заменить ссылку на изображение с пропорциями 1:2 и применить шаблон
2. Заменить ссылку на изображение с пропорциями 2:1 и применить шаблон

Ожидаемое поведение.

Изображение появится в середине на том же месте где появляется квадратное изображение из предыстории.

Фактический результат.

1. При применении шаблона с картинкой 1:2 картинка смещается влево (скрин 2)

<img width="346" height="458" alt="image" src="https://github.com/user-attachments/assets/9738a4db-63f3-4f38-87b2-76fd0e38199e" />

2. При применении шаблона с картинкой 2:1 картинка смещается вверх (скрин 3)

<img width="397" height="523" alt="image" src="https://github.com/user-attachments/assets/34b36bca-c14e-4bba-b79e-5f3da00f64e2" />

Вывод. 

Есть ощущение что формально всё работает правильно, просто TemplateManager не знает что мы заменили `src` ссылкой на другое изображение с другими размерами, поэтому получается, что изображение занимает ту же позицию что и изначальное по originX и originY и кажется что оно сместилось, но на самом деле оно там где должно быть (скрины 4-5)

<img width="485" height="495" alt="image" src="https://github.com/user-attachments/assets/fca69e0f-ca65-4ec2-955a-ef7a75541757" />

<img width="428" height="481" alt="image" src="https://github.com/user-attachments/assets/7c408ade-79cf-4393-9d8e-489ab1c99e3e" />

---

FIXED. 
