### PR TITLE
CropManager. Убираем лишний шаг в 1px при скейлинге кроп-области в состоянии прилипания к краю монтажной области

### DIFF
--- a/e2e/fixtures/data/crop-size-indicator.data.ts
+++ b/e2e/fixtures/data/crop-size-indicator.data.ts
@@ -1,0 +1,96 @@
+import type { CropControlKey } from '../../types'
+
+/** Размер монтажной области, который используется в демо по умолчанию. */
+export const DEFAULT_MONTAGE_SIZE = 512
+
+/** Стартовый размер crop-области для сценария растягивания до монтажной области. */
+export const SMALLER_CROP_SIZE = 400
+
+/** Размер crop-области, до которого пользователь растягивает область в live-сценарии. */
+export const LARGER_CROP_TARGET_SIZE = 513
+
+/** Размер crop-области, до которого пользователь уменьшает область в live-сценарии. */
+export const SHRUNK_CROP_TARGET_SIZE = 372
+
+/** Размер монтажной области для проверки поведения около snap-порога. */
+export const SNAP_THRESHOLD_MONTAGE_SIZE = 1024
+
+/** Размер, который находится внутри snap-порога от края монтажной области. */
+export const CROP_SIZE_INSIDE_SNAP_THRESHOLD = 1023
+
+/** Snap-порог SnappingManager в экранных пикселях. */
+export const SNAP_THRESHOLD_SCREEN_PIXELS = 5
+
+/** Дополнительный отступ за snap-порогом, чтобы drag гарантированно вышел из прилипания. */
+export const SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS = 2
+
+/** Размеры монтажной области, на которых полный crop не должен терять пиксель. */
+export const FULL_CROP_MONTAGE_SIZES = [
+  {
+    width: 1027,
+    height: 1027
+  },
+  {
+    width: 767,
+    height: 768
+  },
+  {
+    width: 1024,
+    height: 1025
+  },
+  {
+    width: 2048,
+    height: 2049
+  }
+] as const
+
+/** Угловые controls для проверки выхода полного crop из snap-порога. */
+export const FULL_CROP_SNAP_THRESHOLD_CORNER_CASES = [
+  {
+    control: 'tl',
+    title: 'левого верхнего угла'
+  },
+  {
+    control: 'tr',
+    title: 'правого верхнего угла'
+  },
+  {
+    control: 'bl',
+    title: 'левого нижнего угла'
+  },
+  {
+    control: 'br',
+    title: 'правого нижнего угла'
+  }
+] as const satisfies ReadonlyArray<{
+  control: CropControlKey
+  title: string
+}>
+
+/** Боковые controls для проверки выхода полного crop из snap-порога по одной оси. */
+export const FULL_CROP_SNAP_THRESHOLD_SIDE_CASES = [
+  {
+    control: 'ml',
+    title: 'левой стороны',
+    axis: 'horizontal'
+  },
+  {
+    control: 'mr',
+    title: 'правой стороны',
+    axis: 'horizontal'
+  },
+  {
+    control: 'mt',
+    title: 'верхней стороны',
+    axis: 'vertical'
+  },
+  {
+    control: 'mb',
+    title: 'нижней стороны',
+    axis: 'vertical'
+  }
+] as const satisfies ReadonlyArray<{
+  control: CropControlKey
+  title: string
+  axis: 'horizontal' | 'vertical'
+}>

--- a/e2e/models/crop.model.ts
+++ b/e2e/models/crop.model.ts
@@ -6,6 +6,7 @@ import type {
   CropControlKey,
   CropImageSourceInfo,
   CropResizeFromControlParams,
+  CropSizeInfo,
   CropStartParams,
   CropStateInfo,
   ObjectTargetParams
@@ -21,6 +22,18 @@ type CropResizePointer = {
 /** Результат browser-side шага drag crop frame. */
 type CropResizeDragResult = {
   point: CropResizePointer
+}
+
+/** Параметры browser-side drag crop frame с управлением live-сессией. */
+type CropFrameControlDragParams = CropResizeFromControlParams & {
+  continueInteraction?: boolean
+}
+
+/** Параметры resize crop frame до целевого размера результата. */
+type CropFrameResizeToSizeParams = {
+  control: CropControlKey
+  size: CropSizeInfo
+  shiftKey?: boolean
 }
 
 /** Соответствие drag-control crop frame его фиксированному противоположному control. */
@@ -182,6 +195,33 @@ export class CropModel {
     return this.requireState()
   }
 
+  /** Тянет crop-область из control до целевого результата в source-пикселях. */
+  async dragFrameFromControlToSize(params: CropFrameResizeToSizeParams): Promise<CropStateInfo> {
+    const resizeParams = await this.resolveResizeFromSize(params)
+
+    return this.dragFrameFromControl(resizeParams)
+  }
+
+  /** Продолжает активный drag crop-control без нового mousedown. */
+  async continueFrameResizeFromControl(params: CropResizeFromControlParams): Promise<CropStateInfo> {
+    const dragResult = await this.performFrameControlDrag({
+      ...params,
+      continueInteraction: true
+    })
+
+    this.lastResizePointer = dragResult.point
+    await waitForCanvasRender({ page: this.page })
+
+    return this.requireState()
+  }
+
+  /** Продолжает активный drag crop-control до целевого результата в source-пикселях. */
+  async continueFrameResizeFromControlToSize(params: CropFrameResizeToSizeParams): Promise<CropStateInfo> {
+    const resizeParams = await this.resolveResizeFromSize(params)
+
+    return this.continueFrameResizeFromControl(resizeParams)
+  }
+
   /** Завершает активный resize crop frame через mouseup. */
   async finishFrameResize(): Promise<CropStateInfo> {
     const pointer = this.lastResizePointer
@@ -215,7 +255,7 @@ export class CropModel {
   }
 
   /** Выполняет browser-side drag crop-control и возвращает pointer для завершения drag. */
-  private async performFrameControlDrag(params: CropResizeFromControlParams): Promise<CropResizeDragResult> {
+  private async performFrameControlDrag(params: CropFrameControlDragParams): Promise<CropResizeDragResult> {
     const oppositeControl = OPPOSITE_CROP_CONTROL[params.control]
     const dragResult = await this.page.evaluate((payload) => {
       const {
@@ -223,7 +263,8 @@ export class CropModel {
         oppositeControl: opposite,
         widthRatio,
         heightRatio,
-        shiftKey = false
+        shiftKey = false,
+        continueInteraction = false
       } = payload
       const {
         editor,
@@ -238,7 +279,8 @@ export class CropModel {
         oppositeControl: opposite,
         scaleX: widthRatio,
         scaleY: heightRatio,
-        shiftKey
+        shiftKey,
+        continueInteraction
       })
       if (!result) return null
 
@@ -333,5 +375,30 @@ export class CropModel {
     }
 
     return state
+  }
+
+  /** Преобразует желаемый размер результата crop в ratio-параметры resize control. */
+  private async resolveResizeFromSize(params: CropFrameResizeToSizeParams): Promise<CropResizeFromControlParams> {
+    const state = await this.requireState()
+    const {
+      control,
+      size,
+      shiftKey
+    } = params
+    const { width, height } = state.rect
+
+    expect(width, 'текущая ширина crop frame должна быть больше нуля').toBeGreaterThan(0)
+    expect(height, 'текущая высота crop frame должна быть больше нуля').toBeGreaterThan(0)
+
+    if (width <= 0 || height <= 0) {
+      throw new Error('Текущий размер crop frame должен быть больше нуля')
+    }
+
+    return {
+      control,
+      widthRatio: size.width / width,
+      heightRatio: size.height / height,
+      shiftKey
+    }
   }
 }

--- a/e2e/tests/crop-manager/crop-size-indicator.spec.ts
+++ b/e2e/tests/crop-manager/crop-size-indicator.spec.ts
@@ -1,36 +1,17 @@
 import { test, expect } from '../../fixtures/editor.fixture'
-
-/** Размер монтажной области, который используется в демо по умолчанию. */
-const DEFAULT_MONTAGE_SIZE = 512
-
-/** Стартовый размер crop-области для сценария растягивания до монтажной области. */
-const SMALLER_CROP_SIZE = 400
-
-/** Drag-target для сценария растягивания crop-области. */
-const LARGER_CROP_DRAG_TARGET_SIZE = 513
-
-/** Drag-target для сценария уменьшения crop-области. */
-const SHRUNK_CROP_DRAG_TARGET_SIZE = 372
-
-/** Размеры монтажной области, на которых полный crop не должен терять пиксель. */
-const FULL_CROP_MONTAGE_SIZES = [
-  {
-    width: 1027,
-    height: 1027
-  },
-  {
-    width: 767,
-    height: 768
-  },
-  {
-    width: 1024,
-    height: 1025
-  },
-  {
-    width: 2048,
-    height: 2049
-  }
-] as const
+import {
+  CROP_SIZE_INSIDE_SNAP_THRESHOLD,
+  DEFAULT_MONTAGE_SIZE,
+  FULL_CROP_MONTAGE_SIZES,
+  FULL_CROP_SNAP_THRESHOLD_CORNER_CASES,
+  FULL_CROP_SNAP_THRESHOLD_SIDE_CASES,
+  LARGER_CROP_TARGET_SIZE,
+  SHRUNK_CROP_TARGET_SIZE,
+  SMALLER_CROP_SIZE,
+  SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS,
+  SNAP_THRESHOLD_MONTAGE_SIZE,
+  SNAP_THRESHOLD_SCREEN_PIXELS
+} from '../../fixtures/data/crop-size-indicator.data'
 
 test.describe('Индикатор размеров crop-области', () => {
   test('при растягивании crop-области показывает размер, который применится после crop', async({
@@ -47,10 +28,12 @@ test.describe('Индикатор размеров crop-области', () => {
     })
 
     const liveState = await test.step('Растянуть crop-область', async() => {
-      return crop.dragFrameFromControl({
+      return crop.dragFrameFromControlToSize({
         control: 'br',
-        widthRatio: LARGER_CROP_DRAG_TARGET_SIZE / SMALLER_CROP_SIZE,
-        heightRatio: LARGER_CROP_DRAG_TARGET_SIZE / SMALLER_CROP_SIZE
+        size: {
+          width: LARGER_CROP_TARGET_SIZE,
+          height: LARGER_CROP_TARGET_SIZE
+        }
       })
     })
 
@@ -84,10 +67,12 @@ test.describe('Индикатор размеров crop-области', () => {
     })
 
     const liveState = await test.step('Уменьшить crop-область до пользовательского размера', async() => {
-      return crop.dragFrameFromControl({
+      return crop.dragFrameFromControlToSize({
         control: 'br',
-        widthRatio: SHRUNK_CROP_DRAG_TARGET_SIZE / DEFAULT_MONTAGE_SIZE,
-        heightRatio: SHRUNK_CROP_DRAG_TARGET_SIZE / DEFAULT_MONTAGE_SIZE
+        size: {
+          width: SHRUNK_CROP_TARGET_SIZE,
+          height: SHRUNK_CROP_TARGET_SIZE
+        }
       })
     })
 
@@ -107,11 +92,177 @@ test.describe('Индикатор размеров crop-области', () => {
     await test.step('Проверить что индикатор совпал с применённым размером', () => {
       expect(indicator.width).toBe(Math.round(liveState.rect.width))
       expect(indicator.height).toBe(Math.round(liveState.rect.height))
-      expect(montageAfter.width).toBe(SHRUNK_CROP_DRAG_TARGET_SIZE)
-      expect(montageAfter.height).toBe(SHRUNK_CROP_DRAG_TARGET_SIZE)
+      expect(montageAfter.width).toBe(SHRUNK_CROP_TARGET_SIZE)
+      expect(montageAfter.height).toBe(SHRUNK_CROP_TARGET_SIZE)
       expect(indicator.width).toBe(montageAfter.width)
       expect(indicator.height).toBe(montageAfter.height)
     })
+  })
+
+  test.describe('уменьшение полного crop около snap-порога', () => {
+    test.beforeEach(async({ canvas, crop }) => {
+      await canvas.setMontageResolution({
+        width: SNAP_THRESHOLD_MONTAGE_SIZE,
+        height: SNAP_THRESHOLD_MONTAGE_SIZE
+      })
+
+      await crop.startCanvasCrop()
+    })
+
+    for (const cropCase of FULL_CROP_SNAP_THRESHOLD_CORNER_CASES) {
+      test(`при уменьшении полного crop из ${cropCase.title} внутри snap-порога не показывает минус один пиксель`, async({
+        editorModel,
+        crop
+      }) => {
+        const heldState = await test.step('Уменьшить crop внутри snap-порога', async() => {
+          return crop.dragFrameFromControlToSize({
+            control: cropCase.control,
+            size: {
+              width: CROP_SIZE_INSIDE_SNAP_THRESHOLD,
+              height: CROP_SIZE_INSIDE_SNAP_THRESHOLD
+            }
+          })
+        })
+
+        const heldIndicator = await test.step('Получить индикатор пока snap держит край', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        const canvasState = await test.step('Получить текущий zoom canvas', async() => {
+          return editorModel.getCanvasState()
+        })
+        expect(canvasState.zoom).toBeGreaterThan(0)
+        if (canvasState.zoom <= 0) {
+          throw new Error('Zoom canvas должен быть больше нуля для расчёта snap-порога')
+        }
+
+        const snapThresholdInSourcePixels = Math.ceil(SNAP_THRESHOLD_SCREEN_PIXELS / canvasState.zoom)
+        const cropSizeOutsideSnapThreshold = SNAP_THRESHOLD_MONTAGE_SIZE
+          - snapThresholdInSourcePixels
+          - SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS
+
+        const releasedState = await test.step('Продолжить уменьшение crop за snap-порог', async() => {
+          return crop.continueFrameResizeFromControlToSize({
+            control: cropCase.control,
+            size: {
+              width: cropSizeOutsideSnapThreshold,
+              height: cropSizeOutsideSnapThreshold
+            }
+          })
+        })
+
+        const releasedIndicator = await test.step('Получить индикатор после выхода из snap-порога', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize', async() => {
+          await crop.finishFrameResize()
+        })
+
+        await test.step('Проверить удержание и выход из snap-порога', () => {
+          expect(Math.round(heldState.rect.width)).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(Math.round(heldState.rect.height)).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(heldIndicator.width).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(heldIndicator.height).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(Math.round(releasedState.rect.width)).toBeLessThanOrEqual(
+            SNAP_THRESHOLD_MONTAGE_SIZE - snapThresholdInSourcePixels
+          )
+          expect(Math.round(releasedState.rect.height)).toBeLessThanOrEqual(
+            SNAP_THRESHOLD_MONTAGE_SIZE - snapThresholdInSourcePixels
+          )
+          expect(releasedIndicator.width).toBe(Math.round(releasedState.rect.width))
+          expect(releasedIndicator.height).toBe(Math.round(releasedState.rect.height))
+        })
+      })
+    }
+
+    for (const cropCase of FULL_CROP_SNAP_THRESHOLD_SIDE_CASES) {
+      test(`при уменьшении полного crop из ${cropCase.title} внутри snap-порога не показывает минус один пиксель по активной оси`, async({
+        editorModel,
+        crop
+      }) => {
+        const heldSize = cropCase.axis === 'horizontal'
+          ? {
+            width: CROP_SIZE_INSIDE_SNAP_THRESHOLD,
+            height: SNAP_THRESHOLD_MONTAGE_SIZE
+          }
+          : {
+            width: SNAP_THRESHOLD_MONTAGE_SIZE,
+            height: CROP_SIZE_INSIDE_SNAP_THRESHOLD
+          }
+
+        const heldState = await test.step('Уменьшить crop внутри snap-порога', async() => {
+          return crop.dragFrameFromControlToSize({
+            control: cropCase.control,
+            size: heldSize
+          })
+        })
+
+        const heldIndicator = await test.step('Получить индикатор пока snap держит край', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        const canvasState = await test.step('Получить текущий zoom canvas', async() => {
+          return editorModel.getCanvasState()
+        })
+        expect(canvasState.zoom).toBeGreaterThan(0)
+        if (canvasState.zoom <= 0) {
+          throw new Error('Zoom canvas должен быть больше нуля для расчёта snap-порога')
+        }
+
+        const snapThresholdInSourcePixels = Math.ceil(SNAP_THRESHOLD_SCREEN_PIXELS / canvasState.zoom)
+        const cropSizeOutsideSnapThreshold = SNAP_THRESHOLD_MONTAGE_SIZE
+          - snapThresholdInSourcePixels
+          - SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS
+        const releasedSize = cropCase.axis === 'horizontal'
+          ? {
+            width: cropSizeOutsideSnapThreshold,
+            height: SNAP_THRESHOLD_MONTAGE_SIZE
+          }
+          : {
+            width: SNAP_THRESHOLD_MONTAGE_SIZE,
+            height: cropSizeOutsideSnapThreshold
+          }
+
+        const releasedState = await test.step('Продолжить уменьшение crop за snap-порог', async() => {
+          return crop.continueFrameResizeFromControlToSize({
+            control: cropCase.control,
+            size: releasedSize
+          })
+        })
+
+        const releasedIndicator = await test.step('Получить индикатор после выхода из snap-порога', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize', async() => {
+          await crop.finishFrameResize()
+        })
+
+        await test.step('Проверить удержание и выход из snap-порога по активной оси', () => {
+          expect(Math.round(heldState.rect.width)).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(Math.round(heldState.rect.height)).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(heldIndicator.width).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(heldIndicator.height).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(releasedIndicator.width).toBe(Math.round(releasedState.rect.width))
+          expect(releasedIndicator.height).toBe(Math.round(releasedState.rect.height))
+
+          if (cropCase.axis === 'horizontal') {
+            expect(Math.round(releasedState.rect.width)).toBeLessThanOrEqual(
+              SNAP_THRESHOLD_MONTAGE_SIZE - snapThresholdInSourcePixels
+            )
+            expect(Math.round(releasedState.rect.height)).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+
+            return
+          }
+
+          expect(Math.round(releasedState.rect.width)).toBe(SNAP_THRESHOLD_MONTAGE_SIZE)
+          expect(Math.round(releasedState.rect.height)).toBeLessThanOrEqual(
+            SNAP_THRESHOLD_MONTAGE_SIZE - snapThresholdInSourcePixels
+          )
+        })
+      })
+    }
   })
 
   for (const montageSize of FULL_CROP_MONTAGE_SIZES) {
@@ -129,10 +280,9 @@ test.describe('Индикатор размеров crop-области', () => {
       })
 
       const liveState = await test.step('Потянуть crop-область без изменения полного размера', async() => {
-        return crop.dragFrameFromControl({
+        return crop.dragFrameFromControlToSize({
           control: 'br',
-          widthRatio: 1,
-          heightRatio: 1
+          size: montageSize
         })
       })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/__mocks__/fabric.ts
+++ b/specs/__mocks__/fabric.ts
@@ -14,6 +14,16 @@ export class Point {
   scalarAdd(value: number) {
     return new Point(this.x + value, this.y + value)
   }
+
+  /** Применяет 2D affine matrix так же, как Point.transform в Fabric. */
+  transform(matrix: [number, number, number, number, number, number]) {
+    const [a, b, c, d, e, f] = matrix
+
+    return new Point(
+      (this.x * a) + (this.y * c) + e,
+      (this.x * b) + (this.y * d) + f
+    )
+  }
 }
 
 export class Canvas {

--- a/specs/src/editor/crop-manager/crop-frame.spec.ts
+++ b/specs/src/editor/crop-manager/crop-frame.spec.ts
@@ -41,4 +41,31 @@ describe('crop frame', () => {
     expect(context.stroke).not.toHaveBeenCalled()
     expect(context.restore).not.toHaveBeenCalled()
   })
+
+  it('возвращает snapping bounds без учёта stroke и control padding', () => {
+    const frame = new CropFrame({
+      left: 200,
+      top: 150,
+      width: 100,
+      height: 60,
+      scaleX: 2,
+      scaleY: 0.5,
+      originX: 'center',
+      originY: 'center',
+      strokeWidth: 12,
+      strokeUniform: true,
+      showGrid: false
+    })
+
+    frame.calcTransformMatrix = jest.fn(() => [2, 0, 0, 0.5, 200, 150])
+
+    const bounds = frame.getObjectSnappingBounds()
+
+    expect(bounds.left).toBe(100)
+    expect(bounds.right).toBe(300)
+    expect(bounds.top).toBe(135)
+    expect(bounds.bottom).toBe(165)
+    expect(bounds.centerX).toBe(200)
+    expect(bounds.centerY).toBe(150)
+  })
 })

--- a/specs/src/editor/utils/geometry.spec.ts
+++ b/specs/src/editor/utils/geometry.spec.ts
@@ -74,6 +74,55 @@ describe('getObjectBounds', () => {
     expect(bounds?.centerY).toBe(20 + 15)
   })
 
+  it('использует кастомные snapping bounds объекта вместо visual bbox', () => {
+    const obj = createBoundsObject({ left: 10, top: 20, width: 50, height: 30 })
+    const customBounds = {
+      left: 100,
+      right: 200,
+      top: 300,
+      bottom: 360,
+      centerX: 150,
+      centerY: 330
+    }
+
+    obj.getObjectSnappingBounds = jest.fn(() => customBounds)
+
+    const bounds = getObjectBounds({ object: obj })
+
+    expect(bounds).toEqual(customBounds)
+    expect(obj.getObjectSnappingBounds).toHaveBeenCalledTimes(1)
+    expect(obj.getBoundingRect).not.toHaveBeenCalled()
+    expect(obj.setCoords).not.toHaveBeenCalled()
+  })
+
+  it('возвращается к visual bbox, если кастомные snapping bounds невалидны', () => {
+    const obj = createBoundsObject({ left: 0, top: 0, width: 50, height: 30 })
+
+    obj.getObjectSnappingBounds = jest.fn(() => ({
+      left: Number.NaN,
+      right: 40,
+      top: 50,
+      bottom: 80,
+      centerX: 20,
+      centerY: 65
+    }))
+    obj.getBoundingRect.mockReturnValue({ left: 12.4, top: 24.2, width: 30.6, height: 19.6 })
+
+    const bounds = getObjectBounds({ object: obj })
+
+    expect(bounds).toEqual({
+      left: 12.4,
+      right: 43.4,
+      top: 24.2,
+      bottom: 44.2,
+      centerX: 27.9,
+      centerY: 34.2
+    })
+    expect(obj.getObjectSnappingBounds).toHaveBeenCalledTimes(1)
+    expect(obj.getBoundingRect).toHaveBeenCalledTimes(1)
+    expect(obj.setCoords).toHaveBeenCalledTimes(1)
+  })
+
   it('возвращает null при ошибке в getBoundingRect', () => {
     const obj: any = {
       setCoords: jest.fn(),

--- a/src/editor/crop-manager/domain/crop-frame.ts
+++ b/src/editor/crop-manager/domain/crop-frame.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-use-before-define -- Public CropFrame держим выше private drawing helpers. */
 import {
+  Point,
   Rect,
   type FabricObject,
   type RectProps
@@ -8,6 +9,7 @@ import { nanoid } from 'nanoid'
 
 import { applyCropResizeControls } from '../interaction/crop-controls'
 import { getCropFrameSourceSize } from './crop-frame-size'
+import type { ObjectBounds } from '../../utils/geometry'
 import type { CropSize } from '../types'
 
 /**
@@ -80,6 +82,13 @@ export class CropFrame extends Rect {
    */
   public getObjectDisplaySize(): CropSize {
     return getCropFrameSourceSize({ frame: this })
+  }
+
+  /**
+   * Возвращает bounds crop frame без stroke, потому что snapping должен работать по crop-результату.
+   */
+  public getObjectSnappingBounds(): ObjectBounds {
+    return getCropFrameBoundsWithoutStroke({ frame: this })
   }
 }
 
@@ -180,6 +189,42 @@ function drawVerticalGridLine({
   ctx.moveTo(x, -height / 2)
   ctx.lineTo(x, height / 2)
   ctx.stroke()
+}
+
+/**
+ * Возвращает canvas-bounds crop frame без stroke и control padding.
+ */
+function getCropFrameBoundsWithoutStroke({ frame }: { frame: CropFrame }): ObjectBounds {
+  const matrix = frame.calcTransformMatrix()
+  const halfWidth = frame.width / 2
+  const halfHeight = frame.height / 2
+  const points = [
+    new Point(-halfWidth, -halfHeight),
+    new Point(halfWidth, -halfHeight),
+    new Point(halfWidth, halfHeight),
+    new Point(-halfWidth, halfHeight)
+  ].map((point) => point.transform(matrix))
+
+  return getBoundsFromPoints({ points })
+}
+
+/**
+ * Возвращает bounds по набору canvas-точек.
+ */
+function getBoundsFromPoints({ points }: { points: Point[] }): ObjectBounds {
+  const left = Math.min(...points.map((point) => point.x))
+  const right = Math.max(...points.map((point) => point.x))
+  const top = Math.min(...points.map((point) => point.y))
+  const bottom = Math.max(...points.map((point) => point.y))
+
+  return {
+    left,
+    right,
+    top,
+    bottom,
+    centerX: left + ((right - left) / 2),
+    centerY: top + ((bottom - top) / 2)
+  }
 }
 
 /**

--- a/src/editor/snapping-manager/index.ts
+++ b/src/editor/snapping-manager/index.ts
@@ -1,7 +1,6 @@
 import {
   BasicTransformEvent,
   Canvas,
-  FabricImage,
   FabricObject,
   Textbox,
   Transform,
@@ -13,7 +12,6 @@ import { ImageEditor } from '..'
 import {
   GUIDE_COLOR,
   GUIDE_WIDTH,
-  MOVE_SNAP_STEP,
   SNAP_THRESHOLD,
   SPACING_CONTEXT_SWITCH_DISTANCE,
   SPACING_SNAP_HOLD_MARGIN
@@ -24,6 +22,11 @@ import {
   type SpacingContextByAxis
 } from './calculations'
 import { drawSpacingGuide } from './renderer'
+import {
+  applyMovementStep,
+  applyScalingStep,
+  shouldApplyPixelScalingStep
+} from './pixel-grid'
 import type {
   AnchorBuckets,
   Bounds,
@@ -242,7 +245,7 @@ export default class SnappingManager {
       return
     }
 
-    SnappingManager._applyMovementStep({
+    applyMovementStep({
       target,
       transform
     })
@@ -310,7 +313,7 @@ export default class SnappingManager {
     }
 
     if (!hasSpacingSnap) {
-      SnappingManager._applyMovementStep({
+      applyMovementStep({
         target,
         transform
       })
@@ -351,20 +354,20 @@ export default class SnappingManager {
       return
     }
 
-    const shouldApplyPixelScalingStep = SnappingManager._shouldApplyPixelScalingStep({
+    const canApplyPixelScalingStep = shouldApplyPixelScalingStep({
       target
     })
     const isCtrlPressed = Boolean(e?.ctrlKey)
     if (isCtrlPressed) {
       this._clearGuides()
-      if (shouldApplyPixelScalingStep) {
-        SnappingManager._applyScalingStep({ target, transform })
+      if (canApplyPixelScalingStep) {
+        applyScalingStep({ target, transform })
       }
       return
     }
 
-    if (shouldApplyPixelScalingStep) {
-      SnappingManager._applyScalingStep({ target, transform })
+    if (canApplyPixelScalingStep) {
+      applyScalingStep({ target, transform })
     }
 
     const {
@@ -558,11 +561,12 @@ export default class SnappingManager {
           object: target,
           placement: anchorPlacement
         })
+        target.setCoords()
       }
     }
 
-    if (shouldApplyPixelScalingStep) {
-      SnappingManager._applyScalingStep({ target, transform })
+    if (canApplyPixelScalingStep) {
+      applyScalingStep({ target, transform })
     }
 
     this._applyGuides({
@@ -1272,138 +1276,6 @@ export default class SnappingManager {
     if (!Number.isFinite(rawWidth) || rawWidth <= 0) return null
 
     return Math.max(1, Math.round(rawWidth))
-  }
-
-  /**
-   * Возвращает true, если live-scaling объекта нужно округлять до целого пиксельного размера.
-   * Для изображений и текста сохраняем их собственный runtime-контракт без дополнительной квантизации:
-   * изображения полагаются на нативное поведение Fabric, а текст материализует scale через TextManager.
-   */
-  private static _shouldApplyPixelScalingStep({ target }: { target: FabricObject }): boolean {
-    const targetType = typeof target.type === 'string' ? target.type.toLowerCase() : ''
-    const isTextTarget = target instanceof Textbox
-      || targetType === 'textbox'
-      || targetType === 'background-textbox'
-
-    return !(target instanceof FabricImage) && !isTextTarget
-  }
-
-  /**
-   * Применяет шаг перемещения, округляя координаты объекта к сетке MOVE_SNAP_STEP.
-   */
-  private static _applyMovementStep({
-    target,
-    transform
-  }: {
-    target: FabricObject
-    transform?: Transform | null
-  }): void {
-    const { left = 0, top = 0 } = target
-    const snappedLeft = Math.round(left / MOVE_SNAP_STEP) * MOVE_SNAP_STEP
-    const snappedTop = Math.round(top / MOVE_SNAP_STEP) * MOVE_SNAP_STEP
-    const originalLeft = typeof transform?.original?.left === 'number'
-      ? transform.original.left
-      : null
-    const originalTop = typeof transform?.original?.top === 'number'
-      ? transform.original.top
-      : null
-    const shouldSnapX = originalLeft === null || originalLeft !== left
-    const shouldSnapY = originalTop === null || originalTop !== top
-    const updates: Partial<Record<'left' | 'top', number>> = {}
-
-    if (shouldSnapX && snappedLeft !== left) {
-      updates.left = snappedLeft
-    }
-
-    if (shouldSnapY && snappedTop !== top) {
-      updates.top = snappedTop
-    }
-
-    if (!('left' in updates) && !('top' in updates)) return
-
-    target.set(updates)
-    target.setCoords()
-  }
-
-  /**
-   * Округляет масштаб объекта так, чтобы его визуальный размер в пикселях был целым числом (минимум 1).
-   */
-  private static _applyScalingStep({
-    target,
-    transform
-  }: {
-    target: FabricObject
-    transform?: Transform | null
-  }): void {
-    const {
-      scaleX: rawScaleX = 1,
-      scaleY: rawScaleY = 1
-    } = target
-    const { width: effectiveWidth, height: effectiveHeight } = SnappingManager._resolveEffectiveDimensions({ target })
-    const isUniform = rawScaleX === rawScaleY
-
-    let snappedScaleX = rawScaleX
-    let snappedScaleY = rawScaleY
-
-    if (isUniform) {
-      const candidateFromWidth = effectiveWidth > 0
-        ? Math.max(1, Math.round(effectiveWidth * rawScaleX)) / effectiveWidth
-        : rawScaleX
-      const candidateFromHeight = effectiveHeight > 0
-        ? Math.max(1, Math.round(effectiveHeight * rawScaleY)) / effectiveHeight
-        : rawScaleY
-      const errorX = Math.abs(candidateFromWidth - rawScaleX)
-      const errorY = Math.abs(candidateFromHeight - rawScaleY)
-      const uniformScale = errorX <= errorY ? candidateFromWidth : candidateFromHeight
-
-      snappedScaleX = uniformScale
-      snappedScaleY = uniformScale
-    } else {
-      snappedScaleX = effectiveWidth > 0
-        ? Math.max(1, Math.round(effectiveWidth * rawScaleX)) / effectiveWidth
-        : rawScaleX
-      snappedScaleY = effectiveHeight > 0
-        ? Math.max(1, Math.round(effectiveHeight * rawScaleY)) / effectiveHeight
-        : rawScaleY
-    }
-
-    const isAlreadySnapped = snappedScaleX === rawScaleX && snappedScaleY === rawScaleY
-
-    if (isAlreadySnapped) return
-
-    target.set({
-      scaleX: snappedScaleX,
-      scaleY: snappedScaleY
-    })
-
-    if (transform) {
-      transform.scaleX = snappedScaleX
-      transform.scaleY = snappedScaleY
-    }
-
-    target.setCoords()
-  }
-
-  /**
-   * Возвращает эффективные размеры объекта (без масштаба), включая strokeWidth если он масштабируется вместе с объектом.
-   */
-  private static _resolveEffectiveDimensions({ target }: { target: FabricObject }): { width: number; height: number } {
-    if (target instanceof Textbox) {
-      return SnappingManager._resolveBaseDimensions({ target })
-    }
-
-    const {
-      width = 0,
-      height = 0,
-      strokeWidth = 0,
-      strokeUniform = false
-    } = target
-    const strokeContribution = strokeUniform ? 0 : strokeWidth
-
-    return {
-      width: width + strokeContribution,
-      height: height + strokeContribution
-    }
   }
 
   /**

--- a/src/editor/snapping-manager/pixel-grid.ts
+++ b/src/editor/snapping-manager/pixel-grid.ts
@@ -1,0 +1,161 @@
+import {
+  FabricImage,
+  FabricObject,
+  Textbox,
+  Transform
+} from 'fabric'
+
+import { MOVE_SNAP_STEP } from './constants'
+
+/**
+ * Возвращает true, если live-scaling объекта нужно округлять до целого пиксельного размера.
+ * Для изображений и текста сохраняем их собственный runtime-контракт без дополнительной квантизации.
+ */
+export function shouldApplyPixelScalingStep({ target }: { target: FabricObject }): boolean {
+  const targetType = typeof target.type === 'string' ? target.type.toLowerCase() : ''
+  const isTextTarget = target instanceof Textbox
+    || targetType === 'textbox'
+    || targetType === 'background-textbox'
+
+  return !(target instanceof FabricImage) && !isTextTarget
+}
+
+/**
+ * Применяет шаг перемещения, округляя координаты объекта к сетке MOVE_SNAP_STEP.
+ */
+export function applyMovementStep({
+  target,
+  transform
+}: {
+  target: FabricObject
+  transform?: Transform | null
+}): void {
+  const { left = 0, top = 0 } = target
+  const snappedLeft = Math.round(left / MOVE_SNAP_STEP) * MOVE_SNAP_STEP
+  const snappedTop = Math.round(top / MOVE_SNAP_STEP) * MOVE_SNAP_STEP
+  const originalLeft = typeof transform?.original?.left === 'number'
+    ? transform.original.left
+    : null
+  const originalTop = typeof transform?.original?.top === 'number'
+    ? transform.original.top
+    : null
+  const shouldSnapX = originalLeft === null || originalLeft !== left
+  const shouldSnapY = originalTop === null || originalTop !== top
+  const updates: Partial<Record<'left' | 'top', number>> = {}
+
+  if (shouldSnapX && snappedLeft !== left) {
+    updates.left = snappedLeft
+  }
+
+  if (shouldSnapY && snappedTop !== top) {
+    updates.top = snappedTop
+  }
+
+  if (!('left' in updates) && !('top' in updates)) return
+
+  target.set(updates)
+  target.setCoords()
+}
+
+/**
+ * Возвращает эффективные размеры текстового объекта без масштаба.
+ */
+function resolveTextboxDimensions({ target }: { target: Textbox }): { width: number; height: number } {
+  const {
+    width = 0,
+    height = 0,
+    paddingTop = 0,
+    paddingRight = 0,
+    paddingBottom = 0,
+    paddingLeft = 0,
+    strokeWidth = 0
+  } = target
+
+  return {
+    width: width + paddingLeft + paddingRight + strokeWidth,
+    height: height + paddingTop + paddingBottom + strokeWidth
+  }
+}
+
+/**
+ * Возвращает эффективные размеры объекта без масштаба.
+ */
+function resolveEffectiveDimensions({ target }: { target: FabricObject }): { width: number; height: number } {
+  if (target instanceof Textbox) {
+    return resolveTextboxDimensions({ target })
+  }
+
+  const {
+    width = 0,
+    height = 0,
+    strokeWidth = 0,
+    strokeUniform = false
+  } = target
+  const strokeContribution = strokeUniform ? 0 : strokeWidth
+
+  return {
+    width: width + strokeContribution,
+    height: height + strokeContribution
+  }
+}
+
+/**
+ * Округляет масштаб объекта так, чтобы его визуальный размер в пикселях был целым числом.
+ */
+export function applyScalingStep({
+  target,
+  transform
+}: {
+  target: FabricObject
+  transform?: Transform | null
+}): void {
+  const {
+    scaleX: rawScaleX = 1,
+    scaleY: rawScaleY = 1
+  } = target
+  const { width: effectiveWidth, height: effectiveHeight } = resolveEffectiveDimensions({ target })
+  const isUniform = rawScaleX === rawScaleY
+
+  let snappedScaleX = rawScaleX
+  let snappedScaleY = rawScaleY
+
+  if (isUniform) {
+    const candidateFromWidth = effectiveWidth > 0
+      ? Math.max(1, Math.round(effectiveWidth * rawScaleX)) / effectiveWidth
+      : rawScaleX
+    const candidateFromHeight = effectiveHeight > 0
+      ? Math.max(1, Math.round(effectiveHeight * rawScaleY)) / effectiveHeight
+      : rawScaleY
+    const errorX = Math.abs(candidateFromWidth - rawScaleX)
+    const errorY = Math.abs(candidateFromHeight - rawScaleY)
+    const uniformScale = errorX <= errorY ? candidateFromWidth : candidateFromHeight
+
+    snappedScaleX = uniformScale
+    snappedScaleY = uniformScale
+  }
+
+  if (!isUniform) {
+    snappedScaleX = effectiveWidth > 0
+      ? Math.max(1, Math.round(effectiveWidth * rawScaleX)) / effectiveWidth
+      : rawScaleX
+    snappedScaleY = effectiveHeight > 0
+      ? Math.max(1, Math.round(effectiveHeight * rawScaleY)) / effectiveHeight
+      : rawScaleY
+  }
+
+  const isAlreadySnapped = snappedScaleX === rawScaleX && snappedScaleY === rawScaleY
+
+  if (isAlreadySnapped) return
+
+  target.set({
+    scaleX: snappedScaleX,
+    scaleY: snappedScaleY
+  })
+
+  if (transform) {
+    transform.scaleX = snappedScaleX
+    transform.scaleY = snappedScaleY
+  }
+
+  target.setCoords()
+}

--- a/src/editor/types/fabric-extensions.d.ts
+++ b/src/editor/types/fabric-extensions.d.ts
@@ -394,6 +394,18 @@ declare module 'fabric' {
      * Используется объектами, у которых итоговый доменный размер отличается от visual bbox.
      */
     getObjectDisplaySize?(): { width: number; height: number };
+
+    /**
+     * Возвращает границы объекта для snapping/measurement, если visual bbox не совпадает с доменной геометрией.
+     */
+    getObjectSnappingBounds?(): {
+      left: number;
+      right: number;
+      top: number;
+      bottom: number;
+      centerX: number;
+      centerY: number;
+    };
   }
 
   interface RectProps {
@@ -426,7 +438,29 @@ declare module 'fabric' {
     id?: string;
   }
 
-  interface TextboxProps {
+  interface EditorTextboxPaddingProperties {
+    /**
+     * Верхний внутренний отступ текстового блока в editor-пикселях.
+     */
+    paddingTop?: number;
+
+    /**
+     * Правый внутренний отступ текстового блока в editor-пикселях.
+     */
+    paddingRight?: number;
+
+    /**
+     * Нижний внутренний отступ текстового блока в editor-пикселях.
+     */
+    paddingBottom?: number;
+
+    /**
+     * Левый внутренний отступ текстового блока в editor-пикселях.
+     */
+    paddingLeft?: number;
+  }
+
+  interface TextboxProps extends EditorTextboxPaddingProperties {
     /**
      * Исходное значение текста без преобразования регистра.
      */
@@ -445,7 +479,7 @@ declare module 'fabric' {
     autoExpand?: boolean;
   }
 
-  interface Textbox {
+  interface Textbox extends EditorTextboxPaddingProperties {
     /**
      * Исходное значение текста без преобразования регистра.
      */

--- a/src/editor/utils/geometry.ts
+++ b/src/editor/utils/geometry.ts
@@ -187,6 +187,18 @@ export const snapObjectToPixelGrid = ({
 }
 
 /**
+ * Проверяет, что кастомные bounds можно использовать в геометрических расчётах.
+ */
+function isFiniteObjectBounds({ bounds }: { bounds: ObjectBounds }): boolean {
+  return Number.isFinite(bounds.left)
+    && Number.isFinite(bounds.right)
+    && Number.isFinite(bounds.top)
+    && Number.isFinite(bounds.bottom)
+    && Number.isFinite(bounds.centerX)
+    && Number.isFinite(bounds.centerY)
+}
+
+/**
  * Возвращает bounding box объекта с учётом трансформации и округлением до целых пикселей.
  */
 export const getObjectBounds = ({
@@ -196,9 +208,14 @@ export const getObjectBounds = ({
 }): ObjectBounds | null => {
   if (!object) return null
 
+  const customBounds = object.getObjectSnappingBounds?.()
+  if (customBounds && isFiniteObjectBounds({ bounds: customBounds })) {
+    return customBounds
+  }
+
   try {
     object.setCoords()
-    const rect = object.getBoundingRect(false, true)
+    const rect = object.getBoundingRect()
     const {
       left: rawLeft = 0,
       top: rawTop = 0,


### PR DESCRIPTION
У нас есть SnappingManager, который отвечат за прилипание объекта при его ресайзе к краям монтажной области или другого объекта. Сейчас настроено так, что для срабатывания прилипания во время скейлинга должно быть расстояние около 5 px до края. В такой ситуации прилипание срабатывает прямо к краю объекта, и если продолжать скейлить в пределах этих 5px, но скейлинг не будет отрабатывать, а будет срабатывать только если мы двинули курсор куда-то на расстояние более 5 px. Например, если я делаю кроп канваса при разрешении 1024х1024 px, то исходным сразу же при скейлинге мы столкнёмся с тем что сработает снэп, и чтобы увеличить кроп-область нам нужно выйти за пределы 5 px при увеличении. То есть, минимальные размеры для увеличения кроп-области при текущем прилипании будут в рйоне 1030px. Визуально это выглядит так что если мы начнём увеличение кроп-области путём скейлинга по диагонали на 1024х1024 px то какое-то время при растягивании ничего не будет происходить, а потом будет резкий прыжок на 2037х2037px (скрины 1-2).

<img width="1920" height="897" alt="image" src="https://github.com/user-attachments/assets/7c404332-4558-469f-acd0-51657385769a" />

<img width="1919" height="900" alt="image" src="https://github.com/user-attachments/assets/87792f94-bc93-42a8-ab2f-06e850dff5b3" />

Это ожидаемое поведение, снеппинг не даёт нам перейти к 1025,1026,1027 размерам и т.д., а вместо этого отпускает прилипание когда мы упираемся в некий трешхолд расчитанный в SnappingManager. 

Однако при уменьшении это работает не так как с увеличением. При уменьшении у нас почему-то есть возможность уменьшить размеры кроп-области на 1px, и только потом будет срабатывать трешхолд SnappingManager, который отпустит нас на 1009х1009 px (Скрины 3-5).

<img width="1920" height="897" alt="image" src="https://github.com/user-attachments/assets/fb9e9e94-0571-4bf0-ae45-34b28b1fa3c1" />

<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/4ba6e87e-892a-4acd-b16a-cdd35c8f5421" />

<img width="1919" height="890" alt="image" src="https://github.com/user-attachments/assets/93003095-874e-4e82-984e-8614419d55fa" />

Вот этого маленького шага на 1px не должно быть при начальном скейлинге когда работает прилипание. Мы должны от 1024 px при движении курсора выходить из снеппинга и прыгать сразу на условные 1000 px.

---

FIXED.