### PR TITLE
ShapeManager. Фиксим кейс когда стирание строки с многострочным текстом с разными размерами текста могло вызывать увеличение высоты шейпа

### DIFF
--- a/e2e/tests/shape-manager/shape-text-empty-line-editing.spec.ts
+++ b/e2e/tests/shape-manager/shape-text-empty-line-editing.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+
+const MULTILINE_TEXT = 'FIRST LINE\nSECOND LINE'
+
+test.describe('Редактирование пустой строки внутри шейпа', () => {
+  test('после очистки второй строки с меньшим размером сохраняет высоту шейпа и размер строки при повторном вводе', async({ shapes }) => {
+    const secondLineStart = MULTILINE_TEXT.indexOf('\n') + 1
+    const secondLineEnd = MULTILINE_TEXT.length
+
+    await test.step('Добавить квадратный шейп с текстом из двух строк', async() => {
+      const shape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          text: MULTILINE_TEXT,
+          textStyle: {
+            fontSize: 48
+          }
+        }
+      })
+
+      shapes.checkCreation({ shape, presetKey: 'square' })
+    })
+
+    await test.step('Задать второй строке меньший размер текста', async() => {
+      await shapes.enterTextEditing({ objectIndex: 0 })
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+      await shapes.updateTextStyleInEditing({
+        objectIndex: 0,
+        style: {
+          fontSize: 20
+        }
+      })
+
+      const secondLineStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+
+      expect(secondLineStyle?.fontSize).toBe(20)
+      expect(secondLineStyle?.fontFamily).not.toBeNull()
+    })
+
+    const styledSnapshot = await test.step('Зафиксировать высоту после изменения второй строки', async() => {
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+    expect(styledSnapshot.textBoundsHeight).not.toBeNull()
+
+    if (styledSnapshot.textBoundsHeight === null) {
+      throw new Error('text bounds должны существовать после изменения второй строки в шейпе')
+    }
+
+    const styledTextBoundsHeight = styledSnapshot.textBoundsHeight
+
+    const snapshotAfterDelete = await test.step('Удалить текст второй строки, не удаляя саму строку', async() => {
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+      await shapes.deleteSelectedText({ objectIndex: 0 })
+
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+
+    await test.step('Проверить что пустая строка не увеличила высоту шейпа', async() => {
+      const textNode = await shapes.getTextNode({ objectIndex: 0 })
+
+      expect(textNode?.text).toBe('FIRST LINE\n')
+      expect(textNode?.lineCount).toBe(2)
+      expect(textNode?.isEditing).toBe(true)
+      expect(textNode?.selectionStart).toBe(secondLineStart)
+      expect(snapshotAfterDelete.textBoundsHeight).not.toBeNull()
+
+      if (snapshotAfterDelete.textBoundsHeight === null) {
+        throw new Error('text bounds должны существовать для текста внутри шейпа')
+      }
+
+      expect(snapshotAfterDelete.groupBoundsHeight).toBeCloseTo(styledSnapshot.groupBoundsHeight, 1)
+      expect(snapshotAfterDelete.textBoundsHeight).toBeCloseTo(styledTextBoundsHeight, 1)
+    })
+
+    const snapshotAfterTyping = await test.step('Ввести новый текст в очищенную строку', async() => {
+      await shapes.typeText({
+        objectIndex: 0,
+        text: 'TE'
+      })
+
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+
+    await test.step('Проверить что повторный ввод не меняет высоту и сохраняет размер второй строки', async() => {
+      const textNode = await shapes.getTextNode({ objectIndex: 0 })
+      const secondLineStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineStart + 2
+      })
+
+      expect(textNode?.text).toBe('FIRST LINE\nTE')
+      expect(textNode?.lineCount).toBe(2)
+      expect(snapshotAfterTyping.groupBoundsHeight).toBeCloseTo(styledSnapshot.groupBoundsHeight, 1)
+      expect(snapshotAfterTyping.textBoundsHeight).not.toBeNull()
+
+      if (snapshotAfterTyping.textBoundsHeight === null) {
+        throw new Error('text bounds должны существовать после повторного ввода в шейпе')
+      }
+
+      expect(snapshotAfterTyping.textBoundsHeight).toBeCloseTo(styledTextBoundsHeight, 1)
+      expect(secondLineStyle?.fontSize).toBe(20)
+    })
+  })
+
+  test('после очистки второй строки с большим размером сохраняет высоту шейпа и размер строки при повторном вводе', async({ shapes }) => {
+    const secondLineStart = MULTILINE_TEXT.indexOf('\n') + 1
+    const secondLineEnd = MULTILINE_TEXT.length
+
+    await test.step('Добавить квадратный шейп с текстом из двух строк', async() => {
+      const shape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          text: MULTILINE_TEXT,
+          textStyle: {
+            fontSize: 30
+          }
+        }
+      })
+
+      shapes.checkCreation({ shape, presetKey: 'square' })
+    })
+
+    await test.step('Задать второй строке больший размер текста', async() => {
+      await shapes.enterTextEditing({ objectIndex: 0 })
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+      await shapes.updateTextStyleInEditing({
+        objectIndex: 0,
+        style: {
+          fontSize: 60
+        }
+      })
+
+      const secondLineStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+
+      expect(secondLineStyle?.fontSize).toBe(60)
+      expect(secondLineStyle?.fontFamily).not.toBeNull()
+    })
+
+    const styledSnapshot = await test.step('Зафиксировать высоту после изменения второй строки', async() => {
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+    expect(styledSnapshot.textBoundsHeight).not.toBeNull()
+
+    if (styledSnapshot.textBoundsHeight === null) {
+      throw new Error('text bounds должны существовать после изменения второй строки в шейпе')
+    }
+
+    const styledTextBoundsHeight = styledSnapshot.textBoundsHeight
+
+    const snapshotAfterDelete = await test.step('Удалить текст второй строки, не удаляя саму строку', async() => {
+      await shapes.setTextSelection({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineEnd
+      })
+      await shapes.deleteSelectedText({ objectIndex: 0 })
+
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+
+    await test.step('Проверить что пустая строка не уменьшила высоту шейпа', async() => {
+      const textNode = await shapes.getTextNode({ objectIndex: 0 })
+
+      expect(textNode?.text).toBe('FIRST LINE\n')
+      expect(textNode?.lineCount).toBe(2)
+      expect(textNode?.isEditing).toBe(true)
+      expect(textNode?.selectionStart).toBe(secondLineStart)
+      expect(snapshotAfterDelete.textBoundsHeight).not.toBeNull()
+
+      if (snapshotAfterDelete.textBoundsHeight === null) {
+        throw new Error('text bounds должны существовать для текста внутри шейпа')
+      }
+
+      expect(snapshotAfterDelete.groupBoundsHeight).toBeCloseTo(styledSnapshot.groupBoundsHeight, 1)
+      expect(snapshotAfterDelete.textBoundsHeight).toBeCloseTo(styledTextBoundsHeight, 1)
+    })
+
+    const snapshotAfterTyping = await test.step('Ввести новый текст в очищенную строку', async() => {
+      await shapes.typeText({
+        objectIndex: 0,
+        text: 'TE'
+      })
+
+      return shapes.getScaleSnapshot({ objectIndex: 0 })
+    })
+
+    await test.step('Проверить что повторный ввод не меняет высоту и сохраняет размер второй строки', async() => {
+      const textNode = await shapes.getTextNode({ objectIndex: 0 })
+      const secondLineStyle = await shapes.getSelectionStyles({
+        objectIndex: 0,
+        start: secondLineStart,
+        end: secondLineStart + 2
+      })
+
+      expect(textNode?.text).toBe('FIRST LINE\nTE')
+      expect(textNode?.lineCount).toBe(2)
+      expect(snapshotAfterTyping.groupBoundsHeight).toBeCloseTo(styledSnapshot.groupBoundsHeight, 1)
+      expect(snapshotAfterTyping.textBoundsHeight).not.toBeNull()
+
+      if (snapshotAfterTyping.textBoundsHeight === null) {
+        throw new Error('text bounds должны существовать после повторного ввода в шейпе')
+      }
+
+      expect(snapshotAfterTyping.textBoundsHeight).toBeCloseTo(styledTextBoundsHeight, 1)
+      expect(secondLineStyle?.fontSize).toBe(60)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.8.24",
+      "version": "0.8.25",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/shape-manager/shape-manager-text.spec.ts
+++ b/specs/src/editor/shape-manager/shape-manager-text.spec.ts
@@ -63,7 +63,9 @@ describe('shape-manager text', () => {
       throw new Error('shape group should be created')
     }
 
-    const textNode = group.getObjects().find((item) => (item as { shapeNodeType?: string }).shapeNodeType === 'text')
+    const textNode = manager.getTextNode({
+      target: group
+    })
 
     if (!textNode) {
       throw new Error('shape text node should exist')
@@ -100,7 +102,9 @@ describe('shape-manager text', () => {
       canvas: editor.canvas,
       eventName: 'editor:before:text-updated'
     })
-    const textNode = group.getObjects().find((item) => (item as { shapeNodeType?: string }).shapeNodeType === 'text')
+    const textNode = manager.getTextNode({
+      target: group
+    })
 
     if (!enteredHandler || !beforeTextUpdatedHandler || !textNode) {
       throw new Error('shape manager handlers should be registered')
@@ -168,7 +172,9 @@ describe('shape-manager text', () => {
       canvas: editor.canvas,
       eventName: 'editor:before:text-updated'
     })
-    const textNode = group.getObjects().find((item) => (item as { shapeNodeType?: string }).shapeNodeType === 'text')
+    const textNode = manager.getTextNode({
+      target: group
+    })
 
     if (!enteredHandler || !beforeTextUpdatedHandler || !textNode) {
       throw new Error('shape manager handlers should be registered')
@@ -733,6 +739,93 @@ describe('shape-manager text', () => {
     expect(applyShapeTextLayoutMock).toHaveBeenCalled()
     expect(group.left).toBe(459)
     expect(group.top).toBe(412)
+  })
+
+  it('text:changed сначала синхронизирует стили пустой строки, а потом пересчитывает layout фигуры', async() => {
+    const editor = createShapeManagerEditorStub()
+    const manager = new ShapeManager({
+      editor: editor as never
+    })
+    const group = await manager.add({
+      presetKey: 'square',
+      options: {
+        text: 'FIRST LINE\nSECOND LINE'
+      }
+    })
+
+    if (!group) {
+      throw new Error('shape group should be created')
+    }
+
+    const enteredHandler = getRequiredCanvasHandler({
+      canvas: editor.canvas,
+      eventName: 'text:editing:entered'
+    })
+    const changedHandler = getRequiredCanvasHandler({
+      canvas: editor.canvas,
+      eventName: 'text:changed'
+    })
+    const textNode = manager.getTextNode({
+      target: group
+    })
+
+    if (!textNode) {
+      throw new Error('shape text node should exist')
+    }
+
+    type ShapeTextLineStyles = {
+      styles?: Record<number, Record<number, { fontSize?: number }>>
+      lineFontDefaults?: Record<number, { fontSize?: number }>
+    }
+
+    const textNodeWithLineStyles = textNode as Textbox & ShapeTextLineStyles
+    const syncLineStylesWithTextMock = editor.textManager.syncLineStylesWithText as jest.Mock
+    const syncedFontSize = 20
+
+    textNodeWithLineStyles.text = 'FIRST LINE\n'
+    textNodeWithLineStyles.styles = {}
+    textNodeWithLineStyles.lineFontDefaults = {
+      1: {
+        fontSize: syncedFontSize
+      }
+    }
+
+    syncLineStylesWithTextMock.mockImplementation(({
+      textbox
+    }: {
+      textbox: Textbox & ShapeTextLineStyles
+    }) => {
+      textbox.styles = {
+        1: {
+          0: {
+            fontSize: syncedFontSize
+          }
+        }
+      }
+    })
+
+    applyShapeTextLayoutMock.mockImplementation((params: Parameters<typeof applyShapeTextLayoutToMockGroup>[0]) => {
+      const textForLayout = params.text as Textbox & ShapeTextLineStyles
+
+      expect(syncLineStylesWithTextMock).toHaveBeenCalledTimes(1)
+      expect(textForLayout.styles?.[1]?.[0]?.fontSize).toBe(syncedFontSize)
+
+      applyShapeTextLayoutToMockGroup(params)
+    })
+
+    enteredHandler({
+      target: textNode
+    })
+    syncLineStylesWithTextMock.mockClear()
+    applyShapeTextLayoutMock.mockClear()
+    changedHandler({
+      target: textNode
+    })
+
+    expect(syncLineStylesWithTextMock).toHaveBeenCalledWith({
+      textbox: textNode
+    })
+    expect(applyShapeTextLayoutMock).toHaveBeenCalledTimes(1)
   })
 
   it('при вводе текста не сужает шейп уже ширины, с которой он был добавлен', async() => {

--- a/specs/test-utils/shape-helpers.ts
+++ b/specs/test-utils/shape-helpers.ts
@@ -726,6 +726,7 @@ export const createShapeManagerEditorStub = ({
         width: Number(style.width) || 180,
         textAlign: (style.align as 'left' | 'center' | 'right' | 'justify') ?? 'center'
       })),
+      syncLineStylesWithText: jest.fn(),
       updateText: jest.fn()
     },
     historyManager: {

--- a/src/editor/shape-manager/events/shape-event-controller.ts
+++ b/src/editor/shape-manager/events/shape-event-controller.ts
@@ -246,6 +246,12 @@ export default class ShapeEventController {
 
     if (!isShapeGroup(textNode.group)) return
 
+    // ShapeManager получает text:changed раньше TextManager,
+    // поэтому line defaults должны попасть в runtime styles до layout-измерения.
+    this.runtime.editor.textManager.syncLineStylesWithText({
+      textbox: textNode
+    })
+
     const wasSynchronized = this.runtime.syncShapeTextLayoutAfterTextMutation({
       textNode
     })

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -131,7 +131,7 @@ export default class TextManager {
         resolveTextObject: (reference) => this._resolveTextObject(reference),
         normalizeTextboxAfterContentChange: (params) => this._normalizeTextboxAfterContentChange(params),
         restoreTextboxContentPlacement: (params) => this._restoreTextboxContentPlacement(params),
-        syncLineStylesWithText: (params) => this._syncLineStylesWithText(params),
+        syncLineStylesWithText: (params) => this.syncLineStylesWithText(params),
         getSnapshot: (textbox) => TextManager._getSnapshot(textbox)
       }
     })
@@ -690,13 +690,13 @@ export default class TextManager {
     }
 
     if (isShapeOwnedTextbox) {
-      this._syncLineStylesWithText({ textbox: target })
+      this.syncLineStylesWithText({ textbox: target })
       return
     }
 
     // Пустая строка должна получить свои line defaults до layout-измерения,
     // иначе Fabric измеряет её через object-level fontSize.
-    this._syncLineStylesWithText({ textbox: target })
+    this.syncLineStylesWithText({ textbox: target })
 
     this._normalizeTextboxAfterContentChange({
       textbox: target,
@@ -709,7 +709,7 @@ export default class TextManager {
   /**
    * Синхронизирует lineFontDefaults и runtime styles после изменения текста.
    */
-  private _syncLineStylesWithText({
+  public syncLineStylesWithText({
     textbox,
     previousText,
     currentText


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить квадртаный шейп с текстом "FIRST LINE\nSECOND LINE" с размером текста 48px (скрин 1)

<img width="564" height="540" alt="image" src="https://github.com/user-attachments/assets/69470a1a-48ff-4b16-89d9-09057062b282" />

3. Для второй строки задать размер текста 20px, объект занимает 86px высоты (скрин 2)

<img width="1206" height="554" alt="image" src="https://github.com/user-attachments/assets/e45ef85c-fec1-4264-bc5f-119ca3cb90a9" />

5. Стереть текст второй строки, так чтобы курсор остался на второй строке

Ожидаемое поведение.

После стирания курсор останется размером 20px, высота шейпа останется прежней.

Фактический результат. 

После стирания курсор остался размером 20px, однако высота шейпа увеличилась и появился большой отступ между строками (скрин 3).

<img width="1341" height="719" alt="image" src="https://github.com/user-attachments/assets/487a4e70-ce2c-46f1-bf29-9988f488646a" />

---

FIXED. Синхронизируем стили строк на text:changed внутри ShapeManager, так как он получает это событие раньше TextManager.