### PR TITLE
SnappingManager & CropManager. Чиним проблему когда сбиваются выбранные пропорции при прилипании во время уменьшения кроп-области

### DIFF
--- a/e2e/tests/crop-manager/crop-frame-proportional-resize.spec.ts
+++ b/e2e/tests/crop-manager/crop-frame-proportional-resize.spec.ts
@@ -4,6 +4,45 @@ import { test, expect } from '../../fixtures/editor.fixture'
  * Допуск сравнения source-пикселей после реальных pointer events.
  */
 const SOURCE_PIXEL_TOLERANCE = 2
+const SNAP_APPROACH_OFFSET = 4
+const SNAP_HOLD_DRAG_PIXELS = 4
+const SNAP_RELEASE_DRAG_PIXELS = 12
+const SNAP_REFERENCE_SHAPE_SIZE = 64
+const SNAP_REFERENCE_SHAPE_GAP = 24
+const SNAP_REFERENCE_SHAPE_OFFSET = 72
+
+const CROP_FRAME_SNAPPING_RESIZE_CASES = [
+  {
+    title: 'при сужении сверху удерживает квадратную crop-область на горизонтальной направляющей',
+    control: 'mt',
+    referenceId: 'vertical-snap-reference',
+    guideType: 'horizontal',
+    continueDeltaX: 0,
+    continueDeltaY: SNAP_HOLD_DRAG_PIXELS,
+    releaseDeltaX: 0,
+    releaseDeltaY: SNAP_RELEASE_DRAG_PIXELS
+  },
+  {
+    title: 'при сужении слева удерживает квадратную crop-область на вертикальной направляющей',
+    control: 'ml',
+    referenceId: 'horizontal-snap-reference',
+    guideType: 'vertical',
+    continueDeltaX: SNAP_HOLD_DRAG_PIXELS,
+    continueDeltaY: 0,
+    releaseDeltaX: SNAP_RELEASE_DRAG_PIXELS,
+    releaseDeltaY: 0
+  },
+  {
+    title: 'при сужении из левого верхнего угла удерживает квадратную crop-область на направляющей',
+    control: 'tl',
+    referenceId: 'diagonal-snap-reference',
+    guideType: 'horizontal',
+    continueDeltaX: SNAP_HOLD_DRAG_PIXELS,
+    continueDeltaY: SNAP_HOLD_DRAG_PIXELS,
+    releaseDeltaX: SNAP_RELEASE_DRAG_PIXELS,
+    releaseDeltaY: SNAP_RELEASE_DRAG_PIXELS
+  }
+] as const
 
 /**
  * Сценарии resize уменьшенного квадратного image crop после переноса в середину source.
@@ -406,4 +445,155 @@ test.describe('Увеличение crop-области изображения �
       expect(Math.abs(stateAfterMouseUp.frame.left - initialState.frame.left)).toBeLessThanOrEqual(1)
     })
   })
+})
+
+test.describe('Уменьшение crop-области изображения с фиксированной пропорцией и прилипанием', () => {
+  for (const resizeCase of CROP_FRAME_SNAPPING_RESIZE_CASES) {
+    test(resizeCase.title, async({
+      crop,
+      images,
+      shapes,
+      snapping
+    }) => {
+      const image = await test.step('Добавить изображение шире квадратной crop-области', async() => {
+        return images.checkCreation({
+          imageObject: await images.addFilledImage({
+            width: 1000,
+            height: 667
+          })
+        })
+      })
+
+      const imageSnapshot = await test.step('Получить bounds изображения', async() => {
+        return images.getSnapshot({ id: image.id })
+      })
+
+      const measuredState = await test.step('Измерить стартовые bounds будущей crop-области', async() => {
+        return crop.startImageCrop({
+          id: image.id,
+          aspectRatio: {
+            width: 1,
+            height: 1
+          },
+          allowFrameOverflow: false,
+          preserveAspectRatio: true
+        })
+      })
+
+      expect(measuredState.frame.id, 'у crop frame должен быть id для измерения bounds').not.toBeNull()
+      if (!measuredState.frame.id) {
+        throw new Error('Crop frame должен иметь id для измерения bounds')
+      }
+
+      const measuredFrame = await snapping.getObjectSnapshot({ id: measuredState.frame.id })
+      await crop.cancel()
+
+      const isHorizontalGuide = resizeCase.guideType === 'horizontal'
+      const initialCropStart = isHorizontalGuide ? measuredFrame.boundsTop : measuredFrame.boundsLeft
+      const referencePosition = initialCropStart + SNAP_REFERENCE_SHAPE_OFFSET
+
+      await test.step('Добавить shape с границей внутри будущей crop-области', async() => {
+        const shape = await shapes.addAtBounds({
+          presetKey: 'square',
+          options: {
+            id: resizeCase.referenceId,
+            left: isHorizontalGuide
+              ? imageSnapshot.boundsRight + SNAP_REFERENCE_SHAPE_GAP
+              : referencePosition,
+            top: isHorizontalGuide
+              ? referencePosition
+              : imageSnapshot.boundsBottom + SNAP_REFERENCE_SHAPE_GAP,
+            width: SNAP_REFERENCE_SHAPE_SIZE,
+            height: SNAP_REFERENCE_SHAPE_SIZE,
+            text: ''
+          }
+        })
+
+        shapes.checkCreation({ shape, presetKey: 'square' })
+      })
+
+      const reference = await snapping.getObjectSnapshot({ id: resizeCase.referenceId })
+      const guidePosition = isHorizontalGuide ? reference.boundsTop : reference.boundsLeft
+      const initialState = await test.step('Войти в image crop 1:1 с запретом выхода за source', async() => {
+        return crop.startImageCrop({
+          id: image.id,
+          aspectRatio: {
+            width: 1,
+            height: 1
+          },
+          allowFrameOverflow: false,
+          preserveAspectRatio: true
+        })
+      })
+
+      expect(initialState.frame.id, 'у active crop frame должен быть id для проверки bounds').not.toBeNull()
+      if (!initialState.frame.id) {
+        throw new Error('Active crop frame должен иметь id для проверки bounds')
+      }
+
+      const activeFrame = await snapping.getObjectSnapshot({ id: initialState.frame.id })
+      const initialCropEnd = isHorizontalGuide ? activeFrame.boundsBottom : activeFrame.boundsRight
+      const frameScale = isHorizontalGuide ? initialState.frame.scaleY : initialState.frame.scaleX
+      const snappedSize = (initialCropEnd - guidePosition) / Math.abs(frameScale)
+      const requestedSize = snappedSize + (SNAP_APPROACH_OFFSET / Math.abs(frameScale))
+      const stateAtSnap = await test.step('Потянуть control почти до направляющей', async() => {
+        return crop.dragFrameFromControlToSize({
+          control: resizeCase.control,
+          size: {
+            width: requestedSize,
+            height: requestedSize
+          }
+        })
+      })
+      const guideState = await snapping.getGuideState()
+      const stateAfterHold = await test.step('Продолжить движение внутри зоны удержания', async() => {
+        return crop.continueFrameResizeBy({
+          deltaX: resizeCase.continueDeltaX,
+          deltaY: resizeCase.continueDeltaY
+        })
+      })
+      const stateAfterRelease = await test.step('Выйти из зоны удержания и продолжить уменьшение', async() => {
+        return crop.continueFrameResizeBy({
+          deltaX: resizeCase.releaseDeltaX,
+          deltaY: resizeCase.releaseDeltaY
+        })
+      })
+      const guideStateAfterRelease = await snapping.getGuideState()
+
+      const stateAfterMouseUp = await test.step('Завершить resize и закрыть crop mode', async() => {
+        const state = await crop.finishFrameResize()
+
+        await crop.cancel()
+
+        return state
+      })
+
+      await test.step('Проверить что snap сразу сохранил пропорции и удержал обе оси', () => {
+        expect(initialState.options.allowFrameOverflow).toBe(false)
+        expect(initialState.options.preserveAspectRatio).toBe(true)
+        expect(guideState.guides).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            type: resizeCase.guideType,
+            position: guidePosition
+          })
+        ]))
+        expect(Math.abs(stateAtSnap.rect.width - snappedSize)).toBeLessThanOrEqual(SOURCE_PIXEL_TOLERANCE)
+        expect(Math.abs(stateAtSnap.rect.height - snappedSize)).toBeLessThanOrEqual(SOURCE_PIXEL_TOLERANCE)
+        expect(stateAtSnap.rect.width).toBeCloseTo(stateAtSnap.rect.height, 4)
+        expect(stateAfterHold.rect.width).toBeCloseTo(stateAtSnap.rect.width, 4)
+        expect(stateAfterHold.rect.height).toBeCloseTo(stateAtSnap.rect.height, 4)
+        expect(stateAfterRelease.rect.width).toBeLessThan(stateAfterHold.rect.width - SOURCE_PIXEL_TOLERANCE)
+        expect(stateAfterRelease.rect.height).toBeLessThan(stateAfterHold.rect.height - SOURCE_PIXEL_TOLERANCE)
+        expect(stateAfterRelease.rect.width).toBeCloseTo(stateAfterRelease.rect.height, 4)
+        expect(guideStateAfterRelease.guides).not.toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            type: resizeCase.guideType,
+            position: guidePosition
+          })
+        ]))
+        expect(stateAfterMouseUp.rect.width).toBeCloseTo(stateAfterRelease.rect.width, 4)
+        expect(stateAfterMouseUp.rect.height).toBeCloseTo(stateAfterRelease.rect.height, 4)
+      })
+    })
+  }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.15",
+      "version": "0.9.16",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/snapping-manager/scaling.spec.ts
+++ b/specs/src/editor/snapping-manager/scaling.spec.ts
@@ -1,0 +1,127 @@
+import {
+  resolveScaleUpdatePlan,
+  shouldUseUniformScaleSnap
+} from '../../../../src/editor/snapping-manager/scaling'
+import {
+  createAxisSnapResult,
+  createCropFrameTarget,
+  createEmptyAxisSnapResult,
+  createScalingBounds,
+  createScalingEvent
+} from '../../../test-utils/shared/snapping-scaling'
+
+describe('SnappingManager scaling contract', () => {
+  it('для side-control crop frame с включённым preserveAspectRatio включает uniform snap и отключает его с Shift', () => {
+    const target = createCropFrameTarget({
+      preserveAspectRatio: true
+    })
+
+    const withoutShift = shouldUseUniformScaleSnap({
+      target,
+      event: createScalingEvent(),
+      isCornerHandle: false
+    })
+    const withShift = shouldUseUniformScaleSnap({
+      target,
+      event: createScalingEvent({ shiftKey: true }),
+      isCornerHandle: false
+    })
+
+    expect(withoutShift).toBe(true)
+    expect(withShift).toBe(false)
+  })
+
+  it('для side-control crop frame с выключенным preserveAspectRatio включает uniform snap только с Shift', () => {
+    const target = createCropFrameTarget({
+      preserveAspectRatio: false
+    })
+
+    const withoutShift = shouldUseUniformScaleSnap({
+      target,
+      event: createScalingEvent(),
+      isCornerHandle: false
+    })
+    const withShift = shouldUseUniformScaleSnap({
+      target,
+      event: createScalingEvent({ shiftKey: true }),
+      isCornerHandle: false
+    })
+
+    expect(withoutShift).toBe(false)
+    expect(withShift).toBe(true)
+  })
+
+  it('при vertical snap side-control пересчитывает обе scale-оси одним коэффициентом', () => {
+    const plan = resolveScaleUpdatePlan({
+      target: createCropFrameTarget(),
+      bounds: createScalingBounds({
+        left: 10,
+        top: 20,
+        width: 100,
+        height: 100
+      }),
+      originX: 'left',
+      originY: 'bottom',
+      scaleX: 1,
+      scaleY: 1,
+      shouldUseUniformScaleSnap: true,
+      verticalSnap: createEmptyAxisSnapResult(),
+      horizontalSnap: createAxisSnapResult({
+        edge: 'top',
+        position: 20,
+        guidePosition: 40
+      })
+    })
+
+    expect(plan).not.toBeNull()
+    if (!plan) {
+      throw new Error('Scale plan для vertical snap должен существовать')
+    }
+
+    expect(plan.guides).toEqual([
+      {
+        type: 'horizontal',
+        position: 40
+      }
+    ])
+    expect(plan.nextScaleX).toBeCloseTo(0.8, 5)
+    expect(plan.nextScaleY).toBeCloseTo(0.8, 5)
+  })
+
+  it('при horizontal snap side-control пересчитывает обе scale-оси одним коэффициентом', () => {
+    const plan = resolveScaleUpdatePlan({
+      target: createCropFrameTarget(),
+      bounds: createScalingBounds({
+        left: 20,
+        top: 10,
+        width: 100,
+        height: 100
+      }),
+      originX: 'right',
+      originY: 'top',
+      scaleX: 1,
+      scaleY: 1,
+      shouldUseUniformScaleSnap: true,
+      verticalSnap: createAxisSnapResult({
+        edge: 'left',
+        position: 20,
+        guidePosition: 40
+      }),
+      horizontalSnap: createEmptyAxisSnapResult()
+    })
+
+    expect(plan).not.toBeNull()
+    if (!plan) {
+      throw new Error('Scale plan для horizontal snap должен существовать')
+    }
+
+    expect(plan.guides).toEqual([
+      {
+        type: 'vertical',
+        position: 40
+      }
+    ])
+    expect(plan.nextScaleX).toBeCloseTo(0.8, 5)
+    expect(plan.nextScaleY).toBeCloseTo(0.8, 5)
+  })
+})

--- a/specs/test-utils/shared/snapping-scaling.ts
+++ b/specs/test-utils/shared/snapping-scaling.ts
@@ -1,0 +1,126 @@
+import type {
+  FabricObject,
+  TPointerEvent
+} from 'fabric'
+
+import type { Bounds } from '../../../src/editor/snapping-manager/types'
+
+/** Минимальный stub crop frame для unit-тестов scaling snap. */
+type CropFrameTargetStub = {
+  width: number
+  height: number
+  scaleX: number
+  scaleY: number
+  cropSource?: FabricObject | null
+  preserveAspectRatio?: boolean
+}
+
+/** Минимальный snap-result stub для unit-тестов scaling snap. */
+type AxisSnapResultStub = {
+  delta: number
+  guidePosition: number | null
+  candidate: {
+    edge: 'left' | 'right' | 'top' | 'bottom'
+    position: number
+  } | null
+}
+
+/** Возвращает bounds прямоугольника с уже посчитанным центром. */
+export function createScalingBounds({
+  left,
+  top,
+  width,
+  height
+}: {
+  left: number
+  top: number
+  width: number
+  height: number
+}): Bounds {
+  return {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    centerX: left + (width / 2),
+    centerY: top + (height / 2)
+  }
+}
+
+/** Возвращает минимальный target для unit-проверок crop scaling snap. */
+export function createCropFrameTarget({
+  width = 100,
+  height = 100,
+  scaleX = 1,
+  scaleY = 1,
+  hasCropSource = true,
+  preserveAspectRatio
+}: {
+  width?: number
+  height?: number
+  scaleX?: number
+  scaleY?: number
+  hasCropSource?: boolean
+  preserveAspectRatio?: boolean
+} = {}): FabricObject {
+  const target: CropFrameTargetStub = {
+    width,
+    height,
+    scaleX,
+    scaleY
+  }
+
+  if (hasCropSource) {
+    target.cropSource = {} as FabricObject
+  }
+
+  if (preserveAspectRatio !== undefined) {
+    target.preserveAspectRatio = preserveAspectRatio
+  }
+
+  return target as FabricObject
+}
+
+/** Возвращает snap-result с привязкой к конкретной границе. */
+export function createAxisSnapResult({
+  edge,
+  position,
+  guidePosition,
+  delta = guidePosition - position
+}: {
+  edge: 'left' | 'right' | 'top' | 'bottom'
+  position: number
+  guidePosition: number
+  delta?: number
+}): AxisSnapResultStub {
+  return {
+    delta,
+    guidePosition,
+    candidate: {
+      edge,
+      position
+    }
+  }
+}
+
+/** Возвращает snap-result без найденной направляющей. */
+export function createEmptyAxisSnapResult(): AxisSnapResultStub {
+  return {
+    delta: 0,
+    guidePosition: null,
+    candidate: null
+  }
+}
+
+/** Возвращает минимальный pointer event wrapper для shouldUseUniformScaleSnap. */
+export function createScalingEvent({
+  shiftKey = false
+}: {
+  shiftKey?: boolean
+} = {}): { e: TPointerEvent } {
+  return {
+    e: {
+      shiftKey
+    } as TPointerEvent
+  }
+}

--- a/src/editor/snapping-manager/index.ts
+++ b/src/editor/snapping-manager/index.ts
@@ -27,6 +27,15 @@ import {
   applyScalingStep,
   shouldApplyPixelScalingStep
 } from './pixel-grid'
+import {
+  resolveScaleAxisSnaps,
+  resolveScaleUpdatePlan,
+  resolveScalingAxisState,
+  resolveScalingTransformState,
+  resolveTextResizeSnapPlan,
+  shouldUseUniformScaleSnap,
+  type ScaleUpdatePlan
+} from './scaling'
 import type {
   AnchorBuckets,
   Bounds,
@@ -52,43 +61,6 @@ type TransformEvent = BasicTransformEvent<TPointerEvent> & {
 
 type MouseEventInfo = TPointerEventInfo<TPointerEvent> & {
   target?: FabricObject | null
-}
-
-type AxisSnapEdge = 'left' | 'right' | 'top' | 'bottom'
-
-type AxisSnapCandidate = {
-  edge: AxisSnapEdge
-  position: number
-}
-
-type AxisSnapResult = {
-  delta: number
-  guidePosition: number | null
-  candidate: AxisSnapCandidate | null
-}
-
-type ScalingAxisState = {
-  isCornerHandle: boolean
-  shouldSnapX: boolean
-  shouldSnapY: boolean
-}
-
-type ScalingTransformState = {
-  originX: Transform['originX']
-  originY: Transform['originY']
-  scaleX: number
-  scaleY: number
-}
-
-type ScaleAxisSnapState = {
-  verticalSnap: AxisSnapResult
-  horizontalSnap: AxisSnapResult
-}
-
-type ScaleUpdatePlan = {
-  guides: GuideLine[]
-  nextScaleX: number | null
-  nextScaleY: number | null
 }
 
 /**
@@ -348,7 +320,7 @@ export default class SnappingManager {
       shouldSnapX,
       shouldSnapY,
       isCornerHandle
-    } = SnappingManager._resolveScalingAxisState({ transform })
+    } = resolveScalingAxisState({ transform })
 
     if (!shouldSnapX && !shouldSnapY) {
       this._clearGuides()
@@ -376,8 +348,8 @@ export default class SnappingManager {
       originY,
       scaleX,
       scaleY
-    } = SnappingManager._resolveScalingTransformState({ target, transform })
-    const snapState = SnappingManager._resolveScaleAxisSnaps({
+    } = resolveScalingTransformState({ target, transform })
+    const snapState = resolveScaleAxisSnaps({
       bounds: activeBounds,
       originX,
       originY,
@@ -392,14 +364,19 @@ export default class SnappingManager {
       return
     }
 
-    const scalePlan = SnappingManager._resolveScaleUpdatePlan({
+    const shouldUseUniformScale = shouldUseUniformScaleSnap({
+      target,
+      event,
+      isCornerHandle
+    })
+    const scalePlan = resolveScaleUpdatePlan({
       target,
       bounds: activeBounds,
       originX,
       originY,
       scaleX,
       scaleY,
-      isCornerHandle,
+      shouldUseUniformScaleSnap: shouldUseUniformScale,
       verticalSnap: snapState.verticalSnap,
       horizontalSnap: snapState.horizontalSnap
     })
@@ -683,44 +660,20 @@ export default class SnappingManager {
     const originX = transformOriginX ?? targetOriginX
     const originY = transformOriginY ?? targetOriginY
 
-    const verticalCandidates = SnappingManager._collectVerticalSnapCandidates({
+    const snapPlan = resolveTextResizeSnapPlan({
+      target,
       bounds: activeBounds,
       originX,
-      shouldSnapX: true
-    })
-    const verticalSnap = SnappingManager._findAxisSnapCandidate({
-      anchors: verticalAnchors,
-      candidates: verticalCandidates,
+      verticalAnchors,
       threshold
     })
 
-    const { guidePosition: verticalGuidePosition } = verticalSnap
-    if (verticalGuidePosition === null) {
+    if (!snapPlan) {
       this._clearGuides()
       return
     }
 
-    const desiredWidth = SnappingManager._resolveDesiredWidth({
-      bounds: activeBounds,
-      originX,
-      snap: verticalSnap
-    })
-
-    if (desiredWidth === null) {
-      this._clearGuides()
-      return
-    }
-
-    const nextWidth = SnappingManager._resolveTextWidthForBounds({
-      target,
-      boundsWidth: desiredWidth
-    })
-
-    if (nextWidth === null) {
-      this._clearGuides()
-      return
-    }
-
+    const { guide, nextWidth } = snapPlan
     const { width: currentWidth = 0 } = target
     if (nextWidth !== currentWidth) {
       const anchorPlacement = this.editor.canvasManager.getObjectPlacement({
@@ -737,12 +690,7 @@ export default class SnappingManager {
     }
 
     this._applyGuides({
-      guides: [
-        {
-          type: 'vertical',
-          position: verticalGuidePosition
-        }
-      ],
+      guides: [guide],
       spacingGuides: []
     })
   }
@@ -863,661 +811,6 @@ export default class SnappingManager {
       vertical: null,
       horizontal: null
     }
-  }
-
-  /**
-   * Определяет активные оси масштабирования по углу и действию трансформации.
-   */
-  private static _resolveScalingAxisState({ transform }: { transform: Transform }): ScalingAxisState {
-    const { corner = '', action = '' } = transform
-    const isHorizontalHandle = corner === 'ml' || corner === 'mr' || action === 'scaleX'
-    const isVerticalHandle = corner === 'mt' || corner === 'mb' || action === 'scaleY'
-    const isCornerHandle = corner === 'tl'
-      || corner === 'tr'
-      || corner === 'bl'
-      || corner === 'br'
-      || action === 'scale'
-
-    return {
-      isCornerHandle,
-      shouldSnapX: isHorizontalHandle || isCornerHandle,
-      shouldSnapY: isVerticalHandle || isCornerHandle
-    }
-  }
-
-  /** Возвращает активные origin и scale из transform с fallback в состояние target. */
-  private static _resolveScalingTransformState({
-    target,
-    transform
-  }: {
-    target: FabricObject
-    transform: Transform
-  }): ScalingTransformState {
-    const {
-      originX: transformOriginX,
-      originY: transformOriginY
-    } = transform
-    const {
-      originX: targetOriginX = 'left',
-      originY: targetOriginY = 'top',
-      scaleX = 1,
-      scaleY = 1
-    } = target
-
-    return {
-      originX: transformOriginX ?? targetOriginX,
-      originY: transformOriginY ?? targetOriginY,
-      scaleX,
-      scaleY
-    }
-  }
-
-  /** Находит активные axis-snap кандидаты для текущего scaling-step. */
-  private static _resolveScaleAxisSnaps({
-    bounds,
-    originX,
-    originY,
-    shouldSnapX,
-    shouldSnapY,
-    threshold,
-    anchors
-  }: {
-    bounds: Bounds
-    originX: Transform['originX']
-    originY: Transform['originY']
-    shouldSnapX: boolean
-    shouldSnapY: boolean
-    threshold: number
-    anchors: AnchorBuckets
-  }): ScaleAxisSnapState | null {
-    const verticalCandidates = SnappingManager._collectVerticalSnapCandidates({
-      bounds,
-      originX,
-      shouldSnapX
-    })
-    const horizontalCandidates = SnappingManager._collectHorizontalSnapCandidates({
-      bounds,
-      originY,
-      shouldSnapY
-    })
-    const verticalSnap = SnappingManager._findAxisSnapCandidate({
-      anchors: anchors.vertical,
-      candidates: verticalCandidates,
-      threshold
-    })
-    const horizontalSnap = SnappingManager._findAxisSnapCandidate({
-      anchors: anchors.horizontal,
-      candidates: horizontalCandidates,
-      threshold
-    })
-
-    if (verticalSnap.guidePosition === null && horizontalSnap.guidePosition === null) {
-      return null
-    }
-
-    return {
-      verticalSnap,
-      horizontalSnap
-    }
-  }
-
-  /** Рассчитывает scale-обновления и соответствующие направляющие для текущего scaling-step. */
-  private static _resolveScaleUpdatePlan({
-    target,
-    bounds,
-    originX,
-    originY,
-    scaleX,
-    scaleY,
-    isCornerHandle,
-    verticalSnap,
-    horizontalSnap
-  }: {
-    target: FabricObject
-    bounds: Bounds
-    originX: Transform['originX']
-    originY: Transform['originY']
-    scaleX: number
-    scaleY: number
-    isCornerHandle: boolean
-    verticalSnap: AxisSnapResult
-    horizontalSnap: AxisSnapResult
-  }): ScaleUpdatePlan | null {
-    const { guidePosition: verticalGuidePosition } = verticalSnap
-    const { guidePosition: horizontalGuidePosition } = horizontalSnap
-    const hasVerticalSnap = verticalGuidePosition !== null
-    const hasHorizontalSnap = horizontalGuidePosition !== null
-    const guides: GuideLine[] = []
-    let nextScaleX: number | null = null
-    let nextScaleY: number | null = null
-
-    if (isCornerHandle) {
-      const uniformResult = SnappingManager._resolveUniformScale({
-        bounds,
-        originX,
-        originY,
-        verticalSnap,
-        horizontalSnap
-      })
-
-      if (uniformResult) {
-        const { scaleFactor, guide } = uniformResult
-        nextScaleX = scaleX * scaleFactor
-        nextScaleY = scaleY * scaleFactor
-        guides.push(guide)
-      }
-    }
-
-    if (!isCornerHandle) {
-      const { angle = 0 } = target
-      const { width: baseWidth, height: baseHeight } = SnappingManager._resolveBaseDimensions({ target })
-      const absScaleX = Math.abs(scaleX) || 1
-      const absScaleY = Math.abs(scaleY) || 1
-
-      if (hasVerticalSnap) {
-        const desiredWidth = SnappingManager._resolveDesiredWidth({
-          bounds,
-          originX,
-          snap: verticalSnap
-        })
-
-        if (desiredWidth !== null) {
-          const absNextScaleX = SnappingManager._resolveScaleForWidth({
-            desiredWidth,
-            baseWidth,
-            baseHeight,
-            scaleY: absScaleY,
-            angle
-          })
-
-          if (absNextScaleX !== null) {
-            nextScaleX = absNextScaleX * (scaleX < 0 ? -1 : 1)
-            guides.push({
-              type: 'vertical',
-              position: verticalGuidePosition
-            })
-          }
-        }
-      }
-
-      if (hasHorizontalSnap) {
-        const desiredHeight = SnappingManager._resolveDesiredHeight({
-          bounds,
-          originY,
-          snap: horizontalSnap
-        })
-
-        if (desiredHeight !== null) {
-          const absNextScaleY = SnappingManager._resolveScaleForHeight({
-            desiredHeight,
-            baseWidth,
-            baseHeight,
-            scaleX: absScaleX,
-            angle
-          })
-
-          if (absNextScaleY !== null) {
-            nextScaleY = absNextScaleY * (scaleY < 0 ? -1 : 1)
-            guides.push({
-              type: 'horizontal',
-              position: horizontalGuidePosition
-            })
-          }
-        }
-      }
-    }
-
-    if (nextScaleX === null && nextScaleY === null && !guides.length) {
-      return null
-    }
-
-    return {
-      guides,
-      nextScaleX,
-      nextScaleY
-    }
-  }
-
-  /**
-   * Собирает кандидаты на вертикальное прилипания по текущему originX.
-   */
-  private static _collectVerticalSnapCandidates({
-    bounds,
-    originX,
-    shouldSnapX
-  }: {
-    bounds: Bounds
-    originX: Transform['originX']
-    shouldSnapX: boolean
-  }): AxisSnapCandidate[] {
-    const candidates: AxisSnapCandidate[] = []
-    if (!shouldSnapX) return candidates
-
-    const { left, right } = bounds
-    let resolvedOriginX: 'left' | 'center' | 'right' = 'left'
-    if (originX === 'center' || originX === 'right') {
-      resolvedOriginX = originX
-    }
-
-    if (resolvedOriginX === 'left') {
-      candidates.push({
-        edge: 'right',
-        position: right
-      })
-    }
-
-    if (resolvedOriginX === 'right') {
-      candidates.push({
-        edge: 'left',
-        position: left
-      })
-    }
-
-    if (resolvedOriginX === 'center') {
-      candidates.push({
-        edge: 'left',
-        position: left
-      })
-      candidates.push({
-        edge: 'right',
-        position: right
-      })
-    }
-
-    return candidates
-  }
-
-  /**
-   * Собирает кандидаты на горизонтальное прилипания по текущему originY.
-   */
-  private static _collectHorizontalSnapCandidates({
-    bounds,
-    originY,
-    shouldSnapY
-  }: {
-    bounds: Bounds
-    originY: Transform['originY']
-    shouldSnapY: boolean
-  }): AxisSnapCandidate[] {
-    const candidates: AxisSnapCandidate[] = []
-    if (!shouldSnapY) return candidates
-
-    const { top, bottom } = bounds
-    let resolvedOriginY: 'top' | 'center' | 'bottom' = 'top'
-    if (originY === 'center' || originY === 'bottom') {
-      resolvedOriginY = originY
-    }
-
-    if (resolvedOriginY === 'top') {
-      candidates.push({
-        edge: 'bottom',
-        position: bottom
-      })
-    }
-
-    if (resolvedOriginY === 'bottom') {
-      candidates.push({
-        edge: 'top',
-        position: top
-      })
-    }
-
-    if (resolvedOriginY === 'center') {
-      candidates.push({
-        edge: 'top',
-        position: top
-      })
-      candidates.push({
-        edge: 'bottom',
-        position: bottom
-      })
-    }
-
-    return candidates
-  }
-
-  /**
-   * Находит ближайший кандидат прилипания с учетом порога и возвращает дельту.
-   */
-  private static _findAxisSnapCandidate({
-    anchors,
-    candidates,
-    threshold
-  }: {
-    anchors: number[]
-    candidates: AxisSnapCandidate[]
-    threshold: number
-  }): AxisSnapResult {
-    let nearestDelta = 0
-    let nearestDistance = threshold + 1
-    let guidePosition: number | null = null
-    let candidate: AxisSnapCandidate | null = null
-
-    for (const snapCandidate of candidates) {
-      const { position } = snapCandidate
-
-      for (const anchor of anchors) {
-        const distance = Math.abs(anchor - position)
-        if (distance > threshold || distance >= nearestDistance) continue
-
-        nearestDelta = anchor - position
-        nearestDistance = distance
-        guidePosition = anchor
-        candidate = snapCandidate
-      }
-    }
-
-    return {
-      delta: nearestDelta,
-      guidePosition,
-      candidate
-    }
-  }
-
-  /**
-   * Рассчитывает коэффициент равномерного масштаба и соответствующий гайд.
-   */
-  private static _resolveUniformScale({
-    bounds,
-    originX,
-    originY,
-    verticalSnap,
-    horizontalSnap
-  }: {
-    bounds: Bounds
-    originX: Transform['originX']
-    originY: Transform['originY']
-    verticalSnap: AxisSnapResult
-    horizontalSnap: AxisSnapResult
-  }): { scaleFactor: number; guide: GuideLine } | null {
-    const {
-      left,
-      right,
-      top,
-      bottom
-    } = bounds
-    const currentWidth = right - left
-    const currentHeight = bottom - top
-
-    const {
-      guidePosition: verticalGuidePosition,
-      delta: verticalDelta
-    } = verticalSnap
-    const {
-      guidePosition: horizontalGuidePosition,
-      delta: horizontalDelta
-    } = horizontalSnap
-
-    let scaleFactorX: number | null = null
-    let scaleFactorY: number | null = null
-
-    if (verticalGuidePosition !== null && currentWidth > 0) {
-      const desiredWidth = SnappingManager._resolveDesiredWidth({
-        bounds,
-        originX,
-        snap: verticalSnap
-      })
-
-      if (desiredWidth !== null) {
-        const factor = desiredWidth / currentWidth
-        if (Number.isFinite(factor) && factor > 0) {
-          scaleFactorX = factor
-        }
-      }
-    }
-
-    if (horizontalGuidePosition !== null && currentHeight > 0) {
-      const desiredHeight = SnappingManager._resolveDesiredHeight({
-        bounds,
-        originY,
-        snap: horizontalSnap
-      })
-
-      if (desiredHeight !== null) {
-        const factor = desiredHeight / currentHeight
-        if (Number.isFinite(factor) && factor > 0) {
-          scaleFactorY = factor
-        }
-      }
-    }
-
-    let chosenAxis: 'x' | 'y' | null = null
-    if (scaleFactorX !== null && scaleFactorY === null) {
-      chosenAxis = 'x'
-    }
-    if (scaleFactorY !== null && scaleFactorX === null) {
-      chosenAxis = 'y'
-    }
-    if (scaleFactorX !== null && scaleFactorY !== null) {
-      const absVerticalDelta = Math.abs(verticalDelta)
-      const absHorizontalDelta = Math.abs(horizontalDelta)
-
-      if (absVerticalDelta <= absHorizontalDelta) {
-        chosenAxis = 'x'
-      }
-      if (absVerticalDelta > absHorizontalDelta) {
-        chosenAxis = 'y'
-      }
-    }
-
-    if (chosenAxis === 'x' && scaleFactorX !== null && verticalGuidePosition !== null) {
-      return {
-        scaleFactor: scaleFactorX,
-        guide: {
-          type: 'vertical',
-          position: verticalGuidePosition
-        }
-      }
-    }
-
-    if (chosenAxis === 'y' && scaleFactorY !== null && horizontalGuidePosition !== null) {
-      return {
-        scaleFactor: scaleFactorY,
-        guide: {
-          type: 'horizontal',
-          position: horizontalGuidePosition
-        }
-      }
-    }
-
-    return null
-  }
-
-  /**
-   * Рассчитывает требуемую ширину bounding-box для прилипания по X.
-   */
-  private static _resolveDesiredWidth({
-    bounds,
-    originX,
-    snap
-  }: {
-    bounds: Bounds
-    originX: Transform['originX']
-    snap: AxisSnapResult
-  }): number | null {
-    const { left, right, centerX } = bounds
-    const { candidate, guidePosition } = snap
-    if (!candidate || guidePosition === null) return null
-
-    let resolvedOriginX: 'left' | 'center' | 'right' = 'left'
-    if (originX === 'center' || originX === 'right') {
-      resolvedOriginX = originX
-    }
-
-    const { edge } = candidate
-    let desiredWidth: number | null = null
-
-    if (resolvedOriginX === 'left' && edge === 'right') {
-      desiredWidth = guidePosition - left
-    }
-    if (resolvedOriginX === 'right' && edge === 'left') {
-      desiredWidth = right - guidePosition
-    }
-    if (resolvedOriginX === 'center' && edge === 'left') {
-      desiredWidth = (centerX - guidePosition) * 2
-    }
-    if (resolvedOriginX === 'center' && edge === 'right') {
-      desiredWidth = (guidePosition - centerX) * 2
-    }
-
-    if (desiredWidth === null) return null
-    if (!Number.isFinite(desiredWidth) || desiredWidth <= 0) return null
-
-    return desiredWidth
-  }
-
-  /**
-   * Рассчитывает требуемую высоту bounding-box для прилипания по Y.
-   */
-  private static _resolveDesiredHeight({
-    bounds,
-    originY,
-    snap
-  }: {
-    bounds: Bounds
-    originY: Transform['originY']
-    snap: AxisSnapResult
-  }): number | null {
-    const { top, bottom, centerY } = bounds
-    const { candidate, guidePosition } = snap
-    if (!candidate || guidePosition === null) return null
-
-    let resolvedOriginY: 'top' | 'center' | 'bottom' = 'top'
-    if (originY === 'center' || originY === 'bottom') {
-      resolvedOriginY = originY
-    }
-
-    const { edge } = candidate
-    let desiredHeight: number | null = null
-
-    if (resolvedOriginY === 'top' && edge === 'bottom') {
-      desiredHeight = guidePosition - top
-    }
-    if (resolvedOriginY === 'bottom' && edge === 'top') {
-      desiredHeight = bottom - guidePosition
-    }
-    if (resolvedOriginY === 'center' && edge === 'top') {
-      desiredHeight = (centerY - guidePosition) * 2
-    }
-    if (resolvedOriginY === 'center' && edge === 'bottom') {
-      desiredHeight = (guidePosition - centerY) * 2
-    }
-
-    if (desiredHeight === null) return null
-    if (!Number.isFinite(desiredHeight) || desiredHeight <= 0) return null
-
-    return desiredHeight
-  }
-
-  /**
-   * Возвращает базовые размеры объекта без учета масштаба, включая отступы текста.
-   */
-  private static _resolveBaseDimensions({ target }: { target: FabricObject }): { width: number; height: number } {
-    const {
-      width: rawWidth = 0,
-      height: rawHeight = 0
-    } = target
-    let width = rawWidth
-    let height = rawHeight
-
-    if (target instanceof Textbox) {
-      const {
-        paddingTop = 0,
-        paddingRight = 0,
-        paddingBottom = 0,
-        paddingLeft = 0,
-        strokeWidth = 0
-      } = target
-      width = rawWidth + paddingLeft + paddingRight + strokeWidth
-      height = rawHeight + paddingTop + paddingBottom + strokeWidth
-    }
-
-    return {
-      width,
-      height
-    }
-  }
-
-  /**
-   * Рассчитывает масштаб по оси X для заданной ширины bounding-box.
-   */
-  private static _resolveScaleForWidth({
-    desiredWidth,
-    baseWidth,
-    baseHeight,
-    scaleY,
-    angle
-  }: {
-    desiredWidth: number
-    baseWidth: number
-    baseHeight: number
-    scaleY: number
-    angle: number
-  }): number | null {
-    const radians = (angle * Math.PI) / 180
-    const cos = Math.abs(Math.cos(radians))
-    const sin = Math.abs(Math.sin(radians))
-    const widthComponent = baseWidth * cos
-    const heightComponent = baseHeight * scaleY * sin
-
-    if (widthComponent <= 0) return null
-
-    const nextScaleX = (desiredWidth - heightComponent) / widthComponent
-    if (!Number.isFinite(nextScaleX) || nextScaleX <= 0) return null
-
-    return nextScaleX
-  }
-
-  /**
-   * Рассчитывает масштаб по оси Y для заданной высоты bounding-box.
-   */
-  private static _resolveScaleForHeight({
-    desiredHeight,
-    baseWidth,
-    baseHeight,
-    scaleX,
-    angle
-  }: {
-    desiredHeight: number
-    baseWidth: number
-    baseHeight: number
-    scaleX: number
-    angle: number
-  }): number | null {
-    const radians = (angle * Math.PI) / 180
-    const cos = Math.abs(Math.cos(radians))
-    const sin = Math.abs(Math.sin(radians))
-    const heightComponent = baseHeight * cos
-    const widthComponent = baseWidth * scaleX * sin
-
-    if (heightComponent <= 0) return null
-
-    const nextScaleY = (desiredHeight - widthComponent) / heightComponent
-    if (!Number.isFinite(nextScaleY) || nextScaleY <= 0) return null
-
-    return nextScaleY
-  }
-
-  /**
-   * Приводит ширину bounding-box текста к ширине текстового блока.
-   */
-  private static _resolveTextWidthForBounds({
-    target,
-    boundsWidth
-  }: {
-    target: Textbox
-    boundsWidth: number
-  }): number | null {
-    const {
-      paddingLeft = 0,
-      paddingRight = 0,
-      strokeWidth = 0
-    } = target
-
-    const rawWidth = boundsWidth - paddingLeft - paddingRight - strokeWidth
-    if (!Number.isFinite(rawWidth) || rawWidth <= 0) return null
-
-    return Math.max(1, Math.round(rawWidth))
   }
 
   /**

--- a/src/editor/snapping-manager/scaling.ts
+++ b/src/editor/snapping-manager/scaling.ts
@@ -1,0 +1,848 @@
+/* eslint-disable no-use-before-define -- публичный контракт модуля держится выше внутренних расчётов. */
+import {
+  FabricObject,
+  Textbox,
+  Transform,
+  TPointerEvent
+} from 'fabric'
+
+import type {
+  AnchorBuckets,
+  Bounds,
+  GuideLine
+} from './types'
+
+type AxisSnapEdge = 'left' | 'right' | 'top' | 'bottom'
+
+type AxisSnapCandidate = {
+  edge: AxisSnapEdge
+  position: number
+}
+
+type AxisSnapResult = {
+  delta: number
+  guidePosition: number | null
+  candidate: AxisSnapCandidate | null
+}
+
+export type ScalingAxisState = {
+  isCornerHandle: boolean
+  shouldSnapX: boolean
+  shouldSnapY: boolean
+}
+
+type CropFrameSnapTarget = FabricObject & {
+  cropSource?: FabricObject | null
+  preserveAspectRatio?: boolean
+}
+
+export type ScalingTransformState = {
+  originX: Transform['originX']
+  originY: Transform['originY']
+  scaleX: number
+  scaleY: number
+}
+
+export type ScaleAxisSnapState = {
+  verticalSnap: AxisSnapResult
+  horizontalSnap: AxisSnapResult
+}
+
+export type ScaleUpdatePlan = {
+  guides: GuideLine[]
+  nextScaleX: number | null
+  nextScaleY: number | null
+}
+
+export type TextResizeSnapPlan = {
+  guide: GuideLine
+  nextWidth: number
+}
+
+type ScaleSnapContext = {
+  target: FabricObject
+  bounds: Bounds
+  originX: Transform['originX']
+  originY: Transform['originY']
+  scaleX: number
+  scaleY: number
+  verticalSnap: AxisSnapResult
+  horizontalSnap: AxisSnapResult
+}
+
+interface ScaleUpdatePlanParams extends ScaleSnapContext {
+  shouldUseUniformScaleSnap: boolean
+}
+
+type AxisScaleUpdate = {
+  guide: GuideLine
+  nextScale: number
+}
+
+type UniformScaleResult = {
+  guide: GuideLine
+  scaleFactor: number
+}
+
+/**
+ * Определяет активные оси масштабирования по углу и действию трансформации.
+ */
+export function resolveScalingAxisState({ transform }: { transform: Transform }): ScalingAxisState {
+  const { corner = '', action = '' } = transform
+  const isHorizontalHandle = corner === 'ml' || corner === 'mr' || action === 'scaleX'
+  const isVerticalHandle = corner === 'mt' || corner === 'mb' || action === 'scaleY'
+  const isCornerHandle = corner === 'tl'
+    || corner === 'tr'
+    || corner === 'bl'
+    || corner === 'br'
+    || action === 'scale'
+
+  return {
+    isCornerHandle,
+    shouldSnapX: isHorizontalHandle || isCornerHandle,
+    shouldSnapY: isVerticalHandle || isCornerHandle
+  }
+}
+
+/** Возвращает активные origin и scale из transform с fallback в состояние target. */
+export function resolveScalingTransformState({
+  target,
+  transform
+}: {
+  target: FabricObject
+  transform: Transform
+}): ScalingTransformState {
+  const {
+    originX: transformOriginX,
+    originY: transformOriginY
+  } = transform
+  const {
+    originX: targetOriginX = 'left',
+    originY: targetOriginY = 'top',
+    scaleX = 1,
+    scaleY = 1
+  } = target
+
+  return {
+    originX: transformOriginX ?? targetOriginX,
+    originY: transformOriginY ?? targetOriginY,
+    scaleX,
+    scaleY
+  }
+}
+
+/** Возвращает true, если snap текущего scaling-step должен менять обе scale-оси единым множителем. */
+export function shouldUseUniformScaleSnap({
+  target,
+  event,
+  isCornerHandle
+}: {
+  target: FabricObject
+  event: { e?: TPointerEvent | null }
+  isCornerHandle: boolean
+}): boolean {
+  if (isCornerHandle) return true
+
+  const cropTarget = target as CropFrameSnapTarget
+  if (!cropTarget.cropSource) return false
+
+  const preserveAspectRatio = cropTarget.preserveAspectRatio ?? true
+  if (!event.e?.shiftKey) return preserveAspectRatio
+
+  return !preserveAspectRatio
+}
+
+/** Находит активные axis-snap кандидаты для текущего scaling-step. */
+export function resolveScaleAxisSnaps({
+  bounds,
+  originX,
+  originY,
+  shouldSnapX,
+  shouldSnapY,
+  threshold,
+  anchors
+}: {
+  bounds: Bounds
+  originX: Transform['originX']
+  originY: Transform['originY']
+  shouldSnapX: boolean
+  shouldSnapY: boolean
+  threshold: number
+  anchors: AnchorBuckets
+}): ScaleAxisSnapState | null {
+  const verticalCandidates = collectVerticalSnapCandidates({
+    bounds,
+    originX,
+    shouldSnapX
+  })
+  const horizontalCandidates = collectHorizontalSnapCandidates({
+    bounds,
+    originY,
+    shouldSnapY
+  })
+  const verticalSnap = findAxisSnapCandidate({
+    anchors: anchors.vertical,
+    candidates: verticalCandidates,
+    threshold
+  })
+  const horizontalSnap = findAxisSnapCandidate({
+    anchors: anchors.horizontal,
+    candidates: horizontalCandidates,
+    threshold
+  })
+
+  if (verticalSnap.guidePosition === null && horizontalSnap.guidePosition === null) {
+    return null
+  }
+
+  return {
+    verticalSnap,
+    horizontalSnap
+  }
+}
+
+/** Рассчитывает scale-обновления и соответствующие направляющие для текущего scaling-step. */
+export function resolveScaleUpdatePlan(params: ScaleUpdatePlanParams): ScaleUpdatePlan | null {
+  if (params.shouldUseUniformScaleSnap) {
+    return resolveUniformScaleUpdatePlan(params)
+  }
+
+  return resolveAxisScaleUpdatePlan(params)
+}
+
+/** Рассчитывает snap-план для горизонтального изменения ширины текстового объекта. */
+export function resolveTextResizeSnapPlan({
+  target,
+  bounds,
+  originX,
+  verticalAnchors,
+  threshold
+}: {
+  target: Textbox
+  bounds: Bounds
+  originX: Transform['originX']
+  verticalAnchors: number[]
+  threshold: number
+}): TextResizeSnapPlan | null {
+  const verticalCandidates = collectVerticalSnapCandidates({
+    bounds,
+    originX,
+    shouldSnapX: true
+  })
+  const verticalSnap = findAxisSnapCandidate({
+    anchors: verticalAnchors,
+    candidates: verticalCandidates,
+    threshold
+  })
+
+  const { guidePosition } = verticalSnap
+  if (guidePosition === null) return null
+
+  const desiredWidth = resolveDesiredWidth({
+    bounds,
+    originX,
+    snap: verticalSnap
+  })
+  if (desiredWidth === null) return null
+
+  const nextWidth = resolveTextWidthForBounds({
+    target,
+    boundsWidth: desiredWidth
+  })
+  if (nextWidth === null) return null
+
+  return {
+    nextWidth,
+    guide: {
+      type: 'vertical',
+      position: guidePosition
+    }
+  }
+}
+
+function resolveUniformScaleUpdatePlan({
+  bounds,
+  originX,
+  originY,
+  scaleX,
+  scaleY,
+  verticalSnap,
+  horizontalSnap
+}: ScaleSnapContext): ScaleUpdatePlan | null {
+  const uniformResult = resolveUniformScale({
+    bounds,
+    originX,
+    originY,
+    verticalSnap,
+    horizontalSnap
+  })
+
+  if (!uniformResult) return null
+
+  const { guide, scaleFactor } = uniformResult
+
+  return {
+    guides: [guide],
+    nextScaleX: scaleX * scaleFactor,
+    nextScaleY: scaleY * scaleFactor
+  }
+}
+
+function resolveAxisScaleUpdatePlan(params: ScaleSnapContext): ScaleUpdatePlan | null {
+  const scaleXUpdate = resolveScaleXUpdate(params)
+  const scaleYUpdate = resolveScaleYUpdate(params)
+
+  if (!scaleXUpdate && !scaleYUpdate) return null
+
+  const guides: GuideLine[] = []
+  let nextScaleX: number | null = null
+  let nextScaleY: number | null = null
+
+  if (scaleXUpdate) {
+    guides.push(scaleXUpdate.guide)
+    nextScaleX = scaleXUpdate.nextScale
+  }
+
+  if (scaleYUpdate) {
+    guides.push(scaleYUpdate.guide)
+    nextScaleY = scaleYUpdate.nextScale
+  }
+
+  return {
+    guides,
+    nextScaleX,
+    nextScaleY
+  }
+}
+
+function resolveScaleXUpdate({
+  target,
+  bounds,
+  originX,
+  scaleX,
+  scaleY,
+  verticalSnap
+}: ScaleSnapContext): AxisScaleUpdate | null {
+  const { guidePosition } = verticalSnap
+  if (guidePosition === null) return null
+
+  const desiredWidth = resolveDesiredWidth({
+    bounds,
+    originX,
+    snap: verticalSnap
+  })
+  if (desiredWidth === null) return null
+
+  const { angle = 0 } = target
+  const { width: baseWidth, height: baseHeight } = resolveBaseDimensions({ target })
+  const absNextScaleX = resolveScaleForWidth({
+    desiredWidth,
+    baseWidth,
+    baseHeight,
+    scaleY: Math.abs(scaleY) || 1,
+    angle
+  })
+  if (absNextScaleX === null) return null
+
+  return {
+    nextScale: absNextScaleX * (scaleX < 0 ? -1 : 1),
+    guide: {
+      type: 'vertical',
+      position: guidePosition
+    }
+  }
+}
+
+function resolveScaleYUpdate({
+  target,
+  bounds,
+  originY,
+  scaleX,
+  scaleY,
+  horizontalSnap
+}: ScaleSnapContext): AxisScaleUpdate | null {
+  const { guidePosition } = horizontalSnap
+  if (guidePosition === null) return null
+
+  const desiredHeight = resolveDesiredHeight({
+    bounds,
+    originY,
+    snap: horizontalSnap
+  })
+  if (desiredHeight === null) return null
+
+  const { angle = 0 } = target
+  const { width: baseWidth, height: baseHeight } = resolveBaseDimensions({ target })
+  const absNextScaleY = resolveScaleForHeight({
+    desiredHeight,
+    baseWidth,
+    baseHeight,
+    scaleX: Math.abs(scaleX) || 1,
+    angle
+  })
+  if (absNextScaleY === null) return null
+
+  return {
+    nextScale: absNextScaleY * (scaleY < 0 ? -1 : 1),
+    guide: {
+      type: 'horizontal',
+      position: guidePosition
+    }
+  }
+}
+
+/**
+ * Собирает кандидаты на вертикальное прилипания по текущему originX.
+ */
+function collectVerticalSnapCandidates({
+  bounds,
+  originX,
+  shouldSnapX
+}: {
+  bounds: Bounds
+  originX: Transform['originX']
+  shouldSnapX: boolean
+}): AxisSnapCandidate[] {
+  const candidates: AxisSnapCandidate[] = []
+  if (!shouldSnapX) return candidates
+
+  const { left, right } = bounds
+  let resolvedOriginX: 'left' | 'center' | 'right' = 'left'
+  if (originX === 'center' || originX === 'right') {
+    resolvedOriginX = originX
+  }
+
+  if (resolvedOriginX === 'left') {
+    candidates.push({
+      edge: 'right',
+      position: right
+    })
+  }
+
+  if (resolvedOriginX === 'right') {
+    candidates.push({
+      edge: 'left',
+      position: left
+    })
+  }
+
+  if (resolvedOriginX === 'center') {
+    candidates.push({
+      edge: 'left',
+      position: left
+    })
+    candidates.push({
+      edge: 'right',
+      position: right
+    })
+  }
+
+  return candidates
+}
+
+/**
+ * Собирает кандидаты на горизонтальное прилипания по текущему originY.
+ */
+function collectHorizontalSnapCandidates({
+  bounds,
+  originY,
+  shouldSnapY
+}: {
+  bounds: Bounds
+  originY: Transform['originY']
+  shouldSnapY: boolean
+}): AxisSnapCandidate[] {
+  const candidates: AxisSnapCandidate[] = []
+  if (!shouldSnapY) return candidates
+
+  const { top, bottom } = bounds
+  let resolvedOriginY: 'top' | 'center' | 'bottom' = 'top'
+  if (originY === 'center' || originY === 'bottom') {
+    resolvedOriginY = originY
+  }
+
+  if (resolvedOriginY === 'top') {
+    candidates.push({
+      edge: 'bottom',
+      position: bottom
+    })
+  }
+
+  if (resolvedOriginY === 'bottom') {
+    candidates.push({
+      edge: 'top',
+      position: top
+    })
+  }
+
+  if (resolvedOriginY === 'center') {
+    candidates.push({
+      edge: 'top',
+      position: top
+    })
+    candidates.push({
+      edge: 'bottom',
+      position: bottom
+    })
+  }
+
+  return candidates
+}
+
+/**
+ * Находит ближайший кандидат прилипания с учетом порога и возвращает дельту.
+ */
+function findAxisSnapCandidate({
+  anchors,
+  candidates,
+  threshold
+}: {
+  anchors: number[]
+  candidates: AxisSnapCandidate[]
+  threshold: number
+}): AxisSnapResult {
+  let nearestDelta = 0
+  let nearestDistance = threshold + 1
+  let guidePosition: number | null = null
+  let candidate: AxisSnapCandidate | null = null
+
+  for (const snapCandidate of candidates) {
+    const { position } = snapCandidate
+
+    for (const anchor of anchors) {
+      const distance = Math.abs(anchor - position)
+      if (distance > threshold || distance >= nearestDistance) continue
+
+      nearestDelta = anchor - position
+      nearestDistance = distance
+      guidePosition = anchor
+      candidate = snapCandidate
+    }
+  }
+
+  return {
+    delta: nearestDelta,
+    guidePosition,
+    candidate
+  }
+}
+
+/**
+ * Рассчитывает коэффициент равномерного масштаба и соответствующий гайд.
+ */
+function resolveUniformScale({
+  bounds,
+  originX,
+  originY,
+  verticalSnap,
+  horizontalSnap
+}: {
+  bounds: Bounds
+  originX: Transform['originX']
+  originY: Transform['originY']
+  verticalSnap: AxisSnapResult
+  horizontalSnap: AxisSnapResult
+}): UniformScaleResult | null {
+  const scaleFactorX = resolveUniformScaleFactorForWidth({
+    bounds,
+    originX,
+    snap: verticalSnap
+  })
+  const scaleFactorY = resolveUniformScaleFactorForHeight({
+    bounds,
+    originY,
+    snap: horizontalSnap
+  })
+  const chosenAxis = chooseUniformScaleAxis({
+    scaleFactorX,
+    scaleFactorY,
+    verticalSnap,
+    horizontalSnap
+  })
+
+  if (chosenAxis === 'x' && scaleFactorX !== null && verticalSnap.guidePosition !== null) {
+    return {
+      scaleFactor: scaleFactorX,
+      guide: {
+        type: 'vertical',
+        position: verticalSnap.guidePosition
+      }
+    }
+  }
+
+  if (chosenAxis === 'y' && scaleFactorY !== null && horizontalSnap.guidePosition !== null) {
+    return {
+      scaleFactor: scaleFactorY,
+      guide: {
+        type: 'horizontal',
+        position: horizontalSnap.guidePosition
+      }
+    }
+  }
+
+  return null
+}
+
+function resolveUniformScaleFactorForWidth({
+  bounds,
+  originX,
+  snap
+}: {
+  bounds: Bounds
+  originX: Transform['originX']
+  snap: AxisSnapResult
+}): number | null {
+  const { left, right } = bounds
+  const currentWidth = right - left
+  if (snap.guidePosition === null || currentWidth <= 0) return null
+
+  const desiredWidth = resolveDesiredWidth({ bounds, originX, snap })
+  if (desiredWidth === null) return null
+
+  const factor = desiredWidth / currentWidth
+  if (!Number.isFinite(factor) || factor <= 0) return null
+
+  return factor
+}
+
+function resolveUniformScaleFactorForHeight({
+  bounds,
+  originY,
+  snap
+}: {
+  bounds: Bounds
+  originY: Transform['originY']
+  snap: AxisSnapResult
+}): number | null {
+  const { top, bottom } = bounds
+  const currentHeight = bottom - top
+  if (snap.guidePosition === null || currentHeight <= 0) return null
+
+  const desiredHeight = resolveDesiredHeight({ bounds, originY, snap })
+  if (desiredHeight === null) return null
+
+  const factor = desiredHeight / currentHeight
+  if (!Number.isFinite(factor) || factor <= 0) return null
+
+  return factor
+}
+
+function chooseUniformScaleAxis({
+  scaleFactorX,
+  scaleFactorY,
+  verticalSnap,
+  horizontalSnap
+}: {
+  scaleFactorX: number | null
+  scaleFactorY: number | null
+  verticalSnap: AxisSnapResult
+  horizontalSnap: AxisSnapResult
+}): 'x' | 'y' | null {
+  if (scaleFactorX !== null && scaleFactorY === null) return 'x'
+  if (scaleFactorY !== null && scaleFactorX === null) return 'y'
+  if (scaleFactorX === null || scaleFactorY === null) return null
+
+  const absVerticalDelta = Math.abs(verticalSnap.delta)
+  const absHorizontalDelta = Math.abs(horizontalSnap.delta)
+
+  if (absVerticalDelta <= absHorizontalDelta) return 'x'
+
+  return 'y'
+}
+
+/**
+ * Рассчитывает требуемую ширину bounding-box для прилипания по X.
+ */
+function resolveDesiredWidth({
+  bounds,
+  originX,
+  snap
+}: {
+  bounds: Bounds
+  originX: Transform['originX']
+  snap: AxisSnapResult
+}): number | null {
+  const { left, right, centerX } = bounds
+  const { candidate, guidePosition } = snap
+  if (!candidate || guidePosition === null) return null
+
+  let resolvedOriginX: 'left' | 'center' | 'right' = 'left'
+  if (originX === 'center' || originX === 'right') {
+    resolvedOriginX = originX
+  }
+
+  const { edge } = candidate
+  let desiredWidth: number | null = null
+
+  if (resolvedOriginX === 'left' && edge === 'right') {
+    desiredWidth = guidePosition - left
+  }
+  if (resolvedOriginX === 'right' && edge === 'left') {
+    desiredWidth = right - guidePosition
+  }
+  if (resolvedOriginX === 'center' && edge === 'left') {
+    desiredWidth = (centerX - guidePosition) * 2
+  }
+  if (resolvedOriginX === 'center' && edge === 'right') {
+    desiredWidth = (guidePosition - centerX) * 2
+  }
+
+  if (desiredWidth === null) return null
+  if (!Number.isFinite(desiredWidth) || desiredWidth <= 0) return null
+
+  return desiredWidth
+}
+
+/**
+ * Рассчитывает требуемую высоту bounding-box для прилипания по Y.
+ */
+function resolveDesiredHeight({
+  bounds,
+  originY,
+  snap
+}: {
+  bounds: Bounds
+  originY: Transform['originY']
+  snap: AxisSnapResult
+}): number | null {
+  const { top, bottom, centerY } = bounds
+  const { candidate, guidePosition } = snap
+  if (!candidate || guidePosition === null) return null
+
+  let resolvedOriginY: 'top' | 'center' | 'bottom' = 'top'
+  if (originY === 'center' || originY === 'bottom') {
+    resolvedOriginY = originY
+  }
+
+  const { edge } = candidate
+  let desiredHeight: number | null = null
+
+  if (resolvedOriginY === 'top' && edge === 'bottom') {
+    desiredHeight = guidePosition - top
+  }
+  if (resolvedOriginY === 'bottom' && edge === 'top') {
+    desiredHeight = bottom - guidePosition
+  }
+  if (resolvedOriginY === 'center' && edge === 'top') {
+    desiredHeight = (centerY - guidePosition) * 2
+  }
+  if (resolvedOriginY === 'center' && edge === 'bottom') {
+    desiredHeight = (guidePosition - centerY) * 2
+  }
+
+  if (desiredHeight === null) return null
+  if (!Number.isFinite(desiredHeight) || desiredHeight <= 0) return null
+
+  return desiredHeight
+}
+
+/**
+ * Возвращает базовые размеры объекта без учета масштаба, включая отступы текста.
+ */
+function resolveBaseDimensions({ target }: { target: FabricObject }): { width: number; height: number } {
+  const {
+    width: rawWidth = 0,
+    height: rawHeight = 0
+  } = target
+  let width = rawWidth
+  let height = rawHeight
+
+  if (target instanceof Textbox) {
+    const {
+      paddingTop = 0,
+      paddingRight = 0,
+      paddingBottom = 0,
+      paddingLeft = 0,
+      strokeWidth = 0
+    } = target
+    width = rawWidth + paddingLeft + paddingRight + strokeWidth
+    height = rawHeight + paddingTop + paddingBottom + strokeWidth
+  }
+
+  return {
+    width,
+    height
+  }
+}
+
+/**
+ * Рассчитывает масштаб по оси X для заданной ширины bounding-box.
+ */
+function resolveScaleForWidth({
+  desiredWidth,
+  baseWidth,
+  baseHeight,
+  scaleY,
+  angle
+}: {
+  desiredWidth: number
+  baseWidth: number
+  baseHeight: number
+  scaleY: number
+  angle: number
+}): number | null {
+  const radians = (angle * Math.PI) / 180
+  const cos = Math.abs(Math.cos(radians))
+  const sin = Math.abs(Math.sin(radians))
+  const widthComponent = baseWidth * cos
+  const heightComponent = baseHeight * scaleY * sin
+
+  if (widthComponent <= 0) return null
+
+  const nextScaleX = (desiredWidth - heightComponent) / widthComponent
+  if (!Number.isFinite(nextScaleX) || nextScaleX <= 0) return null
+
+  return nextScaleX
+}
+
+/**
+ * Рассчитывает масштаб по оси Y для заданной высоты bounding-box.
+ */
+function resolveScaleForHeight({
+  desiredHeight,
+  baseWidth,
+  baseHeight,
+  scaleX,
+  angle
+}: {
+  desiredHeight: number
+  baseWidth: number
+  baseHeight: number
+  scaleX: number
+  angle: number
+}): number | null {
+  const radians = (angle * Math.PI) / 180
+  const cos = Math.abs(Math.cos(radians))
+  const sin = Math.abs(Math.sin(radians))
+  const heightComponent = baseHeight * cos
+  const widthComponent = baseWidth * scaleX * sin
+
+  if (heightComponent <= 0) return null
+
+  const nextScaleY = (desiredHeight - widthComponent) / heightComponent
+  if (!Number.isFinite(nextScaleY) || nextScaleY <= 0) return null
+
+  return nextScaleY
+}
+
+/**
+ * Приводит ширину bounding-box текста к ширине текстового блока.
+ */
+function resolveTextWidthForBounds({
+  target,
+  boundsWidth
+}: {
+  target: Textbox
+  boundsWidth: number
+}): number | null {
+  const {
+    paddingLeft = 0,
+    paddingRight = 0,
+    strokeWidth = 0
+  } = target
+
+  const rawWidth = boundsWidth - paddingLeft - paddingRight - strokeWidth
+  if (!Number.isFinite(rawWidth) || rawWidth <= 0) return null
+
+  return Math.max(1, Math.round(rawWidth))
+}


### PR DESCRIPTION

Порядок воспроизведения.

1. Добавить изображение, рядом с ним какой-то объект справа посередине, например, квадртаный шейп (скрин 1)

<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/1024122f-8888-4742-bd90-7cbe009eac76" />

2. Перейти в кроп-режим изображения с выбранными пропорцями 1:1 с включенным флагом preserveAspectRatio и выключенным флагом allowFrameOverflow (скрин 2)

<img width="1919" height="1004" alt="image" src="https://github.com/user-attachments/assets/fd442c2f-abf6-4c87-8641-9efe1ae8c960" />

3. Уменьшить кроп-область сверху-вниз путём вертикального скейлинга таким образом, чтобы её верхняя граница была на уровне с верхней границей шейпа и чтобы сработало прилипание в SnappingManager

Ожидаемое поведение.

Сработало прилипание из-за чего высота кроп-области резко уменьшилась, при этом, размеры пересчитались так чтобы пропорции сохранялись. Пересчёт произошёл сразу же при срабатывании прилипания, пропорции не изменились ни на секунду. Прилипание и удержание отработало корректно и размеры зафиксировались, поэтому когда мы потянули дальше на расстоянии около 10px размеры не менялись вообще, далее сработало отпускание и размеры снова начали пересчитываться с сохранением пропорций.

Фактический результат.

Сработало прилипание из-за чего высота кроп-области резко уменьшилась, при этом, размеры кроп-области не пересчитались и пропорции больше не соответствуют выбранным 1:1 (скрин 3). Удержание отрабатывает только для высоты, но не для ширины, поэтому когда мы продолжаем тянуть вниз на расстоянии около 10px срабатывает отпускание для высоты, после чего размеры снова пересчитываются и применяются корректные пропорции (скрин 4)

<img width="1916" height="1009" alt="image" src="https://github.com/user-attachments/assets/44016fe8-484f-4181-ae19-9465985e034d" />

<img width="1920" height="1007" alt="image" src="https://github.com/user-attachments/assets/8abaa5de-49fe-48fc-ba6c-68905423c8c1" />

В случае если мы делаем уменьшение кроп-области путём скейлинга по диагонали, то всё работает так как описано в ожидаемом поведении.

Тут проблема как будто в том, что при скейлинге по вертикали удержание не отрабатывает для ширины кроп-области, поэтому она продолжает увеличиваться, в то время как высота стоит на месте.

Аналогичный кейс может быть для уменьшения по горизонтали только уже для высоты (скрин 5-6).

<img width="1919" height="1014" alt="image" src="https://github.com/user-attachments/assets/8e51dcd1-4204-47f5-9bb9-115c855062b7" />

<img width="1917" height="1014" alt="image" src="https://github.com/user-attachments/assets/43b7c869-a4dc-4db2-a1f7-bef02528e4d4" />

---

FIXED.