### PR TITLE
CropManager. Добавляем возможность включать и выключать сохранение пропорций для кроп-области для всех видов скейлинга.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ editor.cropManager.startCanvasCrop({
     width: 1,
     height: 1
   },
+  preserveAspectRatio: true,
   allowFrameOverflow: true,
   showGrid: true,
   cancelOnSelectionClear: true
@@ -305,6 +306,10 @@ editor.cropManager.setSize({
   }
 })
 
+editor.cropManager.setPreserveAspectRatio({
+  preserveAspectRatio: false
+})
+
 // Apply or cancel the active crop mode
 const cropResult = editor.cropManager.apply()
 editor.cropManager.cancel()
@@ -316,12 +321,14 @@ Crop behavior options:
 - `allowFrameOverflow` defaults to `true` and lets the crop frame become larger than the source object.
 - `showGrid` defaults to `true` and draws a composition grid inside the crop frame.
 - `cancelOnSelectionClear` defaults to `true` and cancels crop mode when the crop frame loses focus.
+- `preserveAspectRatio` defaults to `true` and keeps the current aspect ratio during crop resize; `Shift` temporarily inverts the active mode for any resize control.
 
 `CropManager` public methods:
 - `startCanvasCrop()` enters crop mode for the montage area.
 - `startImageCrop()` enters crop mode for a `FabricImage` target or the active image object.
 - `setAspectRatio()` updates the active crop frame by width/height ratio.
 - `setSize()` updates the active crop frame by explicit dimensions.
+- `setPreserveAspectRatio()` toggles whether crop resize keeps the current aspect ratio for the active crop frame.
 - `getState()` returns the active crop state, including mode, frame, target, options, and result rect.
 - `apply()` commits the active crop and saves the new state to history.
 - `cancel()` exits crop mode without changing the montage area or image.

--- a/e2e/models/crop.model.ts
+++ b/e2e/models/crop.model.ts
@@ -171,6 +171,35 @@ export class CropModel {
     return this.requireState()
   }
 
+  /** Задаёт пропорции активной crop-области через публичный API редактора. */
+  async setAspectRatio(params: CropSizeInfo): Promise<CropStateInfo> {
+    await this.page.evaluate((aspectRatio) => {
+      const { editor } = window as any
+
+      editor.cropManager.setAspectRatio({ aspectRatio })
+    }, params)
+
+    await waitForCanvasRender({ page: this.page })
+
+    return this.requireState()
+  }
+
+  /** Переключает сохранение пропорций у resize crop-области через публичный API редактора. */
+  async setPreserveAspectRatio(
+    params: { preserveAspectRatio: boolean }
+  ): Promise<CropStateInfo> {
+    const state = await this.page.evaluate((payload) => {
+      const { editor } = window as any
+
+      return editor.cropManager.setPreserveAspectRatio(payload)
+    }, params)
+
+    expect(state, 'режим сохранения пропорций у active crop должен обновиться').not.toBeNull()
+    await waitForCanvasRender({ page: this.page })
+
+    return this.requireState()
+  }
+
   /** Применяет активный crop mode. */
   async apply(): Promise<void> {
     const result = await this.page.evaluate(() => {
@@ -278,6 +307,40 @@ export class CropModel {
     await waitForCanvasRender({ page: this.page })
 
     return this.requireState()
+  }
+
+  /** Наводит курсор на указанный resize control активной crop-области. */
+  async hoverFrameControl(params: { control: CropControlKey }): Promise<void> {
+    const point = await this.resolveFrameControlPoint(params)
+
+    await this.page.mouse.move(point.x, point.y)
+    await waitForCanvasRender({ page: this.page })
+  }
+
+  /** Возвращает cursor canvas после hover указанного resize control. */
+  async getFrameControlCursor(
+    params: { control: CropControlKey, shiftKey?: boolean }
+  ): Promise<string> {
+    const {
+      control,
+      shiftKey = false
+    } = params
+
+    if (!shiftKey) {
+      await this.hoverFrameControl({ control })
+
+      return this.readCanvasCursor()
+    }
+
+    await this.page.keyboard.down('Shift')
+
+    try {
+      await this.hoverFrameControl({ control })
+
+      return await this.readCanvasCursor()
+    } finally {
+      await this.page.keyboard.up('Shift')
+    }
   }
 
   /** Завершает активный resize crop frame через mouseup. */
@@ -538,6 +601,51 @@ export class CropModel {
     }
 
     return state
+  }
+
+  /** Возвращает viewport-координаты resize control активной crop-области. */
+  private async resolveFrameControlPoint(
+    { control }: { control: CropControlKey }
+  ): Promise<{ x: number, y: number }> {
+    const point = await this.page.evaluate(({ control: controlKey }) => {
+      const { editor } = window as any
+      const cropState = editor.cropManager.getState()
+      if (!cropState) return null
+
+      const { frame } = cropState
+
+      editor.canvas.setActiveObject(frame)
+      frame.setCoords()
+      editor.canvas.renderAll()
+
+      const frameControl = frame.oCoords?.[controlKey]
+      if (!frameControl || typeof frameControl.x !== 'number' || typeof frameControl.y !== 'number') {
+        return null
+      }
+
+      const canvasRect = editor.canvas.upperCanvasEl.getBoundingClientRect()
+
+      return {
+        x: canvasRect.left + frameControl.x,
+        y: canvasRect.top + frameControl.y
+      }
+    }, { control })
+
+    expect(point, 'для hover crop-control должны существовать client-координаты').not.toBeNull()
+    if (!point) {
+      throw new Error('Не удалось получить client-координаты crop-control')
+    }
+
+    return point
+  }
+
+  /** Возвращает текущее значение cursor у верхнего canvas слоя. */
+  private async readCanvasCursor(): Promise<string> {
+    return this.page.evaluate(() => {
+      const { editor } = window as any
+
+      return editor.canvas.upperCanvasEl.style.cursor ?? ''
+    })
   }
 
   /** Преобразует желаемый размер результата crop в ratio-параметры resize control. */

--- a/e2e/tests/crop-manager/crop-size-indicator.spec.ts
+++ b/e2e/tests/crop-manager/crop-size-indicator.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../../fixtures/editor.fixture'
 import {
   CROP_SIZE_INSIDE_SNAP_THRESHOLD,
-  DEFAULT_MONTAGE_SIZE,
   FULL_CROP_MONTAGE_SIZES,
   FULL_CROP_SNAP_THRESHOLD_CORNER_CASES,
   FULL_CROP_SNAP_THRESHOLD_SIDE_CASES,
@@ -181,6 +180,14 @@ test.describe('Индикатор размеров crop-области', () => {
         editorModel,
         crop
       }) => {
+        await test.step('Отключить сохранение пропорций для проверки snap по одной оси', async() => {
+          const state = await crop.setPreserveAspectRatio({
+            preserveAspectRatio: false
+          })
+
+          expect(state.options.preserveAspectRatio).toBe(false)
+        })
+
         const heldSize = cropCase.axis === 'horizontal'
           ? {
             width: CROP_SIZE_INSIDE_SNAP_THRESHOLD,

--- a/e2e/tests/crop-manager/index.spec.ts
+++ b/e2e/tests/crop-manager/index.spec.ts
@@ -55,6 +55,526 @@ test.describe('Crop mode', () => {
     })
   })
 
+  test('resize правой стороны сохраняет пропорции без Shift и снимает ограничение с Shift', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за правую сторону без Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mr',
+        widthRatio: 0.72,
+        heightRatio: 1
+      })
+    })
+
+    await test.step('Проверить что при resize правой стороны пропорции остались прежними', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(initialState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(initialState.rect.height)
+      expect(resizedRatio).toBeCloseTo(initialRatio, 1)
+    })
+
+    await crop.cancel()
+
+    const restartedState = await test.step('Снова войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const freeResizeState = await test.step('Потянуть область за правую сторону с Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mr',
+        widthRatio: 0.72,
+        heightRatio: 1,
+        shiftKey: true
+      })
+    })
+
+    await test.step('Проверить что Shift снимает ограничение и пропорции меняются свободно', async() => {
+      const initialRatio = restartedState.rect.width / restartedState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeLessThan(restartedState.rect.width)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+  })
+
+  test('resize верхней стороны сохраняет пропорции без Shift', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за верхнюю сторону без Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mt',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что при resize верхней стороны пропорции остались прежними', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(initialState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(initialState.rect.height)
+      expect(resizedRatio).toBeCloseTo(initialRatio, 1)
+    })
+  })
+
+  test('resize левой стороны сохраняет пропорции без Shift и снимает ограничение с Shift', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за левую сторону без Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'ml',
+        widthRatio: 0.72,
+        heightRatio: 1
+      })
+    })
+
+    await test.step('Проверить что при resize левой стороны пропорции остались прежними', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(initialState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(initialState.rect.height)
+      expect(resizedRatio).toBeCloseTo(initialRatio, 1)
+    })
+
+    await crop.cancel()
+
+    const restartedState = await test.step('Снова войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const freeResizeState = await test.step('Потянуть область за левую сторону с Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'ml',
+        widthRatio: 0.72,
+        heightRatio: 1,
+        shiftKey: true
+      })
+    })
+
+    await test.step('Проверить что Shift снимает ограничение и оставляет высоту без изменений', async() => {
+      const initialRatio = restartedState.rect.width / restartedState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeLessThan(restartedState.rect.width)
+      expect(freeResizeState.rect.height).toBeCloseTo(restartedState.rect.height, 3)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+  })
+
+  test('resize нижней стороны сохраняет пропорции без Shift и снимает ограничение с Shift', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за нижнюю сторону без Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mb',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что при resize нижней стороны пропорции остались прежними', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(initialState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(initialState.rect.height)
+      expect(resizedRatio).toBeCloseTo(initialRatio, 1)
+    })
+
+    await crop.cancel()
+
+    const restartedState = await test.step('Снова войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const freeResizeState = await test.step('Потянуть область за нижнюю сторону с Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mb',
+        widthRatio: 1,
+        heightRatio: 0.72,
+        shiftKey: true
+      })
+    })
+
+    await test.step('Проверить что Shift снимает ограничение и оставляет ширину без изменений', async() => {
+      const initialRatio = restartedState.rect.width / restartedState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeCloseTo(restartedState.rect.width, 3)
+      expect(freeResizeState.rect.height).toBeLessThan(restartedState.rect.height)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+  })
+
+  CROP_SIDE_CASES.forEach(({ control, title }) => {
+    test(`при hover ${title} курсор не меняется от Shift в обоих режимах preserveAspectRatio`, async({ crop }) => {
+      await test.step('Войти в crop с квадратной областью', async() => {
+        await crop.startCanvasCrop({
+          aspectRatio: {
+            width: 1,
+            height: 1
+          }
+        })
+      })
+
+      const baseCursor = await test.step('Навести курсор на side-control без Shift', async() => {
+        return crop.getFrameControlCursor({ control })
+      })
+
+      const shiftedCursor = await test.step('Зажать Shift и повторно навести курсор на тот же control', async() => {
+        return crop.getFrameControlCursor({
+          control,
+          shiftKey: true
+        })
+      })
+
+      await test.step('Проверить что при preserveAspectRatio = true курсор остался resize', async() => {
+        expect(baseCursor).not.toBe('not-allowed')
+        expect(shiftedCursor).toBe(baseCursor)
+      })
+
+      const unlockedState = await test.step('Отключить preserveAspectRatio у активной crop-области', async() => {
+        return crop.setPreserveAspectRatio({
+          preserveAspectRatio: false
+        })
+      })
+
+      await test.step('Проверить что публичное состояние отражает отключённый режим', async() => {
+        expect(unlockedState.options.preserveAspectRatio).toBe(false)
+        expect(unlockedState.rect.width / unlockedState.rect.height).toBeCloseTo(1, 3)
+      })
+
+      const freeBaseCursor = await test.step('Навести курсор на side-control без Shift при preserveAspectRatio = false', async() => {
+        return crop.getFrameControlCursor({ control })
+      })
+
+      const freeShiftedCursor = await test.step(
+        'Зажать Shift и повторно навести курсор на тот же control при preserveAspectRatio = false',
+        async() => {
+          return crop.getFrameControlCursor({
+            control,
+            shiftKey: true
+          })
+        }
+      )
+
+      await test.step('Проверить что при preserveAspectRatio = false курсор тоже остался resize', async() => {
+        expect(freeBaseCursor).not.toBe('not-allowed')
+        expect(freeShiftedCursor).toBe(freeBaseCursor)
+      })
+    })
+  })
+
+  test('при старте crop mode можно отключить сохранение пропорций у resize правой стороны', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью и отключённым сохранением пропорций', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        },
+        preserveAspectRatio: false
+      })
+    })
+
+    await test.step('Проверить что публичное состояние отражает отключённый режим', async() => {
+      expect(initialState.options.preserveAspectRatio).toBe(false)
+      expect(initialState.rect.width / initialState.rect.height).toBeCloseTo(1, 3)
+    })
+
+    const freeResizeState = await test.step('Потянуть область за правую сторону без Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mr',
+        widthRatio: 0.72,
+        heightRatio: 1
+      })
+    })
+
+    await test.step('Проверить что без Shift правая сторона меняет только ширину', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeLessThan(initialState.rect.width)
+      expect(freeResizeState.rect.height).toBeCloseTo(initialState.rect.height, 3)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+
+    await crop.cancel()
+
+    const restartedState = await test.step('Снова войти в crop с тем же флагом для проверки Shift', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        },
+        preserveAspectRatio: false
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за правую сторону с Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mr',
+        widthRatio: 0.72,
+        heightRatio: 1,
+        shiftKey: true
+      })
+    })
+
+    await test.step('Проверить что Shift возвращает сохранение пропорций и меняет обе оси', async() => {
+      const initialRatio = restartedState.rect.width / restartedState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(restartedState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(restartedState.rect.height)
+      expect(resizedRatio).toBeCloseTo(initialRatio, 1)
+    })
+  })
+
+  test('уже активной crop-области можно переключить сохранение пропорций у resize верхней стороны', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    await test.step('Проверить что по умолчанию режим сохранения пропорций включён', async() => {
+      expect(initialState.options.preserveAspectRatio).toBe(true)
+      expect(initialState.rect.width / initialState.rect.height).toBeCloseTo(1, 3)
+    })
+
+    const unlockedState = await test.step('Отключить сохранение пропорций у уже активной области', async() => {
+      return crop.setPreserveAspectRatio({
+        preserveAspectRatio: false
+      })
+    })
+
+    await test.step('Проверить что новый режим виден через публичное состояние', async() => {
+      expect(unlockedState.options.preserveAspectRatio).toBe(false)
+      expect(unlockedState.rect.width / unlockedState.rect.height).toBeCloseTo(1, 3)
+    })
+
+    const freeResizeState = await test.step('Потянуть область за верхнюю сторону без Shift после переключения режима', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mt',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что без Shift верхняя сторона меняет только высоту', async() => {
+      const initialRatio = unlockedState.rect.width / unlockedState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeCloseTo(unlockedState.rect.width, 3)
+      expect(freeResizeState.rect.height).toBeLessThan(unlockedState.rect.height)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+
+    const relockedState = await test.step('Снова включить сохранение пропорций у уже активной области', async() => {
+      return crop.setPreserveAspectRatio({
+        preserveAspectRatio: true
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за верхнюю сторону без Shift после обратного переключения', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mt',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что после обратного переключения верхняя сторона снова сохраняет пропорции', async() => {
+      const relockedRatio = relockedState.rect.width / relockedState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(relockedState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(relockedState.rect.height)
+      expect(resizedRatio).toBeCloseTo(relockedRatio, 1)
+    })
+  })
+
+  test('при старте crop mode можно отключить сохранение пропорций у resize из угла', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью и отключённым сохранением пропорций', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        },
+        preserveAspectRatio: false
+      })
+    })
+
+    await test.step('Проверить что публичное состояние отражает отключённый режим', async() => {
+      expect(initialState.options.preserveAspectRatio).toBe(false)
+      expect(initialState.rect.width / initialState.rect.height).toBeCloseTo(1, 3)
+    })
+
+    const freeResizeState = await test.step('Потянуть область из угла без Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'br',
+        widthRatio: 1.45,
+        heightRatio: 1.1
+      })
+    })
+
+    await test.step('Проверить что без Shift пропорции больше не фиксируются', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeGreaterThan(initialState.rect.width)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+
+    await crop.cancel()
+
+    const restartedState = await test.step('Снова войти в crop с тем же флагом для проверки Shift', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        },
+        preserveAspectRatio: false
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область из угла с Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'br',
+        widthRatio: 1.45,
+        heightRatio: 1.1,
+        shiftKey: true
+      })
+    })
+
+    await test.step('Проверить что Shift инвертирует режим и возвращает сохранение пропорций', async() => {
+      const initialRatio = restartedState.rect.width / restartedState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeGreaterThan(restartedState.rect.width)
+      expect(resizedRatio).toBeCloseTo(initialRatio, 1)
+    })
+  })
+
+  test('уже активной crop-области можно переключить сохранение пропорций у resize из угла', async({ crop }) => {
+    const initialState = await test.step('Войти в crop с квадратной областью', async() => {
+      return crop.startCanvasCrop({
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    await test.step('Проверить что по умолчанию режим сохранения пропорций включён', async() => {
+      expect(initialState.options.preserveAspectRatio).toBe(true)
+      expect(initialState.rect.width / initialState.rect.height).toBeCloseTo(1, 3)
+    })
+
+    const unlockedState = await test.step('Отключить сохранение пропорций и выбрать пользовательские пропорции', async() => {
+      await crop.setPreserveAspectRatio({
+        preserveAspectRatio: false
+      })
+
+      return crop.setAspectRatio({
+        width: 5,
+        height: 4
+      })
+    })
+
+    await test.step('Проверить что новый режим виден через публичное состояние', async() => {
+      expect(unlockedState.options.preserveAspectRatio).toBe(false)
+      expect(unlockedState.rect.width / unlockedState.rect.height).toBeCloseTo(1.25, 1)
+    })
+
+    const freeResizeState = await test.step('Потянуть область из угла без Shift после переключения режима', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'br',
+        widthRatio: 1.4,
+        heightRatio: 1.1
+      })
+    })
+
+    await test.step('Проверить что без Shift пропорции меняются свободно', async() => {
+      const initialRatio = unlockedState.rect.width / unlockedState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeGreaterThan(unlockedState.rect.width)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+
+    const relockedState = await test.step('Снова включить сохранение пропорций у уже активной области', async() => {
+      return crop.setPreserveAspectRatio({
+        preserveAspectRatio: true
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область из угла без Shift после обратного переключения', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'br',
+        widthRatio: 1.25,
+        heightRatio: 1.05
+      })
+    })
+
+    await test.step('Проверить что после обратного переключения пропорции снова фиксируются', async() => {
+      const relockedRatio = relockedState.rect.width / relockedState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(relockedState.options.preserveAspectRatio).toBe(true)
+      expect(resizedRatio).toBeCloseTo(relockedRatio, 1)
+    })
+  })
+
   test('resize из правого нижнего угла не выпускает crop-область за максимальный размер', async({
     editorModel,
     crop
@@ -103,27 +623,21 @@ test.describe('Crop mode', () => {
     })
   })
 
-  CROP_SIDE_CASES.forEach(({ control, title, direction }) => {
+  CROP_SIDE_CASES.forEach(({ control, title }) => {
     test(`resize ${title} не выпускает crop-область за лимиты`, async({ crop }) => {
       const enlargedState = await test.step('Войти в crop и резко увеличить область', async() => {
         await crop.startCanvasCrop()
 
         return crop.resizeFrameFromControl({
           control,
-          widthRatio: direction === 'horizontal' ? 20 : 1,
-          heightRatio: direction === 'vertical' ? 20 : 1
+          widthRatio: control === 'ml' || control === 'mr' ? 20 : 1,
+          heightRatio: control === 'mt' || control === 'mb' ? 20 : 1
         })
       })
 
-      await test.step('Проверить что live-размер ограничен максимумом по активной оси', async() => {
-        if (direction === 'horizontal') {
-          expect(enlargedState.rect.width).toBe(CROP_MAX_SIZE.width)
-          expect(enlargedState.rect.height).toBeLessThan(CROP_MAX_SIZE.height)
-          return
-        }
-
+      await test.step('Проверить что live-размер ограничен максимумом с сохранением пропорций', async() => {
+        expect(enlargedState.rect.width).toBe(CROP_MAX_SIZE.width)
         expect(enlargedState.rect.height).toBe(CROP_MAX_SIZE.height)
-        expect(enlargedState.rect.width).toBeLessThan(CROP_MAX_SIZE.width)
       })
 
       const shrunkState = await test.step('Снова войти в crop и резко уменьшить область', async() => {
@@ -132,25 +646,19 @@ test.describe('Crop mode', () => {
 
         return crop.resizeFrameFromControl({
           control,
-          widthRatio: direction === 'horizontal' ? 0.001 : 1,
-          heightRatio: direction === 'vertical' ? 0.001 : 1
+          widthRatio: control === 'ml' || control === 'mr' ? 0.001 : 1,
+          heightRatio: control === 'mt' || control === 'mb' ? 0.001 : 1
         })
       })
 
-      await test.step('Проверить что live-размер остановился на минимуме по активной оси', async() => {
-        if (direction === 'horizontal') {
-          expect(shrunkState.rect.width).toBe(CROP_MIN_SIZE.width)
-          expect(shrunkState.rect.height).toBeGreaterThan(CROP_MIN_SIZE.height)
-          return
-        }
-
+      await test.step('Проверить что live-размер остановился на минимуме с сохранением пропорций', async() => {
+        expect(shrunkState.rect.width).toBe(CROP_MIN_SIZE.width)
         expect(shrunkState.rect.height).toBe(CROP_MIN_SIZE.height)
-        expect(shrunkState.rect.width).toBeGreaterThan(CROP_MIN_SIZE.width)
       })
     })
   })
 
-  CROP_RESIZE_CASES.forEach(({ control, title, direction }) => {
+  CROP_RESIZE_CASES.forEach(({ control, title }) => {
     test(`быстрый resize из ${title} через противоположную сторону останавливается на 16 px`, async({ crop }) => {
       const resizedState = await test.step('Войти в crop и резко провести pointer за противоположную сторону', async() => {
         await crop.startCanvasCrop()
@@ -163,18 +671,6 @@ test.describe('Crop mode', () => {
       })
 
       await test.step('Проверить что crop-область зафиксировалась на минимальном размере', async() => {
-        if (direction === 'horizontal') {
-          expect(resizedState.rect.width).toBe(CROP_MIN_SIZE.width)
-          expect(resizedState.rect.height).toBeGreaterThan(CROP_MIN_SIZE.height)
-          return
-        }
-
-        if (direction === 'vertical') {
-          expect(resizedState.rect.height).toBe(CROP_MIN_SIZE.height)
-          expect(resizedState.rect.width).toBeGreaterThan(CROP_MIN_SIZE.width)
-          return
-        }
-
         expect(resizedState.rect.width).toBe(CROP_MIN_SIZE.width)
         expect(resizedState.rect.height).toBe(CROP_MIN_SIZE.height)
       })
@@ -371,6 +867,239 @@ test.describe('Crop mode', () => {
       await toolbar.waitUntilVisible()
 
       expect(await toolbar.isVisible()).toBe(true)
+    })
+  })
+
+  test('при старте image crop можно отключить сохранение пропорций у resize правой стороны', async({
+    crop,
+    images
+  }) => {
+    const image = await test.step('Добавить изображение', async() => {
+      return images.checkCreation({
+        imageObject: await images.addFilledImage({
+          width: 140,
+          height: 100
+        })
+      })
+    })
+
+    const initialState = await test.step('Войти в crop изображения с квадратной областью и отключённым сохранением пропорций', async() => {
+      return crop.startImageCrop({
+        id: image.id,
+        aspectRatio: {
+          width: 1,
+          height: 1
+        },
+        preserveAspectRatio: false
+      })
+    })
+
+    await test.step('Проверить что image crop стартовал с отключённым режимом', async() => {
+      expect(initialState.mode).toBe('image')
+      expect(initialState.options.preserveAspectRatio).toBe(false)
+      expect(initialState.targetId).toBe(image.id)
+    })
+
+    const freeResizeState = await test.step('Потянуть область за правую сторону без Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mr',
+        widthRatio: 0.72,
+        heightRatio: 1
+      })
+    })
+
+    await test.step('Проверить что без Shift правая сторона меняет только ширину', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.width).toBeLessThan(initialState.rect.width)
+      expect(freeResizeState.rect.height).toBeCloseTo(initialState.rect.height, 3)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+
+    await crop.cancel()
+
+    const restartedState = await test.step('Снова войти в image crop с тем же флагом для проверки Shift', async() => {
+      return crop.startImageCrop({
+        id: image.id,
+        aspectRatio: {
+          width: 1,
+          height: 1
+        },
+        preserveAspectRatio: false
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за правую сторону с Shift', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mr',
+        widthRatio: 0.72,
+        heightRatio: 1,
+        shiftKey: true
+      })
+    })
+
+    await test.step('Проверить что Shift возвращает сохранение пропорций и меняет обе оси', async() => {
+      const initialRatio = restartedState.rect.width / restartedState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(restartedState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(restartedState.rect.height)
+      expect(resizedRatio).toBeCloseTo(initialRatio, 1)
+    })
+  })
+
+  test('уже активному image crop можно переключить сохранение пропорций у resize верхней стороны', async({
+    crop,
+    images
+  }) => {
+    const image = await test.step('Добавить изображение', async() => {
+      return images.checkCreation({
+        imageObject: await images.addFilledImage({
+          width: 1000,
+          height: 667
+        })
+      })
+    })
+
+    const initialState = await test.step('Войти в image crop с квадратной областью', async() => {
+      return crop.startImageCrop({
+        id: image.id,
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    await test.step('Проверить что по умолчанию режим сохранения пропорций включён', async() => {
+      expect(initialState.mode).toBe('image')
+      expect(initialState.options.preserveAspectRatio).toBe(true)
+      expect(initialState.targetId).toBe(image.id)
+    })
+
+    const unlockedState = await test.step('Отключить сохранение пропорций у уже активного image crop', async() => {
+      return crop.setPreserveAspectRatio({
+        preserveAspectRatio: false
+      })
+    })
+
+    await test.step('Проверить что новый режим виден через публичное состояние', async() => {
+      expect(unlockedState.mode).toBe('image')
+      expect(unlockedState.options.preserveAspectRatio).toBe(false)
+      expect(unlockedState.targetId).toBe(image.id)
+    })
+
+    const freeResizeState = await test.step('Потянуть область за верхнюю сторону без Shift после переключения режима', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mt',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что без Shift верхняя сторона меняет только высоту', async() => {
+      const initialRatio = unlockedState.rect.width / unlockedState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(Math.abs(freeResizeState.rect.width - unlockedState.rect.width)).toBeLessThan(2)
+      expect(freeResizeState.rect.height).toBeLessThan(unlockedState.rect.height)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+
+    const relockedState = await test.step('Снова включить сохранение пропорций у уже активного image crop', async() => {
+      return crop.setPreserveAspectRatio({
+        preserveAspectRatio: true
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за верхнюю сторону без Shift после обратного переключения', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mt',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что после обратного переключения верхняя сторона снова сохраняет пропорции', async() => {
+      const relockedRatio = relockedState.rect.width / relockedState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(relockedState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(relockedState.rect.height)
+      expect(resizedRatio).toBeCloseTo(relockedRatio, 1)
+    })
+  })
+
+  test('на маленьком image crop повторное включение сохранения пропорций у resize верхней стороны не ломает геометрию', async({
+    crop,
+    images
+  }) => {
+    const image = await test.step('Добавить маленькое изображение', async() => {
+      return images.checkCreation({
+        imageObject: await images.addFilledImage({
+          width: 140,
+          height: 100
+        })
+      })
+    })
+
+    const initialState = await test.step('Войти в image crop с квадратной областью', async() => {
+      return crop.startImageCrop({
+        id: image.id,
+        aspectRatio: {
+          width: 1,
+          height: 1
+        }
+      })
+    })
+
+    const unlockedState = await test.step('Отключить сохранение пропорций у уже активного image crop', async() => {
+      return crop.setPreserveAspectRatio({
+        preserveAspectRatio: false
+      })
+    })
+
+    const freeResizeState = await test.step('Потянуть область за верхнюю сторону без Shift после переключения режима', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mt',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что без Shift маленькая область всё ещё заметно меняет пропорции', async() => {
+      const initialRatio = initialState.rect.width / initialState.rect.height
+      const resizedRatio = freeResizeState.rect.width / freeResizeState.rect.height
+
+      expect(freeResizeState.rect.height).toBeLessThan(unlockedState.rect.height)
+      expect(Math.abs(resizedRatio - initialRatio)).toBeGreaterThan(0.1)
+    })
+
+    const relockedState = await test.step('Снова включить сохранение пропорций у уже активного image crop', async() => {
+      return crop.setPreserveAspectRatio({
+        preserveAspectRatio: true
+      })
+    })
+
+    const preservedState = await test.step('Потянуть область за верхнюю сторону без Shift после обратного переключения', async() => {
+      return crop.resizeFrameFromControl({
+        control: 'mt',
+        widthRatio: 1,
+        heightRatio: 0.72
+      })
+    })
+
+    await test.step('Проверить что маленькая область после relock уменьшается по обеим осям и не уходит в сильный перекос', async() => {
+      const relockedRatio = relockedState.rect.width / relockedState.rect.height
+      const resizedRatio = preservedState.rect.width / preservedState.rect.height
+      const widthScale = preservedState.rect.width / relockedState.rect.width
+      const heightScale = preservedState.rect.height / relockedState.rect.height
+
+      expect(preservedState.rect.width).toBeLessThan(relockedState.rect.width)
+      expect(preservedState.rect.height).toBeLessThan(relockedState.rect.height)
+      expect(Math.abs(widthScale - heightScale)).toBeLessThan(0.06)
+      expect(Math.abs(resizedRatio - relockedRatio)).toBeLessThan(0.12)
     })
   })
 

--- a/e2e/types/crop.types.ts
+++ b/e2e/types/crop.types.ts
@@ -25,6 +25,7 @@ export interface CropSessionOptionsInfo {
   allowFrameOverflow: boolean
   showGrid: boolean
   cancelOnSelectionClear: boolean
+  preserveAspectRatio: boolean
 }
 
 /** Сериализованное состояние runtime crop frame. */
@@ -67,6 +68,7 @@ export interface CropStartParams extends ObjectTargetParams {
   allowFrameOverflow?: boolean
   showGrid?: boolean
   cancelOnSelectionClear?: boolean
+  preserveAspectRatio?: boolean
 }
 
 /** Параметры интерактивного resize crop frame из control. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/crop-manager/crop-controls.spec.ts
+++ b/specs/src/editor/crop-manager/crop-controls.spec.ts
@@ -1,0 +1,133 @@
+import {
+  Control,
+  Rect,
+  type TPointerEvent
+} from 'fabric'
+
+import { applyCropResizeControls } from '../../../../src/editor/crop-manager/interaction/crop-controls'
+
+type CropResizeControl = Control & {
+  cropResizeControl?: boolean
+}
+
+describe('crop-controls', () => {
+  it('боковые контролы остаются resize-only и не переключаются в skew под Shift', () => {
+    const target = new Rect({
+      width: 100,
+      height: 80
+    })
+    const rightControl = new Control({
+      actionHandler: jest.fn(),
+      cursorStyleHandler: jest.fn(() => 'not-allowed'),
+      getActionName: jest.fn(() => 'skewY')
+    })
+    const topControl = new Control({
+      actionHandler: jest.fn(),
+      cursorStyleHandler: jest.fn(() => 'not-allowed'),
+      getActionName: jest.fn(() => 'skewX')
+    })
+
+    target.controls = {
+      mr: rightControl,
+      mt: topControl
+    } as never
+
+    applyCropResizeControls({ target })
+
+    const wrappedRightControl = target.controls.mr as Control
+    const wrappedTopControl = target.controls.mt as Control
+    const plainEvent = {
+      shiftKey: false
+    } satisfies Pick<TPointerEvent, 'shiftKey'>
+    const shiftedEvent = {
+      shiftKey: true
+    } satisfies Pick<TPointerEvent, 'shiftKey'>
+
+    expect((wrappedRightControl as CropResizeControl).cropResizeControl).toBe(true)
+    expect((wrappedTopControl as CropResizeControl).cropResizeControl).toBe(true)
+    expect(wrappedRightControl.cursorStyleHandler(
+      plainEvent as TPointerEvent,
+      wrappedRightControl,
+      target,
+      {} as never
+    )).toBe('e-resize')
+    expect(wrappedRightControl.cursorStyleHandler(
+      shiftedEvent as TPointerEvent,
+      wrappedRightControl,
+      target,
+      {} as never
+    )).toBe('e-resize')
+    expect(wrappedRightControl.getActionName(
+      plainEvent as TPointerEvent,
+      wrappedRightControl,
+      target
+    )).toBe('scaleX')
+    expect(wrappedRightControl.getActionName(
+      shiftedEvent as TPointerEvent,
+      wrappedRightControl,
+      target
+    )).toBe('scaleX')
+    expect(wrappedTopControl.cursorStyleHandler(
+      plainEvent as TPointerEvent,
+      wrappedTopControl,
+      target,
+      {} as never
+    )).toBe('n-resize')
+    expect(wrappedTopControl.cursorStyleHandler(
+      shiftedEvent as TPointerEvent,
+      wrappedTopControl,
+      target,
+      {} as never
+    )).toBe('n-resize')
+    expect(wrappedTopControl.getActionName(
+      plainEvent as TPointerEvent,
+      wrappedTopControl,
+      target
+    )).toBe('scaleY')
+    expect(wrappedTopControl.getActionName(
+      shiftedEvent as TPointerEvent,
+      wrappedTopControl,
+      target
+    )).toBe('scaleY')
+  })
+
+  it('угловой control сохраняет свой getActionName после обёртки', () => {
+    const target = new Rect({
+      width: 100,
+      height: 80
+    })
+    const cornerGetActionName = jest.fn(() => 'corner-scale')
+    const topLeftControl = new Control({
+      actionHandler: jest.fn(),
+      getActionName: cornerGetActionName
+    })
+
+    target.controls = {
+      tl: topLeftControl,
+      mr: new Control({
+        actionHandler: jest.fn()
+      })
+    } as never
+
+    applyCropResizeControls({ target })
+
+    const wrappedTopLeftControl = target.controls.tl as Control
+    const eventData = {
+      shiftKey: true
+    } satisfies Pick<TPointerEvent, 'shiftKey'>
+    const actionName = wrappedTopLeftControl.getActionName(
+      eventData as TPointerEvent,
+      wrappedTopLeftControl,
+      target
+    )
+
+    expect(wrappedTopLeftControl).not.toBe(topLeftControl)
+    expect((wrappedTopLeftControl as CropResizeControl).cropResizeControl).toBe(true)
+    expect(actionName).toBe('corner-scale')
+    expect(cornerGetActionName).toHaveBeenCalledWith(
+      eventData,
+      wrappedTopLeftControl,
+      target
+    )
+  })
+})

--- a/specs/src/editor/crop-manager/crop-frame.spec.ts
+++ b/specs/src/editor/crop-manager/crop-frame.spec.ts
@@ -2,6 +2,23 @@ import { CropFrame } from '../../../../src/editor/crop-manager/domain/crop-frame
 import { resetCropCanvasContext } from '../../../test-utils/crop/image-crop'
 
 describe('crop frame', () => {
+  it('по умолчанию включает preserveAspectRatio и позволяет явно его отключить', () => {
+    const defaultFrame = new CropFrame({
+      width: 90,
+      height: 60,
+      showGrid: false
+    })
+    const unlockedFrame = new CropFrame({
+      width: 90,
+      height: 60,
+      showGrid: false,
+      preserveAspectRatio: false
+    })
+
+    expect(defaultFrame.preserveAspectRatio).toBe(true)
+    expect(unlockedFrame.preserveAspectRatio).toBe(false)
+  })
+
   it('рисует сетку третей, когда showGrid включён', () => {
     const context = resetCropCanvasContext()
     const frame = new CropFrame({

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -239,6 +239,13 @@
                 </label>
               </div>
 
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="crop-preserve-aspect-ratio-checkbox" checked />
+                <label class="form-check-label" for="crop-preserve-aspect-ratio-checkbox">
+                  Keep ratio on resize
+                </label>
+              </div>
+
               <div class="form-check mb-2">
                 <input class="form-check-input" type="checkbox" id="crop-cancel-on-selection-clear-checkbox" checked />
                 <label class="form-check-label" for="crop-cancel-on-selection-clear-checkbox">

--- a/src/demo/js/elements.js
+++ b/src/demo/js/elements.js
@@ -60,6 +60,8 @@ const cropHeightInput = document.getElementById('crop-height-input')
 const cropAllowOverflowCheckbox = document.getElementById('crop-allow-overflow-checkbox')
 /** Checkbox отображения сетки crop frame. */
 const cropShowGridCheckbox = document.getElementById('crop-show-grid-checkbox')
+/** Checkbox сохранения текущих пропорций при resize crop frame. */
+const cropPreserveAspectRatioCheckbox = document.getElementById('crop-preserve-aspect-ratio-checkbox')
 /** Checkbox отмены crop mode при сбросе выделения. */
 const cropCancelOnSelectionClearCheckbox = document.getElementById('crop-cancel-on-selection-clear-checkbox')
 /** Кнопка входа в crop mode монтажной области. */
@@ -313,6 +315,7 @@ export const cropControls = {
   cropAllowOverflowCheckbox,
   cropCancelOnSelectionClearCheckbox,
   cropHeightInput,
+  cropPreserveAspectRatioCheckbox,
   cropRatioSelect,
   cropShowGridCheckbox,
   cropWidthInput,

--- a/src/demo/js/listeners/init-crop-listeners.js
+++ b/src/demo/js/listeners/init-crop-listeners.js
@@ -7,7 +7,8 @@ const getCropBehaviorOptions = ({ controls }) => {
   return {
     allowFrameOverflow: controls.cropAllowOverflowCheckbox.checked,
     showGrid: controls.cropShowGridCheckbox.checked,
-    cancelOnSelectionClear: controls.cropCancelOnSelectionClearCheckbox.checked
+    cancelOnSelectionClear: controls.cropCancelOnSelectionClearCheckbox.checked,
+    preserveAspectRatio: controls.cropPreserveAspectRatioCheckbox.checked
   }
 }
 
@@ -131,5 +132,14 @@ export default ({ editorInstance, controls }) => {
       editorInstance,
       controls
     })
+  })
+
+  controls.cropPreserveAspectRatioCheckbox.addEventListener('change', () => {
+    if (!editorInstance.cropManager.isActive) return
+
+    const state = editorInstance.cropManager.setPreserveAspectRatio({
+      preserveAspectRatio: controls.cropPreserveAspectRatioCheckbox.checked
+    })
+    if (!state) return
   })
 }

--- a/src/demo/js/listeners/init-crop-listeners.js
+++ b/src/demo/js/listeners/init-crop-listeners.js
@@ -140,6 +140,5 @@ export default ({ editorInstance, controls }) => {
     const state = editorInstance.cropManager.setPreserveAspectRatio({
       preserveAspectRatio: controls.cropPreserveAspectRatioCheckbox.checked
     })
-    if (!state) return
   })
 }

--- a/src/editor/crop-manager/domain/crop-frame.ts
+++ b/src/editor/crop-manager/domain/crop-frame.ts
@@ -24,6 +24,14 @@ interface CropFrameOptions extends Partial<RectProps> {
   showGrid: boolean
   sourceScaleX?: number
   sourceScaleY?: number
+  preserveAspectRatio?: boolean
+}
+
+/**
+ * Runtime-контракт crop frame для выбора режима resize.
+ */
+export interface CropFrameResizeTarget extends FabricObject {
+  preserveAspectRatio?: boolean
 }
 
 /**
@@ -41,6 +49,11 @@ export class CropFrame extends Rect {
   public readonly cropSourceScaleY: number
 
   /**
+    * Сохранять ли текущие пропорции при resize без модификаторов.
+   */
+  public preserveAspectRatio: boolean
+
+  /**
    * Показывать ли сетку внутри crop frame.
    */
   private readonly _showGrid: boolean
@@ -53,6 +66,7 @@ export class CropFrame extends Rect {
       showGrid,
       sourceScaleX = 1,
       sourceScaleY = 1,
+      preserveAspectRatio = true,
       ...rectOptions
     } = options
 
@@ -60,6 +74,7 @@ export class CropFrame extends Rect {
     this._showGrid = showGrid
     this.cropSourceScaleX = sourceScaleX
     this.cropSourceScaleY = sourceScaleY
+    this.preserveAspectRatio = preserveAspectRatio
   }
 
   /**
@@ -98,11 +113,13 @@ export class CropFrame extends Rect {
 export function createCropFrame({
   source,
   cropSize,
-  showGrid
+  showGrid,
+  preserveAspectRatio
 }: {
   source: FabricObject
   cropSize: CropSize
   showGrid: boolean
+  preserveAspectRatio: boolean
 }): Rect {
   const center = source.getCenterPoint()
   const sourceScaleX = source.scaleX ?? 1
@@ -133,6 +150,7 @@ export function createCropFrame({
     lockSkewingY: true,
     excludeFromExport: true,
     showGrid,
+    preserveAspectRatio,
     sourceScaleX,
     sourceScaleY
   })

--- a/src/editor/crop-manager/index.ts
+++ b/src/editor/crop-manager/index.ts
@@ -15,7 +15,10 @@ import {
   getSourceSize,
   resolveCropSize
 } from './domain/crop-geometry'
-import { createCropFrame } from './domain/crop-frame'
+import {
+  createCropFrame,
+  type CropFrameResizeTarget
+} from './domain/crop-frame'
 import {
   getCropSessionResultRect,
   getRoundedCropRect
@@ -42,7 +45,8 @@ import type {
 const DEFAULT_CROP_SESSION_OPTIONS = {
   allowFrameOverflow: true,
   showGrid: true,
-  cancelOnSelectionClear: true
+  cancelOnSelectionClear: true,
+  preserveAspectRatio: true
 } satisfies CropSessionOptions
 
 /**
@@ -235,6 +239,27 @@ export default class CropManager {
   }
 
   /**
+   * Переключает сохранение пропорций при resize активной crop-области.
+   */
+  public setPreserveAspectRatio({
+    preserveAspectRatio
+  }: {
+    preserveAspectRatio: boolean
+  }): CropState | null {
+    const { _session: session } = this
+    if (!session) return null
+
+    session.options.preserveAspectRatio = preserveAspectRatio
+    this._setFramePreserveAspectRatio({
+      frame: session.frame,
+      preserveAspectRatio
+    })
+    this.editor.canvas.requestRenderAll()
+
+    return this.getState()
+  }
+
+  /**
    * Сбрасывает активный crop frame к полному размеру source.
    */
   public resetFrameToSource({ target }: { target?: FabricObject | null }): CropState | null {
@@ -364,7 +389,9 @@ export default class CropManager {
     return {
       allowFrameOverflow: options.allowFrameOverflow ?? DEFAULT_CROP_SESSION_OPTIONS.allowFrameOverflow,
       showGrid: options.showGrid ?? DEFAULT_CROP_SESSION_OPTIONS.showGrid,
-      cancelOnSelectionClear: options.cancelOnSelectionClear ?? DEFAULT_CROP_SESSION_OPTIONS.cancelOnSelectionClear
+      cancelOnSelectionClear: options.cancelOnSelectionClear ?? DEFAULT_CROP_SESSION_OPTIONS.cancelOnSelectionClear,
+      preserveAspectRatio: options.preserveAspectRatio
+        ?? DEFAULT_CROP_SESSION_OPTIONS.preserveAspectRatio
     }
   }
 
@@ -391,8 +418,24 @@ export default class CropManager {
     return createCropFrame({
       source,
       cropSize,
-      showGrid: sessionOptions.showGrid
+      showGrid: sessionOptions.showGrid,
+      preserveAspectRatio: sessionOptions.preserveAspectRatio
     })
+  }
+
+  /**
+   * Синхронизирует runtime crop frame с активным режимом сохранения пропорций.
+   */
+  private _setFramePreserveAspectRatio({
+    frame,
+    preserveAspectRatio
+  }: {
+    frame: Rect
+    preserveAspectRatio: boolean
+  }): void {
+    const cropFrame = frame as CropFrameResizeTarget
+
+    cropFrame.preserveAspectRatio = preserveAspectRatio
   }
 
   /**

--- a/src/editor/crop-manager/interaction/crop-controls.ts
+++ b/src/editor/crop-manager/interaction/crop-controls.ts
@@ -12,6 +12,7 @@ import {
   MIN_CROP_FRAME_HEIGHT,
   MIN_CROP_FRAME_WIDTH
 } from '../domain/crop-geometry'
+import type { CropFrameResizeTarget } from '../domain/crop-frame'
 import { getCropFrameSourceSize } from '../domain/crop-frame-size'
 
 /**
@@ -76,11 +77,31 @@ type CropScaleDimensions = {
 type CropScaleAxis = 'x' | 'y'
 
 /**
+ * Action names side-resize crop control-ов без переключения в skew.
+ */
+type CropSideScaleActionName = 'scaleX' | 'scaleY'
+
+/**
  * Стартовые знаки control относительно центра crop frame.
  */
 type CropScaleSigns = {
   signX: number
   signY: number
+}
+
+/**
+ * Боковые control-ключи crop frame.
+ */
+type CropSideControlKey = typeof CROP_SIDE_CONTROL_KEYS[number]
+
+/**
+ * Cursor для side resize crop frame.
+ */
+const CROP_SIDE_RESIZE_CURSOR_BY_KEY: Record<CropSideControlKey, string> = {
+  ml: 'w-resize',
+  mr: 'e-resize',
+  mt: 'n-resize',
+  mb: 's-resize'
 }
 
 /**
@@ -226,6 +247,52 @@ function scaleCropFrameFromSide({
   if (axis === 'x') return currentScale !== target.scaleX
 
   return currentScale !== target.scaleY
+}
+
+/**
+ * Выполняет proportional resize frame через боковой control.
+ */
+function scaleCropFrameProportionallyFromSide({
+  transform,
+  axis,
+  x,
+  y
+}: {
+  transform: Transform
+  axis: CropScaleAxis
+  x: number
+  y: number
+}): boolean {
+  const cropTransform = transform as CropScaleTransform
+  const { target } = cropTransform
+  const { scaleX: currentScaleX = 1, scaleY: currentScaleY = 1 } = target
+
+  if (isPointerAtTransformStart({
+    transform: cropTransform,
+    x,
+    y
+  })) {
+    restoreOriginalScale({ transform: cropTransform })
+
+    return true
+  }
+
+  const localPoint = controlsUtils.getLocalPoint(
+    cropTransform,
+    cropTransform.originX,
+    cropTransform.originY,
+    x,
+    y
+  )
+
+  setInitialScaleSigns({ transform: cropTransform })
+  applyProportionalSideScale({
+    transform: cropTransform,
+    axis,
+    localPoint
+  })
+
+  return currentScaleX !== target.scaleX || currentScaleY !== target.scaleY
 }
 
 /**
@@ -386,6 +453,47 @@ function applySideScale({
 }
 
 /**
+ * Применяет proportional resize через боковой control.
+ */
+function applyProportionalSideScale({
+  transform,
+  axis,
+  localPoint
+}: {
+  transform: CropScaleTransform
+  axis: CropScaleAxis
+  localPoint: { x: number; y: number }
+}): void {
+  const { target } = transform
+  if (target.lockScalingX || target.lockScalingY) return
+
+  const axisScale = resolveAxisScale({
+    transform,
+    axis,
+    localPoint
+  })
+  const originalAxisScale = axis === 'x'
+    ? transform.original.scaleX
+    : transform.original.scaleY
+  const proportionalScale = originalAxisScale > 0
+    ? axisScale / originalAxisScale
+    : 1
+  const clampedScale = clampProportionalScale({
+    target,
+    transform,
+    scale: proportionalScale,
+    forceMinimum: hasScaleOriginCrossed({
+      transform,
+      axis,
+      localPoint
+    })
+  })
+
+  target.set('scaleX', clampedScale.scaleX)
+  target.set('scaleY', clampedScale.scaleY)
+}
+
+/**
  * Возвращает scale одной оси с учётом min/max и перелёта через origin.
  */
 function resolveAxisScale({
@@ -444,7 +552,7 @@ function applyProportionalCornerScale({
     localPoint,
     dimensions
   })
-  const clampedScale = clampProportionalCornerScale({
+  const clampedScale = clampProportionalScale({
     target,
     transform,
     scale,
@@ -521,7 +629,7 @@ function getCropScaleDimensions({ target }: { target: FabricObject }): CropScale
 /**
  * Ограничивает proportional scale единым multiplier, чтобы пропорции не ломались.
  */
-function clampProportionalCornerScale({
+function clampProportionalScale({
   target,
   transform,
   scale,
@@ -623,7 +731,25 @@ function hasProportionalScaleOriginCrossed({
 }
 
 /**
- * Создаёт action handler: пропорциональный resize по умолчанию, свободный при Shift.
+ * Возвращает true, если текущий resize должен сохранять пропорции.
+ */
+function shouldPreserveCropFrameAspectRatioOnResize({
+  eventData,
+  target
+}: {
+  eventData: { shiftKey?: boolean }
+  target: FabricObject
+}): boolean {
+  const cropTarget = target as CropFrameResizeTarget
+  const preserveAspectRatio = cropTarget.preserveAspectRatio ?? true
+
+  if (!eventData.shiftKey) return preserveAspectRatio
+
+  return !preserveAspectRatio
+}
+
+/**
+ * Создаёт action handler для resize из угла с поддержкой инверсии по Shift.
  */
 function createCropCornerScalingActionHandler(): NonNullable<Control['actionHandler']> {
   const freeScaleHandler = controlsUtils.wrapWithFireEvent(
@@ -648,9 +774,12 @@ function createCropCornerScalingActionHandler(): NonNullable<Control['actionHand
   )
 
   return (eventData, transform, x, y) => {
-    const isFreeScale = Boolean(eventData.shiftKey)
+    const shouldPreserveAspectRatio = shouldPreserveCropFrameAspectRatioOnResize({
+      eventData,
+      target: transform.target
+    })
 
-    if (isFreeScale) {
+    if (!shouldPreserveAspectRatio) {
       return freeScaleHandler(eventData, transform, x, y)
     }
 
@@ -659,14 +788,14 @@ function createCropCornerScalingActionHandler(): NonNullable<Control['actionHand
 }
 
 /**
- * Создаёт action handler для бокового resize по одной оси.
+ * Создаёт action handler для бокового resize с поддержкой сохранения пропорций.
  */
 function createCropSideScalingActionHandler({
   axis
 }: {
   axis: CropScaleAxis
 }): NonNullable<Control['actionHandler']> {
-  return controlsUtils.wrapWithFireEvent(
+  const freeScaleHandler = controlsUtils.wrapWithFireEvent(
     'scaling',
     controlsUtils.wrapWithFixedAnchor((_eventData, transform, x, y) => {
       return scaleCropFrameFromSide({
@@ -677,6 +806,30 @@ function createCropSideScalingActionHandler({
       })
     })
   )
+  const proportionalScaleHandler = controlsUtils.wrapWithFireEvent(
+    'scaling',
+    controlsUtils.wrapWithFixedAnchor((_eventData, transform, x, y) => {
+      return scaleCropFrameProportionallyFromSide({
+        transform,
+        axis,
+        x,
+        y
+      })
+    })
+  )
+
+  return (eventData, transform, x, y) => {
+    const shouldPreserveAspectRatio = shouldPreserveCropFrameAspectRatioOnResize({
+      eventData,
+      target: transform.target
+    })
+
+    if (!shouldPreserveAspectRatio) {
+      return freeScaleHandler(eventData, transform, x, y)
+    }
+
+    return proportionalScaleHandler(eventData, transform, x, y)
+  }
 }
 
 /**
@@ -699,20 +852,54 @@ function clampNumber({
  */
 function createCropResizeControl({
   control,
-  actionHandler
+  actionHandler,
+  cursorStyleHandler,
+  getActionName
 }: {
   control: Control
   actionHandler: NonNullable<Control['actionHandler']>
+  cursorStyleHandler?: Control['cursorStyleHandler']
+  getActionName?: Control['getActionName']
 }): Control {
-  const nextControl = new Control({
+  const controlOptions = {
     ...control,
     actionHandler
-  })
+  }
+
+  if (cursorStyleHandler) {
+    Object.assign(controlOptions, {
+      cursorStyleHandler
+    })
+  }
+
+  if (getActionName) {
+    Object.assign(controlOptions, {
+      getActionName
+    })
+  }
+
+  const nextControl = new Control(controlOptions)
   const cropControl = nextControl as CropResizeControl
 
   cropControl.cropResizeControl = true
 
   return cropControl
+}
+
+/**
+ * Возвращает стабильный resize cursor для бокового crop-control.
+ */
+function getCropSideResizeCursor({ controlKey }: { controlKey: CropSideControlKey }): string {
+  return CROP_SIDE_RESIZE_CURSOR_BY_KEY[controlKey]
+}
+
+/**
+ * Возвращает resize action name для бокового crop-control.
+ */
+function getCropSideScaleActionName({ axis }: { axis: CropScaleAxis }): CropSideScaleActionName {
+  if (axis === 'x') return 'scaleX'
+
+  return 'scaleY'
 }
 
 /**
@@ -742,13 +929,17 @@ export function applyCropResizeControls({ target }: { target: FabricObject }): v
     if (!control) return
     if (control.cropResizeControl) return
 
-    const actionHandler = key === 'ml' || key === 'mr'
+    const isHorizontalControl = key === 'ml' || key === 'mr'
+    const actionHandler = isHorizontalControl
       ? horizontalActionHandler
       : verticalActionHandler
+    const axis = isHorizontalControl ? 'x' : 'y'
 
     nextControls[key] = createCropResizeControl({
       control,
-      actionHandler
+      actionHandler,
+      cursorStyleHandler: () => getCropSideResizeCursor({ controlKey: key }),
+      getActionName: () => getCropSideScaleActionName({ axis })
     })
     hasControlChange = true
   })

--- a/src/editor/crop-manager/types.ts
+++ b/src/editor/crop-manager/types.ts
@@ -30,6 +30,7 @@ export type StartCanvasCropOptions = {
   allowFrameOverflow?: boolean
   showGrid?: boolean
   cancelOnSelectionClear?: boolean
+  preserveAspectRatio?: boolean
 }
 
 /**
@@ -42,6 +43,7 @@ export type StartImageCropOptions = {
   allowFrameOverflow?: boolean
   showGrid?: boolean
   cancelOnSelectionClear?: boolean
+  preserveAspectRatio?: boolean
 }
 
 /**
@@ -51,6 +53,7 @@ export type CropSessionOptions = {
   allowFrameOverflow: boolean
   showGrid: boolean
   cancelOnSelectionClear: boolean
+  preserveAspectRatio: boolean
 }
 
 /**


### PR DESCRIPTION
- Добавлен  метод `setPreserveAspectRatio` для включения/выключения сохранения пропорций при скейлинге 
- Добавлен флаг `preserveAspectRatio` при создании кроп-области, который сразу включает или отключает сохранение пропорций
- Теперь при включенном `preserveAspectRatio` мы сохраняем пропорции не только при скейлинге по диагонали, но при скейлинге по горизонтали и по вертикали
- Исправлен баг с отобржанием неправильного курсора при вертикальном скейлинге кроп-области с нажатым Shift