### PR TITLE
TextManager. Синхронизируем стили строк на text:changed до измерения размера строки, чтобы показывать курсор ввода текста тех же размеров что и размеры текста текущей строки, а не всего текстового объекта

### DIFF
--- a/e2e/models/text.model.ts
+++ b/e2e/models/text.model.ts
@@ -307,7 +307,13 @@ export class TextModel {
 
   /** Обновляет стиль текстового объекта через публичный API TextManager. */
   async updateStyle(params: TextUpdateStyleParams): Promise<TextObjectInfo | null> {
-    const textObject = await this.page.evaluate(({ style, objectIndex, id, syncLineStylesWithText }) => {
+    const textObject = await this.page.evaluate(({
+      style,
+      objectIndex,
+      id,
+      selectionRange,
+      syncLineStylesWithText
+    }) => {
       const {
         editor,
         __editorHelpers: helpers
@@ -317,6 +323,7 @@ export class TextModel {
       const result = editor.textManager.updateText({
         target,
         style,
+        selectionRange,
         syncLineStylesWithText
       })
       if (!result) return null

--- a/e2e/tests/text-manager/text-empty-line-editing.spec.ts
+++ b/e2e/tests/text-manager/text-empty-line-editing.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+
+test.describe('Редактирование пустой строки', () => {
+  test('после очистки строки с меньшим размером сохраняет высоту и размер текста при повторном вводе', async({ text }) => {
+    const initialText = 'TEST\nTEST'
+    const secondLineStart = initialText.indexOf('\n') + 1
+    const secondLineEnd = initialText.length
+    const createdTextObject = await test.step('Добавить текст из двух строк', async() => {
+      const textObject = await text.add({
+        text: initialText,
+        fontSize: 48,
+        autoExpand: false,
+        width: 240
+      })
+
+      return text.checkCreation({ textObject })
+    })
+
+    await test.step('Задать второй строке меньший размер текста', async() => {
+      const updatedTextObject = await text.updateStyle({
+        id: createdTextObject.id,
+        selectionRange: {
+          start: secondLineStart,
+          end: secondLineEnd
+        },
+        style: {
+          fontSize: 20
+        }
+      })
+      const secondLineStyle = await text.getSelectionStyles({
+        id: createdTextObject.id,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+
+      expect(updatedTextObject?.fontSize).toBe(48)
+      expect(secondLineStyle?.fontSize).toBe(20)
+    })
+
+    const initialSnapshot = await test.step('Зафиксировать исходную высоту объекта', async() => {
+      return text.getResizeSnapshot({ id: createdTextObject.id })
+    })
+
+    const snapshotAfterDelete = await test.step('Удалить текст второй строки, не удаляя саму строку', async() => {
+      await text.enterTextEditing({ id: createdTextObject.id })
+      await text.setTextSelection({
+        id: createdTextObject.id,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+      await text.deleteSelectedText({ id: createdTextObject.id })
+
+      return text.getResizeSnapshot({ id: createdTextObject.id })
+    })
+
+    await test.step('Проверить что высота не изменилась на пустой строке', async() => {
+      expect(snapshotAfterDelete.text).toBe('TEST\n')
+      expect(snapshotAfterDelete.lineCount).toBe(2)
+      expect(snapshotAfterDelete.isEditing).toBe(true)
+      expect(snapshotAfterDelete.height).toBeCloseTo(initialSnapshot.height, 1)
+    })
+
+    const snapshotAfterTyping = await test.step('Ввести новый текст в очищенную строку', async() => {
+      await text.typeText({
+        id: createdTextObject.id,
+        text: 'TE'
+      })
+
+      return text.getResizeSnapshot({ id: createdTextObject.id })
+    })
+
+    await test.step('Проверить что повторный ввод не меняет высоту и сохраняет размер второй строки', async() => {
+      const secondLineStyle = await text.getSelectionStyles({
+        id: createdTextObject.id,
+        start: secondLineStart,
+        end: secondLineStart + 2
+      })
+
+      expect(snapshotAfterTyping.text).toBe('TEST\nTE')
+      expect(snapshotAfterTyping.lineCount).toBe(2)
+      expect(snapshotAfterTyping.height).toBeCloseTo(initialSnapshot.height, 1)
+      expect(secondLineStyle?.fontSize).toBe(20)
+    })
+  })
+
+  test('после очистки строки с большим размером сохраняет высоту и размер текста при повторном вводе', async({ text }) => {
+    const initialText = 'TEST\nTEST'
+    const secondLineStart = initialText.indexOf('\n') + 1
+    const secondLineEnd = initialText.length
+    const createdTextObject = await test.step('Добавить текст из двух строк', async() => {
+      const textObject = await text.add({
+        text: initialText,
+        fontSize: 30,
+        autoExpand: false,
+        width: 240
+      })
+
+      return text.checkCreation({ textObject })
+    })
+
+    await test.step('Задать второй строке больший размер текста', async() => {
+      const updatedTextObject = await text.updateStyle({
+        id: createdTextObject.id,
+        selectionRange: {
+          start: secondLineStart,
+          end: secondLineEnd
+        },
+        style: {
+          fontSize: 80
+        }
+      })
+      const secondLineStyle = await text.getSelectionStyles({
+        id: createdTextObject.id,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+
+      expect(updatedTextObject?.fontSize).toBe(30)
+      expect(secondLineStyle?.fontSize).toBe(80)
+    })
+
+    const initialSnapshot = await test.step('Зафиксировать исходную высоту объекта', async() => {
+      return text.getResizeSnapshot({ id: createdTextObject.id })
+    })
+
+    const snapshotAfterDelete = await test.step('Удалить текст второй строки, не удаляя саму строку', async() => {
+      await text.enterTextEditing({ id: createdTextObject.id })
+      await text.setTextSelection({
+        id: createdTextObject.id,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+      await text.deleteSelectedText({ id: createdTextObject.id })
+
+      return text.getResizeSnapshot({ id: createdTextObject.id })
+    })
+
+    await test.step('Проверить что высота не уменьшилась на пустой строке', async() => {
+      expect(snapshotAfterDelete.text).toBe('TEST\n')
+      expect(snapshotAfterDelete.lineCount).toBe(2)
+      expect(snapshotAfterDelete.isEditing).toBe(true)
+      expect(snapshotAfterDelete.height).toBeCloseTo(initialSnapshot.height, 1)
+    })
+
+    const snapshotAfterTyping = await test.step('Ввести новый текст в очищенную строку', async() => {
+      await text.typeText({
+        id: createdTextObject.id,
+        text: 'TE'
+      })
+
+      return text.getResizeSnapshot({ id: createdTextObject.id })
+    })
+
+    await test.step('Проверить что повторный ввод не меняет высоту и сохраняет размер второй строки', async() => {
+      const secondLineStyle = await text.getSelectionStyles({
+        id: createdTextObject.id,
+        start: secondLineStart,
+        end: secondLineStart + 2
+      })
+
+      expect(snapshotAfterTyping.text).toBe('TEST\nTE')
+      expect(snapshotAfterTyping.lineCount).toBe(2)
+      expect(snapshotAfterTyping.height).toBeCloseTo(initialSnapshot.height, 1)
+      expect(secondLineStyle?.fontSize).toBe(80)
+    })
+  })
+})

--- a/e2e/types/text.types.ts
+++ b/e2e/types/text.types.ts
@@ -119,6 +119,7 @@ export interface TextResizeSnapshot extends TextObjectInfo {
 /** Параметры обновления стиля текстового объекта через TextManager. */
 export interface TextUpdateStyleParams extends ObjectTargetParams {
   style: TextStyleParams
+  selectionRange?: TextSelectionRange
   syncLineStylesWithText?: boolean
 }
 
@@ -129,11 +130,14 @@ export interface TextRangeStyleParams extends ObjectTargetParams {
   style: TextInlineStyle
 }
 
-/** Параметры выделения диапазона в режиме редактирования текста. */
-export interface TextSelectionParams extends ObjectTargetParams {
+/** Диапазон текста для выделения или частичного обновления стиля. */
+export interface TextSelectionRange {
   start: number
   end: number
 }
+
+/** Параметры выделения диапазона в режиме редактирования текста. */
+export interface TextSelectionParams extends ObjectTargetParams, TextSelectionRange {}
 
 /** Сериализованный стиль выделенного диапазона текстового объекта. */
 export interface TextSelectionStyleInfo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -507,19 +507,22 @@ export default class TextManager {
   /**
    * Нормализует standalone-геометрию текстового объекта после layout-изменений.
    * При включённом autoExpand пересчитывает ширину по фактической ширине текста.
-   * В остальных случаях только округляет размеры и восстанавливает placement.
+    * При shouldRefreshDimensions сначала сбрасывает measurement cache Fabric через initDimensions.
+    * В остальных случаях только округляет размеры и восстанавливает placement.
    */
   private _normalizeTextboxAfterContentChange(
     {
       textbox,
       placement,
       shouldAutoExpand,
-      clampToMontage = true
+      clampToMontage = true,
+      shouldRefreshDimensions = false
     }: {
       textbox: EditorTextbox
       placement?: ObjectPlacement | null
       shouldAutoExpand: boolean
       clampToMontage?: boolean
+      shouldRefreshDimensions?: boolean
     }
   ): boolean {
     let geometryAdjusted = false
@@ -531,7 +534,18 @@ export default class TextManager {
       })
     }
 
+    let dimensionsRecalculated = false
     let dimensionsRounded = false
+    if (!geometryAdjusted && shouldRefreshDimensions) {
+      const previousWidth = textbox.width ?? 0
+      const previousHeight = textbox.height ?? 0
+
+      textbox.initDimensions()
+
+      dimensionsRecalculated = Math.abs((textbox.width ?? 0) - previousWidth) > DIMENSION_EPSILON
+        || Math.abs((textbox.height ?? 0) - previousHeight) > DIMENSION_EPSILON
+    }
+
     if (!geometryAdjusted) {
       dimensionsRounded = roundTextboxDimensions({ textbox })
     }
@@ -545,15 +559,15 @@ export default class TextManager {
       placementApplied = true
     }
 
-    if (geometryAdjusted || dimensionsRounded) {
+    if (geometryAdjusted || dimensionsRecalculated || dimensionsRounded) {
       textbox.dirty = true
     }
 
-    if (geometryAdjusted || dimensionsRounded || placementApplied) {
+    if (geometryAdjusted || dimensionsRecalculated || dimensionsRounded || placementApplied) {
       textbox.setCoords()
     }
 
-    return geometryAdjusted || dimensionsRounded
+    return geometryAdjusted || dimensionsRecalculated || dimensionsRounded
   }
 
   /**
@@ -680,13 +694,16 @@ export default class TextManager {
       return
     }
 
+    // Пустая строка должна получить свои line defaults до layout-измерения,
+    // иначе Fabric измеряет её через object-level fontSize.
+    this._syncLineStylesWithText({ textbox: target })
+
     this._normalizeTextboxAfterContentChange({
       textbox: target,
       placement,
-      shouldAutoExpand: isAutoExpandEnabled
+      shouldAutoExpand: isAutoExpandEnabled,
+      shouldRefreshDimensions: true
     })
-
-    this._syncLineStylesWithText({ textbox: target })
   }
 
   /**

--- a/src/editor/text-manager/text-update-controller.ts
+++ b/src/editor/text-manager/text-update-controller.ts
@@ -55,6 +55,7 @@ type TextUpdateRuntime = {
     placement?: ObjectPlacement
     shouldAutoExpand: boolean
     clampToMontage?: boolean
+    shouldRefreshDimensions?: boolean
   }) => void
   restoreTextboxContentPlacement: (params: {
     textbox: EditorTextbox
@@ -1049,11 +1050,15 @@ export default class TextUpdateController {
   }): void {
     const nextRenderedText = textbox.text ?? ''
     const hasBackgroundStyleUpdate = this._hasBackgroundStyleUpdate({ style })
+    const shouldRefreshDimensions = this._shouldRefreshDimensions({
+      contentUpdate,
+      styleMaps
+    })
     const shouldAutoExpand = this._resolveShouldAutoExpand({
       textbox,
       style,
       styleMaps,
-      contentUpdate
+      shouldRefreshDimensions
     })
 
     if (hasBackgroundStyleUpdate) {
@@ -1074,7 +1079,8 @@ export default class TextUpdateController {
     this.runtime.normalizeTextboxAfterContentChange({
       textbox,
       placement,
-      shouldAutoExpand
+      shouldAutoExpand,
+      shouldRefreshDimensions
     })
 
     if (contentPlacement) {
@@ -1110,30 +1116,40 @@ export default class TextUpdateController {
     textbox,
     style,
     styleMaps,
-    contentUpdate
+    shouldRefreshDimensions
   }: {
     textbox: EditorTextbox
     style: TextStyleOptions
     styleMaps: TextStyleMaps
-    contentUpdate: TextContentUpdate
+    shouldRefreshDimensions: boolean
   }): boolean {
     const resolvedAutoExpand = style.autoExpand ?? textbox.autoExpand
-    const hasLayoutUpdates = hasLayoutAffectingStyles({
-      stylesList: [
-        styleMaps.updates,
-        styleMaps.selectionStyles,
-        styleMaps.lineSelectionStyles,
-        styleMaps.wholeTextStyles
-      ]
-    })
 
     return resolvedAutoExpand !== false
       && !Object.prototype.hasOwnProperty.call(styleMaps.updates, 'width')
-      && (
-        contentUpdate.hasTextUpdate
-        || contentUpdate.uppercaseChanged
-        || hasLayoutUpdates
-      )
+      && shouldRefreshDimensions
+  }
+
+  /**
+   * Определяет, нужно ли заново измерять textbox после обновления текста или layout-affecting styles.
+   */
+  private _shouldRefreshDimensions({
+    contentUpdate,
+    styleMaps
+  }: {
+    contentUpdate: TextContentUpdate
+    styleMaps: TextStyleMaps
+  }): boolean {
+    return contentUpdate.hasTextUpdate
+      || contentUpdate.uppercaseChanged
+      || hasLayoutAffectingStyles({
+        stylesList: [
+          styleMaps.updates,
+          styleMaps.selectionStyles,
+          styleMaps.lineSelectionStyles,
+          styleMaps.wholeTextStyles
+        ]
+      })
   }
 
   /**


### PR DESCRIPTION
Порядок воспроизведения

1. Добавить текстовый объект где первая строка "TEST" имеет размер текста 48 px, а вторая строка "TEST" имеет размер текста 20 (скрин 1)

<img width="1377" height="774" alt="image" src="https://github.com/user-attachments/assets/5f969bfc-fc94-46fd-ae3d-a5d26429112e" />

2. Стереть вторую строку, но не удалять саму строку 

Ожидаемое поведение.

Высота текстового объекта не изменится.

Фактический результат.

Высота текстового объекта увеличилась, потому что пустая строка получила размер текста 48px который задан для всего объекта, а не для конкретной строки (скрин 2). Однако после того как мы начинаем вводить текст, высота текстового объекта снова уменьшается (скрин 3)

<img width="1260" height="725" alt="image" src="https://github.com/user-attachments/assets/0293eb33-416d-4087-89a9-5726e0adf71a" />

<img width="1305" height="798" alt="image" src="https://github.com/user-attachments/assets/5f9b63cf-597e-46d8-9b21-ab8ba6908faf" />

Возможна и обратная ситуация, где если для первой строки задан размер текста, например, 30px,а для второй строки задан 80px, то при стирании текста второй строки объект будет уменьшаться, а при повторном вводе текста увеличиваться обратно (скрины 4-6)

<img width="1873" height="744" alt="image" src="https://github.com/user-attachments/assets/1988a5b8-8ccb-4560-b7be-8e2898e928e1" />

<img width="1369" height="777" alt="image" src="https://github.com/user-attachments/assets/26a520eb-19a6-4171-9ae7-ac34b674e3fc" />

<img width="1358" height="713" alt="image" src="https://github.com/user-attachments/assets/64b81490-5807-4c0e-9345-21718fe91726" />

---

FIXED.