### PR TITLE
ZoomManager. Правим баг когда зум по курсору позволяет выйти за пределы установленные PanConstraintManager.

### DIFF
--- a/e2e/fixtures/data/listeners.data.ts
+++ b/e2e/fixtures/data/listeners.data.ts
@@ -19,3 +19,27 @@ export const LISTENERS_CUT_HOTKEY_SHAPE_OFFSET = {
 } as const
 
 export const LISTENERS_CLIPBOARD_OFFSET = 10
+
+export const LISTENERS_EDGE_ZOOM_MONTAGE_RESOLUTION = {
+  width: 4096,
+  height: 4096
+} as const
+
+export const LISTENERS_EDGE_ZOOM_SHAPE_ID = 'edge-zoom-pan-shape'
+
+export const LISTENERS_EDGE_ZOOM_SHAPE_SIZE = {
+  width: 2400,
+  height: 2400
+} satisfies Pick<ShapeAddAtBoundsParams['options'], 'width' | 'height'>
+
+export const LISTENERS_EDGE_ZOOM_TEXT = 'TEST'
+
+export const LISTENERS_EDGE_ZOOM_TEXT_FONT_SIZE = 720
+
+export const LISTENERS_EDGE_ZOOM_VIEWPORT_RIGHT_INSET = 16
+
+export const LISTENERS_EDGE_ZOOM_DELTA_Y = -240
+
+export const LISTENERS_EDGE_ZOOM_WHEEL_STEPS = 24
+
+export const LISTENERS_EDGE_ZOOM_SCROLL_DELTA_Y = 48

--- a/e2e/models/editor.model.ts
+++ b/e2e/models/editor.model.ts
@@ -252,6 +252,25 @@ export class EditorModel {
     })
   }
 
+  /** Возвращает DOM-границы верхнего canvas слоя для реальных pointer-взаимодействий. */
+  async getCanvasViewportBounds(): Promise<ViewportBoundsInfo> {
+    return this.page.evaluate(() => {
+      const { canvas } = (window as any).editor
+      const rect = canvas.upperCanvasEl.getBoundingClientRect()
+
+      return {
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        right: rect.right,
+        bottom: rect.bottom,
+        centerX: rect.left + (rect.width / 2),
+        centerY: rect.top + (rect.height / 2)
+      }
+    })
+  }
+
   /** Возвращает список пользовательских объектов canvas (без служебных) */
   async getObjects(): Promise<EditorObjectInfo[]> {
     return this.page.evaluate(() => {
@@ -800,11 +819,117 @@ export class EditorModel {
     })
   }
 
+  /** Переводит viewport-координаты canvas в client-координаты браузера. */
+  private async _resolveCanvasClientPoint({
+    x,
+    y
+  }: {
+    x: number
+    y: number
+  }): Promise<{
+    x: number
+    y: number
+  }> {
+    return this.page.evaluate(({ viewportX, viewportY }) => {
+      const { editor } = window as any
+      const rect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+
+      return {
+        x: rect.left + viewportX,
+        y: rect.top + viewportY
+      }
+    }, {
+      viewportX: x,
+      viewportY: y
+    })
+  }
+
+  /** Выполняет реальный wheel-input в заданной viewport-точке canvas. */
+  private async _wheelAtViewportPoint({
+    x,
+    y,
+    deltaX = 0,
+    deltaY,
+    ctrlKey = false
+  }: {
+    x: number
+    y: number
+    deltaX?: number
+    deltaY: number
+    ctrlKey?: boolean
+  }): Promise<void> {
+    const clientPoint = await this._resolveCanvasClientPoint({ x, y })
+
+    await this.page.mouse.move(clientPoint.x, clientPoint.y)
+
+    if (ctrlKey) {
+      await this.page.keyboard.down('Control')
+    }
+
+    try {
+      await this.page.mouse.wheel(deltaX, deltaY)
+    } finally {
+      if (ctrlKey) {
+        await this.page.keyboard.up('Control')
+      }
+    }
+
+    await waitForCanvasRender({ page: this.page })
+  }
+
   /** Отправляет Ctrl + wheel на DOM-границу canvas и ждёт завершения рендера. */
   async zoomByCtrlWheel(params: { deltaY: number }): Promise<WheelInputDispatchState> {
     return this._dispatchWheelEvents({
       ctrlKey: true,
       deltaYSteps: [params.deltaY]
+    })
+  }
+
+  /** Делает серию реальных Ctrl + wheel событий в заданной viewport-точке canvas. */
+  async zoomByCtrlWheelRepeatedlyAtViewportPoint({
+    deltaY,
+    steps,
+    x,
+    y
+  }: {
+    deltaY: number
+    steps: number
+    x: number
+    y: number
+  }): Promise<void> {
+    const clientPoint = await this._resolveCanvasClientPoint({ x, y })
+
+    await this.page.mouse.move(clientPoint.x, clientPoint.y)
+    await this.page.keyboard.down('Control')
+
+    try {
+      for (let stepIndex = 0; stepIndex < steps; stepIndex += 1) {
+        await this.page.mouse.wheel(0, deltaY)
+      }
+    } finally {
+      await this.page.keyboard.up('Control')
+    }
+
+    await waitForCanvasRender({ page: this.page })
+  }
+
+  /** Делает реальный wheel-pan в заданной viewport-точке canvas. */
+  async panByWheelAtViewportPoint({
+    deltaX = 0,
+    deltaY,
+    x,
+    y
+  }: {
+    deltaX?: number
+    deltaY: number
+    x: number
+    y: number
+  }): Promise<void> {
+    await this._wheelAtViewportPoint({
+      deltaX,
+      deltaY,
+      x,
+      y
     })
   }
 

--- a/e2e/tests/listeners.spec.ts
+++ b/e2e/tests/listeners.spec.ts
@@ -9,6 +9,15 @@ import {
   LISTENERS_CUT_HOTKEY_SHAPE_OFFSET,
   LISTENERS_DUPLICATE_HOTKEY_SHAPE_ID,
   LISTENERS_DUPLICATE_HOTKEY_SHAPE_OFFSET,
+  LISTENERS_EDGE_ZOOM_DELTA_Y,
+  LISTENERS_EDGE_ZOOM_MONTAGE_RESOLUTION,
+  LISTENERS_EDGE_ZOOM_SCROLL_DELTA_Y,
+  LISTENERS_EDGE_ZOOM_SHAPE_ID,
+  LISTENERS_EDGE_ZOOM_SHAPE_SIZE,
+  LISTENERS_EDGE_ZOOM_TEXT,
+  LISTENERS_EDGE_ZOOM_TEXT_FONT_SIZE,
+  LISTENERS_EDGE_ZOOM_VIEWPORT_RIGHT_INSET,
+  LISTENERS_EDGE_ZOOM_WHEEL_STEPS,
   LISTENERS_HOTKEY_SHAPE_SIZE
 } from '../fixtures/data/listeners.data'
 
@@ -153,6 +162,115 @@ test.describe('Горячие клавиши и zoom', () => {
       expect(afterPan.zoom).toBeCloseTo(beforePan.zoom, 4)
       expect(afterPan.x).toBeLessThan(beforePan.x)
       expect(afterPan.y).toBeLessThan(beforePan.y)
+    })
+  })
+
+  test.describe('ctrl + wheel у правого края canvas', () => {
+    let zoomPoint = {
+      x: 0,
+      y: 0
+    }
+
+    test.beforeEach(async({
+      canvas,
+      editorModel,
+      shapes
+    }) => {
+      await canvas.setMontageResolution(LISTENERS_EDGE_ZOOM_MONTAGE_RESOLUTION)
+
+      const shape = await shapes.addWithText({
+        presetKey: 'square',
+        text: LISTENERS_EDGE_ZOOM_TEXT,
+        fontSize: LISTENERS_EDGE_ZOOM_TEXT_FONT_SIZE,
+        options: {
+          id: LISTENERS_EDGE_ZOOM_SHAPE_ID,
+          ...LISTENERS_EDGE_ZOOM_SHAPE_SIZE
+        }
+      })
+      const montageArea = await editorModel.getMontageArea()
+
+      expect(shape?.id).toBe(LISTENERS_EDGE_ZOOM_SHAPE_ID)
+      expect(montageArea.width).toBe(LISTENERS_EDGE_ZOOM_MONTAGE_RESOLUTION.width)
+      expect(montageArea.height).toBe(LISTENERS_EDGE_ZOOM_MONTAGE_RESOLUTION.height)
+
+      const viewportBounds = await editorModel.getCanvasViewportBounds()
+
+      zoomPoint = {
+        x: viewportBounds.width - LISTENERS_EDGE_ZOOM_VIEWPORT_RIGHT_INSET,
+        y: viewportBounds.height / 2
+      }
+
+      await editorModel.zoomByCtrlWheelRepeatedlyAtViewportPoint({
+        deltaY: LISTENERS_EDGE_ZOOM_DELTA_Y,
+        steps: LISTENERS_EDGE_ZOOM_WHEEL_STEPS,
+        ...zoomPoint
+      })
+
+      const panState = await editorModel.getViewportPanState()
+      const scrollbarState = await editorModel.getViewportScrollbarState()
+
+      expect(panState.horizontal.canPan).toBe(true)
+      expect(panState.vertical.canPan).toBe(true)
+      expect(scrollbarState.horizontal.visible).toBe(true)
+      expect(scrollbarState.vertical.visible).toBe(true)
+    })
+
+    test('не даёт камере прыгнуть при следующем scroll', async({ editorModel }) => {
+      const afterZoom = await test.step('Проверить что zoom сразу оставляет viewport в pan-границах', async() => {
+        const viewport = await editorModel.getCanvasViewportTransform()
+        const panState = await editorModel.getViewportPanState()
+
+        expect(viewport.x).toBeGreaterThanOrEqual(panState.horizontal.min)
+        expect(viewport.x).toBeLessThanOrEqual(panState.horizontal.max)
+        expect(viewport.y).toBeGreaterThanOrEqual(panState.vertical.min)
+        expect(viewport.y).toBeLessThanOrEqual(panState.vertical.max)
+
+        return viewport
+      })
+
+      await test.step('Сделать обычный scroll без Ctrl только по вертикали', async() => {
+        await editorModel.panByWheelAtViewportPoint({
+          deltaY: LISTENERS_EDGE_ZOOM_SCROLL_DELTA_Y,
+          ...zoomPoint
+        })
+      })
+
+      await test.step('Проверить что scroll не вызывает горизонтальный скачок камеры', async() => {
+        const afterScroll = await editorModel.getCanvasViewportTransform()
+
+        expect(Math.abs(afterScroll.x - afterZoom.x)).toBeLessThan(1)
+        expect(afterScroll.y).toBeLessThan(afterZoom.y)
+        expect(afterScroll.zoom).toBeCloseTo(afterZoom.zoom, 4)
+      })
+    })
+
+    test('не даёт камере прыгнуть при следующем Space + ЛКМ drag', async({ editorModel }) => {
+      const afterZoom = await test.step('Проверить что zoom сразу оставляет viewport в pan-границах', async() => {
+        const viewport = await editorModel.getCanvasViewportTransform()
+        const panState = await editorModel.getViewportPanState()
+
+        expect(viewport.x).toBeGreaterThanOrEqual(panState.horizontal.min)
+        expect(viewport.x).toBeLessThanOrEqual(panState.horizontal.max)
+        expect(viewport.y).toBeGreaterThanOrEqual(panState.vertical.min)
+        expect(viewport.y).toBeLessThanOrEqual(panState.vertical.max)
+
+        return viewport
+      })
+
+      await test.step('Сдвинуть viewport через Space + ЛКМ вверх без горизонтального смещения', async() => {
+        await editorModel.dragViewportBySpaceMouse({
+          deltaX: 0,
+          deltaY: -24
+        })
+      })
+
+      await test.step('Проверить что drag не вызывает горизонтальный скачок камеры', async() => {
+        const afterDrag = await editorModel.getCanvasViewportTransform()
+
+        expect(Math.abs(afterDrag.x - afterZoom.x)).toBeLessThan(1)
+        expect(afterDrag.y).toBeLessThan(afterZoom.y)
+        expect(afterDrag.zoom).toBeCloseTo(afterZoom.zoom, 4)
+      })
     })
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/zoom-manager/index.spec.ts
+++ b/specs/src/editor/zoom-manager/index.spec.ts
@@ -153,6 +153,48 @@ describe('ZoomManager', () => {
       expect(mockCanvas.zoomToPoint).not.toHaveBeenCalled()
       expect(mockCanvas.fire).not.toHaveBeenCalled()
     })
+
+    it('после zoom сразу зажимает viewport в pan-границах', () => {
+      mockCanvas.getZoom.mockReturnValue(1)
+      mockCanvas.zoomToPoint.mockImplementation((_point: Point, zoom: number) => {
+        mockCanvas.viewportTransform = [zoom, 0, 0, zoom, -260, -180]
+      })
+      mockEditor.panConstraintManager.constrainPan.mockReturnValue({
+        x: -200,
+        y: -150
+      })
+      jest.spyOn(zoomManager as any, '_applyViewportCentering').mockReturnValue(false)
+      mockCanvas.setViewportTransform.mockClear()
+      mockEditor.montageArea.setCoords.mockClear()
+
+      zoomManager.zoom(0.1)
+
+      expect(mockEditor.panConstraintManager.updateBounds).toHaveBeenCalledTimes(1)
+      expect(mockEditor.panConstraintManager.constrainPan).toHaveBeenCalledWith(-260, -180)
+      expect(mockCanvas.setViewportTransform).toHaveBeenCalledWith([1.1, 0, 0, 1.1, -200, -150])
+      expect(mockEditor.montageArea.setCoords).toHaveBeenCalledTimes(2)
+    })
+
+    it('не делает лишний viewport write если zoom уже оставил камеру в pan-границах', () => {
+      mockCanvas.getZoom.mockReturnValue(1)
+      mockCanvas.zoomToPoint.mockImplementation((_point: Point, zoom: number) => {
+        mockCanvas.viewportTransform = [zoom, 0, 0, zoom, -200, -150]
+      })
+      mockEditor.panConstraintManager.constrainPan.mockReturnValue({
+        x: -200,
+        y: -150
+      })
+      jest.spyOn(zoomManager as any, '_applyViewportCentering').mockReturnValue(false)
+      mockCanvas.setViewportTransform.mockClear()
+      mockEditor.montageArea.setCoords.mockClear()
+
+      zoomManager.zoom(0.1)
+
+      expect(mockEditor.panConstraintManager.updateBounds).toHaveBeenCalledTimes(1)
+      expect(mockEditor.panConstraintManager.constrainPan).toHaveBeenCalledWith(-200, -150)
+      expect(mockCanvas.setViewportTransform).not.toHaveBeenCalled()
+      expect(mockEditor.montageArea.setCoords).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('setZoom', () => {

--- a/src/editor/zoom-manager/index.ts
+++ b/src/editor/zoom-manager/index.ts
@@ -343,6 +343,34 @@ export default class ZoomManager {
   }
 
   /**
+   * Нормализует текущий viewportTransform по pan-границам после zoom-сценария.
+   * Zoom может сдвинуть camera-state за допустимый pan-диапазон быстрее,
+   * чем следующий scroll или Space-drag успеют пройти через PanConstraintManager.
+   * В этом случае bounds нужно применить сразу в том же zoom write-path,
+   * чтобы не оставлять invalid viewport до первого pan-события.
+   * @private
+   */
+  private _constrainViewportToPanBounds(): void {
+    const { canvas, montageArea, panConstraintManager } = this.editor
+    const vpt = canvas.viewportTransform
+
+    panConstraintManager.updateBounds()
+
+    const constrainedViewport = panConstraintManager.constrainPan(vpt[4], vpt[5])
+    const didViewportChange = constrainedViewport.x !== vpt[4] || constrainedViewport.y !== vpt[5]
+
+    if (!didViewportChange) return
+
+    const nextViewportTransform = [...vpt] as typeof vpt
+
+    nextViewportTransform[4] = constrainedViewport.x
+    nextViewportTransform[5] = constrainedViewport.y
+
+    canvas.setViewportTransform(nextViewportTransform)
+    montageArea.setCoords()
+  }
+
+  /**
    * Пересчитывает defaultZoom для текущих размеров контейнера и монтажной области.
    * Метод обновляет только derived camera-state и не меняет текущий viewport.
    * @param scale - Желаемый масштаб относительно размеров контейнера редактора.
@@ -464,8 +492,8 @@ export default class ZoomManager {
 
     canvas.zoomToPoint(point, zoom)
 
-    this.editor.panConstraintManager.updateBounds()
     this._applyViewportCentering(zoom, isZoomingOut, scale)
+    this._constrainViewportToPanBounds()
 
     canvas.fire('editor:zoom-changed', {
       currentZoom: canvas.getZoom(),


### PR DESCRIPTION
Порядок воспроизведения.

1. Сделать побольше разрешение монтажной области, например, 4096х4096 px и добавить какой-нибудь заметный объект, например, шейп с текстом который занимает большую часть монтажной области (скрин 1)

<img width="1920" height="1012" alt="image" src="https://github.com/user-attachments/assets/7f03140e-102f-459c-8f4c-d27069e962a4" />

2. Сделать увеличение масштаба путём нажатия на CTRL и прокрутки колеса мыши с курсором установленным в крайней правой части канваса так чтобы появилась вертикальная полоса прокрутки (скрин 2)

<img width="1919" height="1008" alt="image" src="https://github.com/user-attachments/assets/04cba31e-55dc-4b3e-95a5-16d5a4bf5812" />

3. Выполнить скролл колесом мыши или перетаскивание с зажатым пробелом

Ожидаемое поведение.

Скролл выполнен, камера осталась в том же положении по горизонтали в котором была при увеличении масштаба в пункте 2. 

Фактический результат.

Скролл выполнен, а камера сместилась в центр вьюпорта так чтобы расстояние справа от монтажной области до края канваса соответствовало ограничению установленному в PanConstraintManager, из-за чего кажется что мы прыгнули куда-то (скрин 3). На самом деле, проблема здесь заключается в том, что в пункте 2 при увеличении масштаба по курсору мыши мы должны были ещё тогда упереться в ограничения установленные в PanConstraintManager, но это произошло только при попытке скролла или перетаскивания камеры с зажатым пробелом. 

<img width="1920" height="1014" alt="image" src="https://github.com/user-attachments/assets/d007a948-f847-4890-9e1c-3f637be1786b" />

---

FIXED.