### PR TITLE
ObjectSizeIndicatorManager & CropManager. Фиксим проблему с отображением некорректных размеров кроп-области при скейлинге

### DIFF
--- a/e2e/models/crop.model.ts
+++ b/e2e/models/crop.model.ts
@@ -11,6 +11,18 @@ import type {
   ObjectTargetParams
 } from '../types'
 
+/** Последняя pointer-позиция live resize crop frame. */
+type CropResizePointer = {
+  x: number
+  y: number
+  shiftKey: boolean
+}
+
+/** Результат browser-side шага drag crop frame. */
+type CropResizeDragResult = {
+  point: CropResizePointer
+}
+
 /** Соответствие drag-control crop frame его фиксированному противоположному control. */
 const OPPOSITE_CROP_CONTROL = {
   tl: 'br',
@@ -25,6 +37,9 @@ const OPPOSITE_CROP_CONTROL = {
 
 export class CropModel {
   private readonly page: Page
+
+  /** Pointer-позиция последнего незавершённого resize crop frame. */
+  private lastResizePointer: CropResizePointer | null = null
 
   constructor(page: Page) {
     this.page = page
@@ -152,8 +167,57 @@ export class CropModel {
 
   /** Масштабирует crop-область из control через реальную Fabric drag-сессию. */
   async resizeFrameFromControl(params: CropResizeFromControlParams): Promise<CropStateInfo> {
-    const oppositeControl = OPPOSITE_CROP_CONTROL[params.control]
+    await this.dragFrameFromControl(params)
+
+    return this.finishFrameResize()
+  }
+
+  /** Тянет crop-область из control и оставляет Fabric drag-сессию активной. */
+  async dragFrameFromControl(params: CropResizeFromControlParams): Promise<CropStateInfo> {
+    const dragResult = await this.performFrameControlDrag(params)
+
+    this.lastResizePointer = dragResult.point
+    await waitForCanvasRender({ page: this.page })
+
+    return this.requireState()
+  }
+
+  /** Завершает активный resize crop frame через mouseup. */
+  async finishFrameResize(): Promise<CropStateInfo> {
+    const pointer = this.lastResizePointer
+
+    expect(pointer, 'должна существовать активная resize-сессия crop frame').not.toBeNull()
+    if (!pointer) {
+      throw new Error('Нельзя завершить resize crop frame без активной drag-сессии')
+    }
+
     const state = await this.page.evaluate((payload) => {
+      const { editor } = window as any
+
+      editor.canvas.__onMouseUp(new MouseEvent('mouseup', {
+        bubbles: true,
+        button: 0,
+        buttons: 0,
+        clientX: payload.x,
+        clientY: payload.y,
+        shiftKey: payload.shiftKey
+      }))
+
+      return editor.cropManager.getState()
+    }, pointer)
+
+    this.lastResizePointer = null
+
+    expect(state, 'после mouseup crop mode должен остаться активным').not.toBeNull()
+    await waitForCanvasRender({ page: this.page })
+
+    return this.requireState()
+  }
+
+  /** Выполняет browser-side drag crop-control и возвращает pointer для завершения drag. */
+  private async performFrameControlDrag(params: CropResizeFromControlParams): Promise<CropResizeDragResult> {
+    const oppositeControl = OPPOSITE_CROP_CONTROL[params.control]
+    const dragResult = await this.page.evaluate((payload) => {
       const {
         control,
         oppositeControl: opposite,
@@ -178,25 +242,26 @@ export class CropModel {
       })
       if (!result) return null
 
-      editor.canvas.__onMouseUp(new MouseEvent('mouseup', {
-        bubbles: true,
-        button: 0,
-        buttons: 0,
-        clientX: result.point.x,
-        clientY: result.point.y,
-        shiftKey
-      }))
+      if (!editor.cropManager.getState()) return null
 
-      return editor.cropManager.getState()
+      return {
+        point: {
+          x: result.point.x,
+          y: result.point.y,
+          shiftKey: result.shiftKey
+        }
+      }
     }, {
       ...params,
       oppositeControl
     })
 
-    expect(state, 'после resize crop mode должен остаться активным').not.toBeNull()
-    await waitForCanvasRender({ page: this.page })
+    expect(dragResult, 'после drag crop mode должен остаться активным').not.toBeNull()
+    if (!dragResult) {
+      throw new Error('Не удалось выполнить drag crop-control')
+    }
 
-    return this.requireState()
+    return dragResult
   }
 
   /** Кликает в центр canvas-объекта реальным mouse-событием. */

--- a/e2e/tests/crop-manager/crop-size-indicator.spec.ts
+++ b/e2e/tests/crop-manager/crop-size-indicator.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+
+/** Размер монтажной области, который используется в демо по умолчанию. */
+const DEFAULT_MONTAGE_SIZE = 512
+
+/** Стартовый размер crop-области для сценария растягивания до монтажной области. */
+const SMALLER_CROP_SIZE = 400
+
+/** Drag-target для сценария растягивания crop-области. */
+const LARGER_CROP_DRAG_TARGET_SIZE = 513
+
+/** Drag-target для сценария уменьшения crop-области. */
+const SHRUNK_CROP_DRAG_TARGET_SIZE = 372
+
+/** Итоговый размер crop-области из пользовательского сценария с off-by-one ошибкой. */
+const SHRUNK_CROP_SIZE = 371
+
+test.describe('Индикатор размеров crop-области', () => {
+  test('при растягивании crop-области показывает размер, который применится после crop', async({
+    editorModel,
+    crop
+  }) => {
+    await test.step('Войти в crop с областью меньше монтажной', async() => {
+      await crop.startCanvasCrop({
+        size: {
+          width: SMALLER_CROP_SIZE,
+          height: SMALLER_CROP_SIZE
+        }
+      })
+    })
+
+    const liveState = await test.step('Растянуть crop-область', async() => {
+      return crop.dragFrameFromControl({
+        control: 'br',
+        widthRatio: LARGER_CROP_DRAG_TARGET_SIZE / SMALLER_CROP_SIZE,
+        heightRatio: LARGER_CROP_DRAG_TARGET_SIZE / SMALLER_CROP_SIZE
+      })
+    })
+
+    const indicator = await test.step('Получить текст индикатора до mouseup', async() => {
+      return editorModel.requireObjectSizeIndicator()
+    })
+
+    await test.step('Завершить resize и применить crop', async() => {
+      await crop.finishFrameResize()
+      await crop.apply()
+    })
+
+    const montageAfter = await test.step('Получить размер монтажной области после crop', async() => {
+      return editorModel.getMontageArea()
+    })
+
+    await test.step('Проверить что индикатор совпал с применённым размером', () => {
+      expect(indicator.width).toBe(Math.round(liveState.rect.width))
+      expect(indicator.height).toBe(Math.round(liveState.rect.height))
+      expect(indicator.width).toBe(montageAfter.width)
+      expect(indicator.height).toBe(montageAfter.height)
+    })
+  })
+
+  test('при уменьшении crop-области показывает размер, который применится после crop', async({
+    editorModel,
+    crop
+  }) => {
+    await test.step('Войти в crop монтажной области', async() => {
+      await crop.startCanvasCrop()
+    })
+
+    const liveState = await test.step('Уменьшить crop-область до пользовательского размера', async() => {
+      return crop.dragFrameFromControl({
+        control: 'br',
+        widthRatio: SHRUNK_CROP_DRAG_TARGET_SIZE / DEFAULT_MONTAGE_SIZE,
+        heightRatio: SHRUNK_CROP_DRAG_TARGET_SIZE / DEFAULT_MONTAGE_SIZE
+      })
+    })
+
+    const indicator = await test.step('Получить текст индикатора до mouseup', async() => {
+      return editorModel.requireObjectSizeIndicator()
+    })
+
+    await test.step('Завершить resize и применить crop', async() => {
+      await crop.finishFrameResize()
+      await crop.apply()
+    })
+
+    const montageAfter = await test.step('Получить размер монтажной области после crop', async() => {
+      return editorModel.getMontageArea()
+    })
+
+    await test.step('Проверить что индикатор совпал с применённым размером', () => {
+      expect(indicator.width).toBe(Math.round(liveState.rect.width))
+      expect(indicator.height).toBe(Math.round(liveState.rect.height))
+      expect(montageAfter.width).toBe(SHRUNK_CROP_SIZE)
+      expect(montageAfter.height).toBe(SHRUNK_CROP_SIZE)
+      expect(indicator.width).toBe(montageAfter.width)
+      expect(indicator.height).toBe(montageAfter.height)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/ui/object-size-indicator/index.spec.ts
+++ b/specs/src/editor/ui/object-size-indicator/index.spec.ts
@@ -78,6 +78,29 @@ describe('ObjectSizeIndicatorManager', () => {
     expect(manager.el.textContent).toBe('ширина: 181 высота: 76')
   })
 
+  it('использует доменный размер объекта, если он отличается от visual bbox', () => {
+    const {
+      manager,
+      mockCanvas,
+      target
+    } = createObjectSizeIndicatorManagerFixture({
+      width: 513,
+      height: 513,
+      indicatorSize: {
+        width: 512,
+        height: 512
+      }
+    })
+
+    getCanvasHandler(mockCanvas, 'object:scaling')(createObjectSizeTransformEvent({ target }))
+
+    expect(manager.el.style.display).toBe('block')
+    expect(manager.el.textContent).toBe('ширина: 512 высота: 512')
+    expect(target.getObjectDisplaySize).toHaveBeenCalledTimes(1)
+    expect(target.getScaledWidth).not.toHaveBeenCalled()
+    expect(target.getScaledHeight).not.toHaveBeenCalled()
+  })
+
   it('не показывает индикатор на mouse:move, если активная трансформация не меняет размер', () => {
     const {
       manager,

--- a/specs/test-utils/ui/indicator-test-utils.ts
+++ b/specs/test-utils/ui/indicator-test-utils.ts
@@ -21,6 +21,7 @@ export interface ObjectSizeIndicatorTargetStub {
   lockScalingY?: boolean
   getScaledWidth: jest.Mock<number, []>
   getScaledHeight: jest.Mock<number, []>
+  getObjectDisplaySize?: jest.Mock<{ width: number; height: number }, []>
 }
 
 /** Минимальная форма Fabric transform event, нужная ObjectSizeIndicatorManager. */
@@ -114,6 +115,7 @@ export const createObjectSizeIndicatorTarget = ({
   id = 'test-object',
   width = 120,
   height = 80,
+  indicatorSize,
   locked = false,
   lockScalingX = false,
   lockScalingY = false
@@ -121,25 +123,36 @@ export const createObjectSizeIndicatorTarget = ({
   id?: string
   width?: number
   height?: number
+  indicatorSize?: { width: number; height: number }
   locked?: boolean
   lockScalingX?: boolean
   lockScalingY?: boolean
-} = {}): ObjectSizeIndicatorTargetStub => ({
-  id,
-  locked,
-  lockScalingX,
-  lockScalingY,
-  getScaledWidth: jest.fn(() => width),
-  getScaledHeight: jest.fn(() => height)
-})
+} = {}): ObjectSizeIndicatorTargetStub => {
+  const target: ObjectSizeIndicatorTargetStub = {
+    id,
+    locked,
+    lockScalingX,
+    lockScalingY,
+    getScaledWidth: jest.fn(() => width),
+    getScaledHeight: jest.fn(() => height)
+  }
+
+  if (indicatorSize) {
+    target.getObjectDisplaySize = jest.fn(() => indicatorSize)
+  }
+
+  return target
+}
 
 /** Создаёт ObjectSizeIndicatorManager с минимальными editor/canvas mocks. */
 export const createObjectSizeIndicatorManagerFixture = ({
   width,
-  height
+  height,
+  indicatorSize
 }: {
   width?: number
   height?: number
+  indicatorSize?: { width: number; height: number }
 } = {}): ObjectSizeIndicatorManagerTestFixture => {
   const {
     mockCanvas,
@@ -147,7 +160,7 @@ export const createObjectSizeIndicatorManagerFixture = ({
   } = createManagerTestMocks()
   mockEditor.options.showObjectSizeOnScale = true
 
-  const target = createObjectSizeIndicatorTarget({ width, height })
+  const target = createObjectSizeIndicatorTarget({ width, height, indicatorSize })
   const manager = new ObjectSizeIndicatorManager({ editor: mockEditor })
   mockElementBounds({
     element: manager.el,

--- a/src/editor/crop-manager/domain/crop-frame-size.ts
+++ b/src/editor/crop-manager/domain/crop-frame-size.ts
@@ -1,0 +1,32 @@
+import type { FabricObject } from 'fabric'
+
+import type { CropSize } from '../types'
+
+/**
+ * Crop frame хранит scale источника, чтобы считать отображаемый размер в source-пикселях.
+ */
+interface CropFrameSizeTarget extends FabricObject {
+  cropSourceScaleX?: number
+  cropSourceScaleY?: number
+}
+
+/**
+ * Возвращает размер crop frame в локальных пикселях источника без stroke.
+ */
+export function getCropFrameSourceSize({
+  frame,
+  scaleX = frame.scaleX ?? 1,
+  scaleY = frame.scaleY ?? 1
+}: {
+  frame: CropFrameSizeTarget
+  scaleX?: number
+  scaleY?: number
+}): CropSize {
+  const sourceScaleX = Math.abs(frame.cropSourceScaleX ?? 1) || 1
+  const sourceScaleY = Math.abs(frame.cropSourceScaleY ?? 1) || 1
+
+  return {
+    width: Math.max(1, (frame.width * Math.abs(scaleX)) / sourceScaleX),
+    height: Math.max(1, (frame.height * Math.abs(scaleY)) / sourceScaleY)
+  }
+}

--- a/src/editor/crop-manager/domain/crop-frame.ts
+++ b/src/editor/crop-manager/domain/crop-frame.ts
@@ -7,6 +7,7 @@ import {
 import { nanoid } from 'nanoid'
 
 import { applyCropResizeControls } from '../interaction/crop-controls'
+import { getCropFrameSourceSize } from './crop-frame-size'
 import type { CropSize } from '../types'
 
 /**
@@ -72,6 +73,13 @@ export class CropFrame extends Rect {
       width: this.width,
       height: this.height
     })
+  }
+
+  /**
+   * Возвращает размер crop frame, который совпадает с результатом применения crop.
+   */
+  public getObjectDisplaySize(): CropSize {
+    return getCropFrameSourceSize({ frame: this })
   }
 }
 

--- a/src/editor/crop-manager/interaction/crop-controls.ts
+++ b/src/editor/crop-manager/interaction/crop-controls.ts
@@ -12,6 +12,7 @@ import {
   MIN_CROP_FRAME_HEIGHT,
   MIN_CROP_FRAME_WIDTH
 } from '../domain/crop-geometry'
+import { getCropFrameSourceSize } from '../domain/crop-frame-size'
 
 /**
  * Угловые controls, которые отвечают за диагональный resize crop frame.
@@ -428,8 +429,8 @@ function clampProportionalCornerScale({
   scale: number
   forceMinimum: boolean
 }): { scaleX: number; scaleY: number } {
-  const startSize = getCropFrameLocalSize({
-    target,
+  const startSize = getCropFrameSourceSize({
+    frame: target,
     scaleX: transform.original.scaleX,
     scaleY: transform.original.scaleY
   })
@@ -452,28 +453,6 @@ function clampProportionalCornerScale({
   return {
     scaleX: transform.original.scaleX * nextScale,
     scaleY: transform.original.scaleY * nextScale
-  }
-}
-
-/**
- * Возвращает crop-размер frame в локальных пикселях источника.
- */
-function getCropFrameLocalSize({
-  target,
-  scaleX,
-  scaleY
-}: {
-  target: FabricObject
-  scaleX: number
-  scaleY: number
-}): { width: number; height: number } {
-  const cropTarget = target as CropFrameScaleTarget
-  const sourceScaleX = Math.abs(cropTarget.cropSourceScaleX ?? 1) || 1
-  const sourceScaleY = Math.abs(cropTarget.cropSourceScaleY ?? 1) || 1
-
-  return {
-    width: Math.max(1, (target.width * Math.abs(scaleX)) / sourceScaleX),
-    height: Math.max(1, (target.height * Math.abs(scaleY)) / sourceScaleY)
   }
 }
 

--- a/src/editor/types/fabric-extensions.d.ts
+++ b/src/editor/types/fabric-extensions.d.ts
@@ -388,6 +388,12 @@ declare module 'fabric' {
      * Роль объекта внутри shape-группы.
      */
     shapeNodeType?: 'shape' | 'text';
+
+    /**
+     * Возвращает текущий доменный размер объекта в editor-пикселях.
+     * Используется объектами, у которых итоговый доменный размер отличается от visual bbox.
+     */
+    getObjectDisplaySize?(): { width: number; height: number };
   }
 
   interface RectProps {

--- a/src/editor/ui/object-size-indicator/index.ts
+++ b/src/editor/ui/object-size-indicator/index.ts
@@ -185,8 +185,26 @@ export default class ObjectSizeIndicatorManager {
    * Возвращает текущие размеры объекта с учётом live-scale, но без screen zoom.
    */
   private static _resolveDisplaySize({ target }: { target: FabricObject }): ObjectDisplaySize | null {
-    const width = Math.abs(target.getScaledWidth())
-    const height = Math.abs(target.getScaledHeight())
+    const customSize = target.getObjectDisplaySize?.()
+
+    if (customSize) {
+      return ObjectSizeIndicatorManager._normalizeDisplaySize({ size: customSize })
+    }
+
+    return ObjectSizeIndicatorManager._normalizeDisplaySize({
+      size: {
+        width: target.getScaledWidth(),
+        height: target.getScaledHeight()
+      }
+    })
+  }
+
+  /**
+   * Нормализует размер перед показом в индикаторе.
+   */
+  private static _normalizeDisplaySize({ size }: { size: ObjectDisplaySize }): ObjectDisplaySize | null {
+    const width = Math.abs(size.width)
+    const height = Math.abs(size.height)
 
     if (!Number.isFinite(width) || !Number.isFinite(height)) return null
 


### PR DESCRIPTION

Сейчас могут быть ситуации когда индикатор показывает размеры больше на 1px. Особенно это заметно при кроппинге объектов через CropManager. Например, если монтажная область имеет размеры 512х512px, то при ресайзе кроп-области мы будем показывать 513х513 px (скрин 1)

<img width="1919" height="815" alt="image" src="https://github.com/user-attachments/assets/cf4da83f-45aa-4c8f-9761-847160e6b33d" />

Второй пример, если уменьшить кроп-область до 372х372 px, то при применении кропа получим размеры 371х371 px (скрины 2-3)

<img width="1918" height="761" alt="image" src="https://github.com/user-attachments/assets/eeabf890-1cca-4aa3-9372-9adaaeddd8e5" />

<img width="1919" height="759" alt="image" src="https://github.com/user-attachments/assets/b9ae885c-5631-43ee-9983-9cff2b663b21" />

---

FIXED.