### PR TITLE
TextManager. Чиним прыгающий текст в одну строку при скейлинге

### DIFF
--- a/e2e/fixtures/data/text-resizing.data.ts
+++ b/e2e/fixtures/data/text-resizing.data.ts
@@ -2,7 +2,9 @@ import type {
   TemplateDefinition,
   TextAddParams,
   TextInlineStyle,
-  TextLineDefaults
+  TextLineDefaults,
+  TextScaleDragStep,
+  TextScaleHandleCase
 } from '../../types'
 
 /** Допуски для standalone text resize assertions. */
@@ -35,6 +37,69 @@ export const TEXT_HORIZONTAL_SCALING_NARROW_STEPS = [
   0.62,
   0.42
 ]
+
+/** Создаёт повторяющиеся pointer-шаги для live-сужения текста за scale-угол. */
+const createTextScaleDragSteps = ({
+  deltaX,
+  deltaY,
+  count
+}: {
+  deltaX: number
+  deltaY: number
+  count: number
+}): TextScaleDragStep[] => {
+  const steps: TextScaleDragStep[] = []
+
+  for (let index = 0; index < count; index += 1) {
+    steps.push({
+      deltaX,
+      deltaY,
+      pointerSteps: 1
+    })
+  }
+
+  return steps
+}
+
+/** Реальные pointer-сценарии сужения текста за диагональные углы для проверки live-переносов. */
+export const TEXT_DIAGONAL_SCALING_NARROW_DRAG_CASES = [
+  {
+    title: 'правый верхний угол',
+    corner: 'tr',
+    steps: createTextScaleDragSteps({
+      deltaX: -7,
+      deltaY: 3,
+      count: 7
+    })
+  },
+  {
+    title: 'правый нижний угол',
+    corner: 'br',
+    steps: createTextScaleDragSteps({
+      deltaX: -7,
+      deltaY: -3,
+      count: 7
+    })
+  },
+  {
+    title: 'левый верхний угол',
+    corner: 'tl',
+    steps: createTextScaleDragSteps({
+      deltaX: 7,
+      deltaY: 3,
+      count: 7
+    })
+  },
+  {
+    title: 'левый нижний угол',
+    corner: 'bl',
+    steps: createTextScaleDragSteps({
+      deltaX: 7,
+      deltaY: -3,
+      count: 7
+    })
+  }
+] satisfies TextScaleHandleCase[]
 
 /** Минимальный размер шрифта при скейлинге standalone text. */
 export const TEXT_SCALING_MINIMUM_FONT_SIZE = 8
@@ -241,6 +306,96 @@ export const TEXT_RESIZING_REGRESSION_TEMPLATE: TemplateDefinition = {
       _templateCenterY: 0.5,
       _templateAnchorX: 'center',
       _templateAnchorY: 'center'
+    }
+  ]
+}
+
+/** Template JSON из регрессии, где standalone text дрожит при сужении за правый верхний угол. */
+export const TEXT_TOP_RIGHT_SCALING_REGRESSION_TEMPLATE: TemplateDefinition = {
+  id: 'template-li-6iWreVuR-zClIK1_iN',
+  meta: {
+    baseWidth: 512,
+    baseHeight: 512,
+    positionsNormalized: true
+  },
+  objects: [
+    {
+      fontSize: 54.28960333834419,
+      fontWeight: 'normal',
+      fontFamily: 'Arial',
+      fontStyle: 'normal',
+      lineHeight: 1.16,
+      text: 'Новый текст',
+      charSpacing: 0,
+      textAlign: 'left',
+      styles: [],
+      pathStartOffset: 0,
+      pathSide: 'left',
+      pathAlign: 'baseline',
+      underline: false,
+      overline: false,
+      linethrough: false,
+      textBackgroundColor: '',
+      direction: 'ltr',
+      textDecorationThickness: 66.667,
+      minWidth: 20,
+      splitByGrapheme: false,
+      id: 'background-textbox-X2r5MeYF_jIApB8Xk2RHd',
+      width: 313,
+      height: 133,
+      originX: 'center',
+      originY: 'center',
+      editable: true,
+      evented: true,
+      selectable: true,
+      lockMovementX: false,
+      lockMovementY: false,
+      lockRotation: false,
+      lockScalingX: false,
+      lockScalingY: false,
+      lockSkewingX: false,
+      lockSkewingY: false,
+      textCaseRaw: 'Новый текст',
+      uppercase: false,
+      autoExpand: true,
+      backgroundOpacity: 1,
+      paddingTop: 0,
+      paddingRight: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      radiusTopLeft: 0,
+      radiusTopRight: 0,
+      radiusBottomRight: 0,
+      radiusBottomLeft: 0,
+      type: 'background-textbox',
+      version: '7.2.0',
+      left: 0.5048828125000002,
+      top: 0.7562030782926384,
+      fill: '#000000',
+      stroke: null,
+      strokeWidth: 0,
+      strokeDashArray: null,
+      strokeLineCap: 'butt',
+      strokeDashOffset: 0,
+      strokeLineJoin: 'miter',
+      strokeUniform: true,
+      strokeMiterLimit: 4,
+      scaleX: 1,
+      scaleY: 1,
+      angle: 0,
+      flipX: false,
+      flipY: false,
+      opacity: 1,
+      shadow: null,
+      visible: true,
+      backgroundColor: '',
+      fillRule: 'nonzero',
+      paintFirst: 'fill',
+      globalCompositeOperation: 'source-over',
+      skewX: 0,
+      skewY: 0,
+      _templateAnchorX: 'center',
+      _templateAnchorY: 'end'
     }
   ]
 }

--- a/e2e/models/text.model.ts
+++ b/e2e/models/text.model.ts
@@ -11,6 +11,8 @@ import type {
   TextResizeSnapshot,
   TextResizeUntilWrapParams,
   TextRotateParams,
+  TextScaleDragStep,
+  TextScaleHandleCorner,
   TextSelectionParams,
   TextSelectionStyleInfo,
   TextTemplateApplyParams,
@@ -36,7 +38,7 @@ export class TextModel {
       x: number
       y: number
     }
-    corner: 'mb' | 'br' | 'mr'
+    corner: TextScaleHandleCorner
     objectIndex?: number
     id?: string
   } | null
@@ -696,13 +698,62 @@ export class TextModel {
     })
   }
 
-  /** Тянет scale-ручку текстового объекта реальной мышью и оставляет drag-сессию открытой. */
+  /** Сжимает standalone text за выбранный угол и возвращает live-состояния после каждого шага. */
+  async shrinkFromScaleCornerInLiveSteps(
+    params: {
+      corner: TextScaleHandleCorner
+      steps: TextScaleDragStep[]
+    } & ObjectTargetParams
+  ): Promise<TextResizeSnapshot[]> {
+    const {
+      corner,
+      steps,
+      objectIndex,
+      id
+    } = params
+
+    expect(steps.length, 'для live-сужения текста должен быть хотя бы один шаг').toBeGreaterThan(0)
+
+    const firstStep = steps[0]
+    expect(firstStep, 'первый шаг live-сужения текста должен существовать').toBeDefined()
+
+    if (!firstStep) {
+      throw new Error('первый шаг live-сужения текста должен существовать')
+    }
+
+    const states = [
+      await this.dragScaleHandleBy({
+        corner,
+        objectIndex,
+        id,
+        ...firstStep
+      })
+    ]
+
+    for (let index = 1; index < steps.length; index += 1) {
+      const step = steps[index]
+
+      expect(step, 'каждый шаг live-сужения текста должен существовать').toBeDefined()
+
+      if (!step) {
+        throw new Error('каждый шаг live-сужения текста должен существовать')
+      }
+
+      states.push(await this.continueScaleHandleBy(step))
+    }
+
+    expect(states.length, 'число live-состояний текста должно совпадать с числом шагов').toBe(steps.length)
+
+    return states
+  }
+
+  /** Тянет ручку масштабирования текстового объекта реальной мышью и оставляет drag-сессию открытой. */
   async dragScaleHandleBy(
     params: {
-      corner: 'mb' | 'br' | 'mr'
+      corner: TextScaleHandleCorner
       deltaX: number
       deltaY: number
-      steps?: number
+      pointerSteps?: number
     } & ObjectTargetParams
   ): Promise<TextResizeSnapshot> {
     expect(
@@ -714,7 +765,7 @@ export class TextModel {
       corner,
       deltaX,
       deltaY,
-      steps = 8,
+      pointerSteps = 8,
       objectIndex,
       id
     } = params
@@ -730,9 +781,19 @@ export class TextModel {
 
     await this.page.mouse.move(point.x, point.y)
     await this.page.mouse.down()
-    await this.page.mouse.move(nextPoint.x, nextPoint.y, { steps })
+    await this.page.mouse.move(nextPoint.x, nextPoint.y, { steps: pointerSteps })
+    await waitForCanvasRender({ page: this.page })
 
     const snapshot = await this.getResizeSnapshot({ objectIndex, id })
+
+    expect(
+      snapshot.width,
+      'после drag ручки масштабирования текста ширина должна быть положительной'
+    ).toBeGreaterThan(0)
+    expect(
+      snapshot.height,
+      'после drag ручки масштабирования текста высота должна быть положительной'
+    ).toBeGreaterThan(0)
 
     this.activeScaleInteraction = {
       point: nextPoint,
@@ -744,10 +805,64 @@ export class TextModel {
     return snapshot
   }
 
-  /** Возвращает viewport-точку scale-ручки текстового объекта. */
+  /** Продолжает открытую drag-сессию масштабирования текстового объекта реальным движением мыши. */
+  async continueScaleHandleBy(
+    params: {
+      deltaX: number
+      deltaY: number
+      pointerSteps?: number
+    }
+  ): Promise<TextResizeSnapshot> {
+    expect(
+      this.activeScaleInteraction,
+      'нельзя продолжать scale drag текста без активной drag-сессии'
+    ).not.toBeNull()
+
+    if (!this.activeScaleInteraction) {
+      throw new Error('активная drag-сессия scale текста должна существовать')
+    }
+
+    const {
+      deltaX,
+      deltaY,
+      pointerSteps = 1
+    } = params
+    const {
+      point,
+      objectIndex,
+      id
+    } = this.activeScaleInteraction
+    const nextPoint = {
+      x: point.x + deltaX,
+      y: point.y + deltaY
+    }
+
+    await this.page.mouse.move(nextPoint.x, nextPoint.y, { steps: pointerSteps })
+    await waitForCanvasRender({ page: this.page })
+
+    const snapshot = await this.getResizeSnapshot({ objectIndex, id })
+
+    expect(
+      snapshot.width,
+      'после продолжения drag масштабирования текста ширина должна быть положительной'
+    ).toBeGreaterThan(0)
+    expect(
+      snapshot.height,
+      'после продолжения drag масштабирования текста высота должна быть положительной'
+    ).toBeGreaterThan(0)
+
+    this.activeScaleInteraction = {
+      ...this.activeScaleInteraction,
+      point: nextPoint
+    }
+
+    return snapshot
+  }
+
+  /** Возвращает viewport-точку ручки масштабирования текстового объекта. */
   private async _resolveScaleHandlePoint(
     params: {
-      corner: 'mb' | 'br' | 'mr'
+      corner: TextScaleHandleCorner
     } & ObjectTargetParams
   ): Promise<{ x: number, y: number }> {
     const {
@@ -787,10 +902,13 @@ export class TextModel {
       id
     })
 
-    expect(point, 'должна существовать стартовая точка scale-ручки текста').not.toBeNull()
+    expect(point, 'должна существовать стартовая точка ручки масштабирования текста').not.toBeNull()
     if (!point) {
-      throw new Error('стартовая точка scale-ручки текста должна существовать')
+      throw new Error('стартовая точка ручки масштабирования текста должна существовать')
     }
+
+    expect(Number.isFinite(point.x), 'x-координата ручки масштабирования текста должна быть конечным числом').toBe(true)
+    expect(Number.isFinite(point.y), 'y-координата ручки масштабирования текста должна быть конечным числом').toBe(true)
 
     return point
   }

--- a/e2e/tests/text-manager/text-scaling.spec.ts
+++ b/e2e/tests/text-manager/text-scaling.spec.ts
@@ -10,7 +10,9 @@ import {
   TEXT_RESIZING_REGRESSION_SECOND_LINE_SELECTION,
   TEXT_RESIZING_TOLERANCE,
   TEXT_SCALING_MINIMUM_FONT_SIZE,
-  TEXT_SCALING_REGRESSION_WIDTH
+  TEXT_SCALING_REGRESSION_WIDTH,
+  TEXT_DIAGONAL_SCALING_NARROW_DRAG_CASES,
+  TEXT_TOP_RIGHT_SCALING_REGRESSION_TEMPLATE
 } from '../../fixtures/data/text-resizing.data'
 
 test.describe('Скейлинг текстового объекта', () => {
@@ -552,6 +554,85 @@ test.describe('Скейлинг текстового объекта', () => {
         expect(afterPointerMoveSnapshot.leftTopY).toBeCloseTo(finalSnapshot.leftTopY, 1)
       })
     })
+  })
+
+  test.describe('объект "Новый текст" восстановлен из шаблона', () => {
+    test.beforeEach(async({ text }) => {
+      const textObject = await text.applyTemplate({
+        template: TEXT_TOP_RIGHT_SCALING_REGRESSION_TEMPLATE
+      })
+
+      text.checkCreation({ textObject })
+    })
+
+    for (const scalingCase of TEXT_DIAGONAL_SCALING_NARROW_DRAG_CASES) {
+      test(`при сужении за ${scalingCase.title} текст остаётся в одну строку во время drag`, async({
+        text
+      }) => {
+        await test.step('Явно выбрать текстовый объект перед началом скейлинга', async() => {
+          await text.select({ objectIndex: 0 })
+        })
+
+        const initialSnapshot = await test.step('Получить исходное состояние текста из шаблона', async() => {
+          return text.getResizeSnapshot({ objectIndex: 0 })
+        })
+
+        const liveStates = await test.step(`Сузить текст за ${scalingCase.title} по live-шагам`, async() => {
+          return text.shrinkFromScaleCornerInLiveSteps({
+            objectIndex: 0,
+            corner: scalingCase.corner,
+            steps: scalingCase.steps
+          })
+        })
+
+        const finalSnapshot = await test.step('Отпустить мышь и получить итоговое состояние текста', async() => {
+          return text.finishScale({ objectIndex: 0 })
+        })
+
+        await test.step('Проверить что во время drag текст ни разу не перепрыгнул на две строки', () => {
+          expect(initialSnapshot.text).toBe('Новый текст')
+          expect(initialSnapshot.lineCount).toBe(1)
+          expect(liveStates.length).toBe(scalingCase.steps.length)
+
+          for (let index = 0; index < liveStates.length; index += 1) {
+            const state = liveStates[index]
+
+            expect(state, 'live-состояние текста должно существовать').toBeDefined()
+
+            if (!state) {
+              throw new Error('live-состояние текста должно существовать')
+            }
+
+            expect(state.text).toBe(initialSnapshot.text)
+            expect(
+              state.lineCount,
+              `шаг ${index + 1}: width=${state.width}, height=${state.height}, fontSize=${state.fontSize}`
+            ).toBe(1)
+            expect(state.width).toBeLessThan(initialSnapshot.width)
+            expect(state.fontSize).toBeLessThan(initialSnapshot.fontSize)
+          }
+        })
+
+        await test.step('Проверить что после mouseup текст остался в одну строку без скачка размеров', () => {
+          const lastLiveState = liveStates[liveStates.length - 1]
+
+          expect(lastLiveState, 'последнее live-состояние текста должно существовать').toBeDefined()
+
+          if (!lastLiveState) {
+            throw new Error('последнее live-состояние текста должно существовать')
+          }
+
+          expect(finalSnapshot.text).toBe(initialSnapshot.text)
+          expect(finalSnapshot.lineCount).toBe(1)
+          expect(Math.abs(finalSnapshot.width - lastLiveState.width))
+            .toBeLessThanOrEqual(TEXT_RESIZING_TOLERANCE.mouseupJump)
+          expect(Math.abs(finalSnapshot.height - lastLiveState.height))
+            .toBeLessThanOrEqual(TEXT_RESIZING_TOLERANCE.mouseupJump)
+          expect(finalSnapshot.scaleX).toBe(1)
+          expect(finalSnapshot.scaleY).toBe(1)
+        })
+      })
+    }
   })
 
   test('после ручного сужения объект из буфера масштабируется так же, как исходный', async({

--- a/e2e/types/text.types.ts
+++ b/e2e/types/text.types.ts
@@ -9,6 +9,21 @@ export type TextPlacementOriginX = 'left' | 'center' | 'right'
 export type TextPlacementOriginY = 'top' | 'center' | 'bottom'
 export type TextResizeOriginX = 'left' | 'right'
 export type TextResizeOriginY = 'top' | 'center' | 'bottom'
+export type TextScaleHandleCorner = 'tl' | 'tr' | 'bl' | 'br' | 'mb' | 'mr'
+
+/** Один pointer-шаг реального перетаскивания ручки масштабирования standalone text. */
+export interface TextScaleDragStep {
+  deltaX: number
+  deltaY: number
+  pointerSteps?: number
+}
+
+/** E2E-кейс сужения standalone text за конкретный угол. */
+export interface TextScaleHandleCase {
+  title: string
+  corner: TextScaleHandleCorner
+  steps: TextScaleDragStep[]
+}
 
 /** Параметры стилизации отдельного текстового объекта. */
 export interface TextStyleParams {
@@ -29,6 +44,10 @@ export interface TextStyleParams {
   backgroundOpacity?: number
   lineHeight?: number
   autoExpand?: boolean
+  left?: number
+  top?: number
+  originX?: TextPlacementOriginX
+  originY?: TextPlacementOriginY
   paddingTop?: number
   paddingRight?: number
   paddingBottom?: number
@@ -116,6 +135,12 @@ export interface TextResizeSnapshot extends TextObjectInfo {
   textAreaLeftTopY: number
 }
 
+/** Диапазон текста для выделения или частичного обновления стиля. */
+export interface TextSelectionRange {
+  start: number
+  end: number
+}
+
 /** Параметры обновления стиля текстового объекта через TextManager. */
 export interface TextUpdateStyleParams extends ObjectTargetParams {
   style: TextStyleParams
@@ -128,12 +153,6 @@ export interface TextRangeStyleParams extends ObjectTargetParams {
   start: number
   end: number
   style: TextInlineStyle
-}
-
-/** Диапазон текста для выделения или частичного обновления стиля. */
-export interface TextSelectionRange {
-  start: number
-  end: number
 }
 
 /** Параметры выделения диапазона в режиме редактирования текста. */

--- a/specs/src/editor/text-manager/scaling/text-scaling-materialization.spec.ts
+++ b/specs/src/editor/text-manager/scaling/text-scaling-materialization.spec.ts
@@ -61,6 +61,24 @@ describe('масштабирование текста', () => {
         underline: true
       })
     })
+
+    it('отличает явные строки от строк после переноса', () => {
+      const textbox = new BackgroundTextbox('Новый текст', {
+        width: 120,
+        fontSize: 54,
+        left: 40,
+        top: 60,
+        originX: 'left',
+        originY: 'top'
+      })
+
+      textbox.textLines = ['Новый', 'текст']
+
+      const base = captureTextScaleBase({ textbox })
+
+      expect(base.explicitLineCount).toBe(1)
+      expect(base.renderedLineCount).toBe(2)
+    })
   })
 
   describe('ограничение уменьшения', () => {

--- a/src/editor/text-manager/scaling/text-scaling-materialization.ts
+++ b/src/editor/text-manager/scaling/text-scaling-materialization.ts
@@ -14,6 +14,7 @@ import {
   scaleLineFontDefaults
 } from '../line-defaults'
 import {
+  getLongestLineWidth,
   roundTextboxDimensions
 } from '../geometry'
 import type {
@@ -59,6 +60,137 @@ type ApplyScaledTextboxVisualStateOptions = {
   shouldScaleRadii?: boolean
 }
 
+type ScaledAutoExpandOptions = {
+  textbox: EditorTextbox
+  canvasManager: CanvasManager
+  base: TextScaleBaseState
+  committedWidth: number
+  shouldScaleFontSize: boolean
+  shouldRoundDimensions: boolean
+}
+
+/**
+ * Возвращает число строк, заданных явными переносами текста.
+ */
+const resolveExplicitLineCount = ({ text }: { text?: string }): number => {
+  const textValue = typeof text === 'string' ? text : ''
+  return Math.max(textValue.split('\n').length, 1)
+}
+
+/**
+ * Возвращает число реально рассчитанных Fabric строк.
+ */
+const resolveRenderedLineCount = ({
+  textbox,
+  fallbackLineCount
+}: {
+  textbox: EditorTextbox
+  fallbackLineCount: number
+}): number => {
+  const { textLines } = textbox
+
+  return Array.isArray(textLines) && textLines.length > 0
+    ? textLines.length
+    : fallbackLineCount
+}
+
+/**
+ * Пересчитывает Fabric dimensions с явным управлением локальным правилом округления.
+ */
+const recalculateTextboxDimensions = ({
+  textbox,
+  shouldRoundDimensions
+}: {
+  textbox: EditorTextbox
+  shouldRoundDimensions: boolean
+}): void => {
+  const previousShouldRoundDimensionsOnInit = textbox.shouldRoundDimensionsOnInit
+
+  textbox.shouldRoundDimensionsOnInit = shouldRoundDimensions
+
+  try {
+    textbox.initDimensions()
+  } finally {
+    textbox.shouldRoundDimensionsOnInit = previousShouldRoundDimensionsOnInit
+  }
+}
+
+/**
+ * Возвращает максимальную ширину text-area для autoExpand внутри монтажной области.
+ */
+const resolveAutoExpandMaxWidth = ({
+  textbox,
+  canvasManager
+}: {
+  textbox: EditorTextbox
+  canvasManager: CanvasManager
+}): number => {
+  const { width: montageWidth } = canvasManager.getMontageAreaSceneBounds()
+  const scaleX = Math.abs(textbox.scaleX ?? 1) || 1
+  const paddingLeft = textbox.paddingLeft ?? 0
+  const paddingRight = textbox.paddingRight ?? 0
+  const strokeWidth = textbox.strokeWidth ?? 0
+
+  return Math.max(
+    1,
+    (montageWidth / scaleX) - paddingLeft - paddingRight - strokeWidth
+  )
+}
+
+/**
+ * При autoExpand сохраняет отсутствие soft-wrap во время пропорционального live-scale.
+ */
+const preserveScaledAutoExpandLineCount = ({
+  textbox,
+  canvasManager,
+  base,
+  committedWidth,
+  shouldScaleFontSize,
+  shouldRoundDimensions
+}: ScaledAutoExpandOptions): void => {
+  if (!shouldScaleFontSize) return
+  if (textbox.autoExpand === false) return
+
+  const explicitLineCount = base.explicitLineCount
+    ?? resolveExplicitLineCount({ text: textbox.text })
+  const renderedLineCount = base.renderedLineCount ?? explicitLineCount
+  if (renderedLineCount > explicitLineCount) return
+
+  const currentLineCount = resolveRenderedLineCount({
+    textbox,
+    fallbackLineCount: explicitLineCount
+  })
+  if (currentLineCount <= explicitLineCount) return
+
+  const currentWidth = textbox.width ?? committedWidth
+  const maxWidth = resolveAutoExpandMaxWidth({
+    textbox,
+    canvasManager
+  })
+  if (maxWidth <= currentWidth + DIMENSION_EPSILON) return
+
+  textbox.set({ width: maxWidth })
+  recalculateTextboxDimensions({
+    textbox,
+    shouldRoundDimensions
+  })
+
+  const text = typeof textbox.text === 'string' ? textbox.text : ''
+  const targetWidth = Math.min(
+    maxWidth,
+    Math.max(
+      currentWidth,
+      Math.ceil(getLongestLineWidth({ textbox, text }))
+    )
+  )
+
+  textbox.set({ width: targetWidth })
+  recalculateTextboxDimensions({
+    textbox,
+    shouldRoundDimensions
+  })
+}
+
 /**
  * Снимает с textbox базовое состояние, относительно которого можно материализовать transient scale.
  */
@@ -69,6 +201,11 @@ export const captureTextScaleBase = ({
 }): TextScaleBaseState => {
   const width = textbox.width ?? textbox.calcTextWidth()
   const fontSize = textbox.fontSize ?? 16
+  const explicitLineCount = resolveExplicitLineCount({ text: textbox.text })
+  const renderedLineCount = resolveRenderedLineCount({
+    textbox,
+    fallbackLineCount: explicitLineCount
+  })
   const { styles: textboxStyles = {} } = textbox
   const { lineFontDefaults } = textbox
   const {
@@ -87,6 +224,8 @@ export const captureTextScaleBase = ({
   return {
     width,
     fontSize,
+    explicitLineCount,
+    renderedLineCount,
     padding: {
       top: paddingTop,
       right: paddingRight,
@@ -292,15 +431,19 @@ export const commitStandaloneTextboxScale = (
     scaleY: 1
   })
 
-  const previousShouldRoundDimensionsOnInit = textbox.shouldRoundDimensionsOnInit
+  recalculateTextboxDimensions({
+    textbox,
+    shouldRoundDimensions
+  })
 
-  textbox.shouldRoundDimensionsOnInit = shouldRoundDimensions
-
-  try {
-    textbox.initDimensions()
-  } finally {
-    textbox.shouldRoundDimensionsOnInit = previousShouldRoundDimensionsOnInit
-  }
+  preserveScaledAutoExpandLineCount({
+    textbox,
+    canvasManager,
+    base,
+    committedWidth,
+    shouldScaleFontSize,
+    shouldRoundDimensions
+  })
 
   const dimensionsRounded = shouldRoundDimensions
     ? roundTextboxDimensions({ textbox })

--- a/src/editor/text-manager/types.ts
+++ b/src/editor/text-manager/types.ts
@@ -69,6 +69,7 @@ export type EditorTextbox = BackgroundTextbox & Partial<BackgroundTextboxProps> 
   autoExpand?: boolean
   __lineDefaultsPrevText?: string
   shouldRoundDimensionsOnInit?: boolean
+  textLines?: string[]
 }
 
 export type TextReference = string | EditorTextbox | null | undefined
@@ -158,6 +159,8 @@ export type LineFontDefaultUpdate = {
 export type TextScaleBaseState = {
   width: number
   fontSize: number
+  explicitLineCount?: number
+  renderedLineCount?: number
   styles: TextboxStyles
   lineFontDefaults?: LineFontDefaults
   padding: PaddingValues


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить тестовый объект с текстом "Новый текст" 54px как в шаблоне ниже (скрин 1)

<img width="528" height="511" alt="image" src="https://github.com/user-attachments/assets/c1d68798-f213-4402-99ef-85ac68d057b9" />

```json
{
  "id": "template-li-6iWreVuR-zClIK1_iN",
  "meta": {
    "baseWidth": 512,
    "baseHeight": 512,
    "positionsNormalized": true
  },
  "objects": [
    {
      "fontSize": 54.28960333834419,
      "fontWeight": "normal",
      "fontFamily": "Arial",
      "fontStyle": "normal",
      "lineHeight": 1.16,
      "text": "Новый текст",
      "charSpacing": 0,
      "textAlign": "left",
      "styles": [],
      "pathStartOffset": 0,
      "pathSide": "left",
      "pathAlign": "baseline",
      "underline": false,
      "overline": false,
      "linethrough": false,
      "textBackgroundColor": "",
      "direction": "ltr",
      "textDecorationThickness": 66.667,
      "minWidth": 20,
      "splitByGrapheme": false,
      "id": "background-textbox-X2r5MeYF_jIApB8Xk2RHd",
      "width": 313,
      "height": 133,
      "originX": "center",
      "originY": "center",
      "editable": true,
      "evented": true,
      "selectable": true,
      "lockMovementX": false,
      "lockMovementY": false,
      "lockRotation": false,
      "lockScalingX": false,
      "lockScalingY": false,
      "lockSkewingX": false,
      "lockSkewingY": false,
      "textCaseRaw": "Новый текст",
      "uppercase": false,
      "autoExpand": true,
      "backgroundOpacity": 1,
      "paddingTop": 0,
      "paddingRight": 0,
      "paddingBottom": 0,
      "paddingLeft": 0,
      "radiusTopLeft": 0,
      "radiusTopRight": 0,
      "radiusBottomRight": 0,
      "radiusBottomLeft": 0,
      "type": "background-textbox",
      "version": "7.2.0",
      "left": 0.5048828125000002,
      "top": 0.7562030782926384,
      "fill": "#000000",
      "stroke": null,
      "strokeWidth": 0,
      "strokeDashArray": null,
      "strokeLineCap": "butt",
      "strokeDashOffset": 0,
      "strokeLineJoin": "miter",
      "strokeUniform": true,
      "strokeMiterLimit": 4,
      "scaleX": 1,
      "scaleY": 1,
      "angle": 0,
      "flipX": false,
      "flipY": false,
      "opacity": 1,
      "shadow": null,
      "visible": true,
      "backgroundColor": "",
      "fillRule": "nonzero",
      "paintFirst": "fill",
      "globalCompositeOperation": "source-over",
      "skewX": 0,
      "skewY": 0,
      "_templateAnchorX": "center",
      "_templateAnchorY": "end"
    }
  ]
}
```

2. Выполнить уменьшение объекта путём скейлинга по диагонали за правый верхний угол

Ожидаемое поведение.

При скейлинге текст остаётся в одну строку и не прыгает в две строки, ничего не трясётся и не прыгает.

Фактический результат.

Во время уменьшения текст начинает перепрыгивать в две строки, а потом опять в одну, потом в две, всё происходит очень быстро и выглядит так как будто текст трясётся и увеличивается/уменьшается в размерах (Скрины 2-3)


<img width="508" height="532" alt="image" src="https://github.com/user-attachments/assets/6f0902a0-764a-43bd-8afa-67d9053e7942" />

<img width="672" height="502" alt="image" src="https://github.com/user-attachments/assets/876c1177-acf9-4b24-9f4f-9ebaf90161d2" />

---

FIXED. 