### PR TITLE
CropManager & Listeners. Правим баг когда двойной клик по кроп-области мог увеличить её до размеров монтажной области в режиме обрезки изображения с отключенным флагом allowFrameOverflow

### DIFF
--- a/e2e/models/crop.model.ts
+++ b/e2e/models/crop.model.ts
@@ -250,6 +250,36 @@ export class CropModel {
     return this.requireState()
   }
 
+  /** Выполняет реальный двойной клик по центру активной crop-области. */
+  async doubleClickFrame(): Promise<CropStateInfo> {
+    const point = await this.page.evaluate(() => {
+      const { editor } = window as any
+      const cropState = editor.cropManager.getState()
+      if (!cropState) return null
+
+      const { frame } = cropState
+      frame.setCoords()
+
+      const bounds = frame.getBoundingRect(false, true)
+      const canvasRect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+
+      return {
+        x: canvasRect.left + bounds.left + (bounds.width / 2),
+        y: canvasRect.top + bounds.top + (bounds.height / 2)
+      }
+    })
+
+    expect(point, 'для двойного клика по crop-области должны существовать client-координаты').not.toBeNull()
+    if (!point) {
+      throw new Error('Не удалось получить client-координаты для двойного клика по crop-области')
+    }
+
+    await this.page.mouse.dblclick(point.x, point.y)
+    await waitForCanvasRender({ page: this.page })
+
+    return this.requireState()
+  }
+
   /** Завершает активный resize crop frame через mouseup. */
   async finishFrameResize(): Promise<CropStateInfo> {
     const pointer = this.lastResizePointer

--- a/e2e/tests/crop-manager/crop-frame-double-click.spec.ts
+++ b/e2e/tests/crop-manager/crop-frame-double-click.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+
+test.describe('Двойной клик по crop-области изображения', () => {
+  test('не растягивает crop-область до монтажной области, когда overflow выключен', async({
+    crop,
+    images
+  }) => {
+    const image = await test.step('Добавить изображение, которое не занимает всю монтажную область', async() => {
+      return images.checkCreation({
+        imageObject: await images.addFilledImage({
+          width: 1000,
+          height: 667
+        })
+      })
+    })
+
+    await test.step('Дополнительно уменьшить изображение перед входом в crop mode', async() => {
+      await images.scaleHorizontallyFromRight({
+        id: image.id,
+        scaleX: 0.38
+      })
+
+      await images.finishScale({ id: image.id })
+    })
+
+    const initialState = await test.step('Войти в image crop с выключенным overflow', async() => {
+      return crop.startImageCrop({
+        id: image.id,
+        allowFrameOverflow: false
+      })
+    })
+
+    const stateAfterDoubleClick = await test.step('Сделать двойной клик по crop-области', async() => {
+      return crop.doubleClickFrame()
+    })
+
+    await test.step('Проверить что crop-область осталась в пределах изображения', () => {
+      expect(initialState.options.allowFrameOverflow).toBe(false)
+      expect(initialState.rect.width).toBeCloseTo(image.width, 5)
+      expect(initialState.rect.height).toBeCloseTo(image.height, 5)
+      expect(stateAfterDoubleClick.rect.width).toBeCloseTo(initialState.rect.width, 5)
+      expect(stateAfterDoubleClick.rect.height).toBeCloseTo(initialState.rect.height, 5)
+      expect(stateAfterDoubleClick.frame.scaleX).toBeCloseTo(initialState.frame.scaleX ?? 1, 5)
+      expect(stateAfterDoubleClick.frame.scaleY).toBeCloseTo(initialState.frame.scaleY ?? 1, 5)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/test-utils/editor/editor-stub.ts
+++ b/specs/test-utils/editor/editor-stub.ts
@@ -301,7 +301,8 @@ export const createEditorStub = () => {
     },
     cropManager: {
       isActive: false,
-      isFrameOverflowingSource: jest.fn().mockReturnValue(false)
+      isFrameOverflowingSource: jest.fn().mockReturnValue(false),
+      resetFrameToSource: jest.fn().mockReturnValue(null)
     },
     montageArea,
     options: {

--- a/src/editor/crop-manager/index.ts
+++ b/src/editor/crop-manager/index.ts
@@ -235,6 +235,23 @@ export default class CropManager {
   }
 
   /**
+   * Сбрасывает активный crop frame к полному размеру source.
+   */
+  public resetFrameToSource({ target }: { target?: FabricObject | null }): CropState | null {
+    const { _session: session } = this
+    if (!session || session.frame !== target) return null
+
+    const sourceSize = getSourceSize({ source: session.source })
+
+    this._applyFrameSize({
+      session,
+      size: sourceSize
+    })
+
+    return this.getState()
+  }
+
+  /**
    * Применяет активный crop mode.
    */
   public apply(): CropApplyResult | null {

--- a/src/editor/listeners.ts
+++ b/src/editor/listeners.ts
@@ -1078,7 +1078,7 @@ class Listeners {
   }
 
   /**
-   * Обработчик сброса объекта по двойному клику.
+   * Обработчик сброса объекта или active crop frame по двойному клику.
    * @param options - объект события fabric
    */
   handleResetObjectFit(options: TPointerEventInfo<TPointerEvent>): void {
@@ -1086,7 +1086,12 @@ class Listeners {
     const isCtrlPressed = Boolean(e && (e.ctrlKey || e.metaKey))
 
     if (isCtrlPressed) return
+
+    const cropResetState = this.editor.cropManager.resetFrameToSource({ target })
+
+    if (cropResetState) return
     if (!target || target instanceof Textbox || Boolean(target.shapeComposite)) return
+
     this.editor.transformManager.resetObject({ object: target })
   }
 


### PR DESCRIPTION

Порядок воспроизведения.

1. Добавить изображение которое занимает не всю монтажную область и включить кроп режим с выключенным флагом `allowFrameOverflow` (скрин 1)

 <img width="1920" height="1012" alt="image" src="https://github.com/user-attachments/assets/391a292b-cbb9-4096-ae44-705d6157ace6" />

2. Кликнуть дважды на кроп-область

Ожидаемое поведение.

При двойном клике мы должны вписать размеры кроп-области в пределах изображения, потому что флаг `allowFrameOverflow` выключен.

Фактический результат.

При двойном клике мы вписали размеры кроп-области таким образом, что кроп-область вписалась по размерам монтажной области, а не изображения, что нарушает поведение заданное наличием выключенного флага `allowFrameOverflow` (скрин 2). далее при попытке скейлинга кроп-области она схлопывается обратно до размеров изображения (скрин 3).

<img width="1918" height="1009" alt="image" src="https://github.com/user-attachments/assets/565026bf-f567-402d-a7d1-c5e071fb5845" />

<img width="1919" height="1013" alt="image" src="https://github.com/user-attachments/assets/20e16b30-ee04-49c5-85f9-a19e8fc6531a" />

---

FIXED.