### PR TITLE
CropManager & SnappingManager. Чиним некорректный snap/release для кроп-области в разных кейсах, а также некорректные размеры в objectSizeIndicator

### DIFF
--- a/e2e/fixtures/data/crop-size-indicator.data.ts
+++ b/e2e/fixtures/data/crop-size-indicator.data.ts
@@ -27,6 +27,24 @@ export const SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS = 2
 /** Вертикальный drag внутри snap-порога для проверки ручного resize из угла. */
 export const STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS = 2
 
+/** Размер изображения для проверки image crop у границ source. */
+export const EDGE_IMAGE_CROP_SOURCE_SIZE = {
+  width: 1000,
+  height: 667
+} as const
+
+/** Квадратная crop-область, ограниченная высотой тестового изображения. */
+export const EDGE_IMAGE_CROP_SQUARE_SIZE = 667
+
+/** Небольшой drag внутри snap-порога для proportional image crop у границы source. */
+export const EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS = 1
+
+/** Небольшой экранный drag внутри snap-порога для proportional image crop у границы source. */
+export const EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS = 1
+
+/** Размер crop-области после уменьшения квадратного image crop до серединных guide source. */
+export const EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE = Math.floor(EDGE_IMAGE_CROP_SQUARE_SIZE / 2)
+
 /** Размеры монтажной области, на которых полный crop не должен терять пиксель. */
 export const FULL_CROP_MONTAGE_SIZES = [
   {
@@ -157,4 +175,169 @@ export const STRICT_FREE_CROP_VERTICAL_SNAP_CORNER_CASES = [
   control: CropControlKey
   title: string
   shrinkDeltaY: -1 | 1
+}>
+
+/** Угловые resize-сценарии proportional image crop у правой границы source. */
+export const EDGE_IMAGE_CROP_BOUNDARY_DRAG_CASES = [
+  {
+    control: 'tl',
+    title: 'левого верхнего угла',
+    directionTitle: 'внутрь source',
+    deltaX: 1,
+    deltaY: 1
+  },
+  {
+    control: 'tl',
+    title: 'левого верхнего угла',
+    directionTitle: 'наружу source',
+    deltaX: -1,
+    deltaY: -1
+  },
+  {
+    control: 'tr',
+    title: 'правого верхнего угла',
+    directionTitle: 'внутрь source',
+    deltaX: -1,
+    deltaY: 1
+  },
+  {
+    control: 'tr',
+    title: 'правого верхнего угла',
+    directionTitle: 'наружу source',
+    deltaX: 1,
+    deltaY: -1
+  },
+  {
+    control: 'bl',
+    title: 'левого нижнего угла',
+    directionTitle: 'внутрь source',
+    deltaX: 1,
+    deltaY: -1
+  },
+  {
+    control: 'bl',
+    title: 'левого нижнего угла',
+    directionTitle: 'наружу source',
+    deltaX: -1,
+    deltaY: 1
+  },
+  {
+    control: 'br',
+    title: 'правого нижнего угла',
+    directionTitle: 'внутрь source',
+    deltaX: -1,
+    deltaY: -1
+  },
+  {
+    control: 'br',
+    title: 'правого нижнего угла',
+    directionTitle: 'наружу source',
+    deltaX: 1,
+    deltaY: 1
+  }
+] as const satisfies ReadonlyArray<{
+  control: CropControlKey
+  title: string
+  directionTitle: string
+  deltaX: -1 | 1
+  deltaY: -1 | 1
+}>
+
+/** Осевые drag-сценарии из углов proportional image crop у правой границы source. */
+export const EDGE_IMAGE_CROP_AXIS_BOUNDARY_DRAG_CASES = [
+  {
+    control: 'tl',
+    title: 'левого верхнего угла',
+    directionTitle: 'по ширине наружу source',
+    deltaX: -1,
+    deltaY: 0
+  },
+  {
+    control: 'tl',
+    title: 'левого верхнего угла',
+    directionTitle: 'по высоте наружу source',
+    deltaX: 0,
+    deltaY: -1
+  },
+  {
+    control: 'tr',
+    title: 'правого верхнего угла',
+    directionTitle: 'по ширине наружу source',
+    deltaX: 1,
+    deltaY: 0
+  },
+  {
+    control: 'tr',
+    title: 'правого верхнего угла',
+    directionTitle: 'по высоте наружу source',
+    deltaX: 0,
+    deltaY: -1
+  },
+  {
+    control: 'bl',
+    title: 'левого нижнего угла',
+    directionTitle: 'по ширине наружу source',
+    deltaX: -1,
+    deltaY: 0
+  },
+  {
+    control: 'bl',
+    title: 'левого нижнего угла',
+    directionTitle: 'по высоте наружу source',
+    deltaX: 0,
+    deltaY: 1
+  },
+  {
+    control: 'br',
+    title: 'правого нижнего угла',
+    directionTitle: 'по ширине наружу source',
+    deltaX: 1,
+    deltaY: 0
+  },
+  {
+    control: 'br',
+    title: 'правого нижнего угла',
+    directionTitle: 'по высоте наружу source',
+    deltaX: 0,
+    deltaY: 1
+  }
+] as const satisfies ReadonlyArray<{
+  control: CropControlKey
+  title: string
+  directionTitle: string
+  deltaX: -1 | 0 | 1
+  deltaY: -1 | 0 | 1
+}>
+
+/** Угловые resize-сценарии proportional image crop до серединных guide source. */
+export const EDGE_IMAGE_CROP_MIDDLE_GUIDE_DRAG_CASES = [
+  {
+    control: 'tl',
+    title: 'левого верхнего угла',
+    deltaX: 1,
+    deltaY: 1
+  },
+  {
+    control: 'tr',
+    title: 'правого верхнего угла',
+    deltaX: -1,
+    deltaY: 1
+  },
+  {
+    control: 'bl',
+    title: 'левого нижнего угла',
+    deltaX: 1,
+    deltaY: -1
+  },
+  {
+    control: 'br',
+    title: 'правого нижнего угла',
+    deltaX: -1,
+    deltaY: -1
+  }
+] as const satisfies ReadonlyArray<{
+  control: CropControlKey
+  title: string
+  deltaX: -1 | 1
+  deltaY: -1 | 1
 }>

--- a/e2e/fixtures/data/crop-size-indicator.data.ts
+++ b/e2e/fixtures/data/crop-size-indicator.data.ts
@@ -24,6 +24,9 @@ export const SNAP_THRESHOLD_SCREEN_PIXELS = 5
 /** Дополнительный отступ за snap-порогом, чтобы drag гарантированно вышел из прилипания. */
 export const SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS = 2
 
+/** Вертикальный drag внутри snap-порога для проверки ручного resize из угла. */
+export const STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS = 2
+
 /** Размеры монтажной области, на которых полный crop не должен терять пиксель. */
 export const FULL_CROP_MONTAGE_SIZES = [
   {
@@ -93,4 +96,65 @@ export const FULL_CROP_SNAP_THRESHOLD_SIDE_CASES = [
   control: CropControlKey
   title: string
   axis: 'horizontal' | 'vertical'
+}>
+
+/** Угловые resize-сценарии без сохранения пропорций около snap-порога. */
+export const FREE_CROP_CORNER_SNAP_AXIS_CASES = [
+  {
+    control: 'tr',
+    title: 'при уменьшении высоты из правого верхнего угла',
+    sizeProperty: 'height',
+    directionMultiplier: -1
+  },
+  {
+    control: 'tr',
+    title: 'при увеличении высоты из правого верхнего угла',
+    sizeProperty: 'height',
+    directionMultiplier: 1
+  },
+  {
+    control: 'tr',
+    title: 'при уменьшении ширины из правого верхнего угла',
+    sizeProperty: 'width',
+    directionMultiplier: -1
+  },
+  {
+    control: 'tr',
+    title: 'при увеличении ширины из правого верхнего угла',
+    sizeProperty: 'width',
+    directionMultiplier: 1
+  }
+] as const satisfies ReadonlyArray<{
+  control: CropControlKey
+  title: string
+  sizeProperty: 'width' | 'height'
+  directionMultiplier: -1 | 1
+}>
+
+/** Угловые controls для вертикального resize без overflow и без сохранения пропорций. */
+export const STRICT_FREE_CROP_VERTICAL_SNAP_CORNER_CASES = [
+  {
+    control: 'tl',
+    title: 'левого верхнего угла',
+    shrinkDeltaY: 1
+  },
+  {
+    control: 'tr',
+    title: 'правого верхнего угла',
+    shrinkDeltaY: 1
+  },
+  {
+    control: 'bl',
+    title: 'левого нижнего угла',
+    shrinkDeltaY: -1
+  },
+  {
+    control: 'br',
+    title: 'правого нижнего угла',
+    shrinkDeltaY: -1
+  }
+] as const satisfies ReadonlyArray<{
+  control: CropControlKey
+  title: string
+  shrinkDeltaY: -1 | 1
 }>

--- a/e2e/models/crop.model.ts
+++ b/e2e/models/crop.model.ts
@@ -67,6 +67,21 @@ type CropFrameControlMouseDragContinuationParams = {
   pointerSteps?: number
 }
 
+/** Параметры drag resize control crop frame в source-пикселях. */
+type CropFrameControlSourceDragParams = {
+  control: CropControlKey
+  deltaX: number
+  deltaY: number
+  pointerSteps?: number
+}
+
+/** Параметры продолжения drag resize control crop frame в source-пикселях. */
+type CropFrameControlSourceDragContinuationParams = {
+  deltaX: number
+  deltaY: number
+  pointerSteps?: number
+}
+
 /** Параметры пошагового resize crop frame до набора live-размеров. */
 type CropFrameResizeToSizesParams = {
   control: CropControlKey
@@ -376,6 +391,43 @@ export class CropModel {
     return this.requireState()
   }
 
+  /** Тянет resize control crop frame на смещение, заданное в source-пикселях. */
+  async dragFrameControlBySourcePixels(
+    params: CropFrameControlSourceDragParams
+  ): Promise<CropStateInfo> {
+    const {
+      control,
+      deltaX,
+      deltaY,
+      pointerSteps
+    } = params
+
+    expect(
+      Number.isFinite(deltaX),
+      'source-смещение crop frame по X должно быть конечным числом'
+    ).toBe(true)
+    expect(
+      Number.isFinite(deltaY),
+      'source-смещение crop frame по Y должно быть конечным числом'
+    ).toBe(true)
+    if (!Number.isFinite(deltaX) || !Number.isFinite(deltaY)) {
+      throw new Error('Source-смещение crop frame должно быть конечным числом')
+    }
+
+    const canvasZoom = await this.getCanvasZoom()
+    expect(canvasZoom).toBeGreaterThan(0)
+    if (canvasZoom <= 0) {
+      throw new Error('Zoom canvas должен быть больше нуля для пересчёта source-пикселей')
+    }
+
+    return this.dragFrameControlBy({
+      control,
+      deltaX: deltaX * canvasZoom,
+      deltaY: deltaY * canvasZoom,
+      pointerSteps
+    })
+  }
+
   /** Тянет resize control до source-границы и продолжает движение наружу. */
   async dragFrameControlPastSourceBoundary({
     control,
@@ -465,6 +517,41 @@ export class CropModel {
     this.lastResizePointer = nextPoint
 
     return this.requireState()
+  }
+
+  /** Продолжает resize crop frame на смещение, заданное в source-пикселях. */
+  async continueFrameResizeBySourcePixels(
+    params: CropFrameControlSourceDragContinuationParams
+  ): Promise<CropStateInfo> {
+    const {
+      deltaX,
+      deltaY,
+      pointerSteps
+    } = params
+
+    expect(
+      Number.isFinite(deltaX),
+      'source-смещение crop frame по X должно быть конечным числом'
+    ).toBe(true)
+    expect(
+      Number.isFinite(deltaY),
+      'source-смещение crop frame по Y должно быть конечным числом'
+    ).toBe(true)
+    if (!Number.isFinite(deltaX) || !Number.isFinite(deltaY)) {
+      throw new Error('Source-смещение crop frame должно быть конечным числом')
+    }
+
+    const canvasZoom = await this.getCanvasZoom()
+    expect(canvasZoom).toBeGreaterThan(0)
+    if (canvasZoom <= 0) {
+      throw new Error('Zoom canvas должен быть больше нуля для пересчёта source-пикселей')
+    }
+
+    return this.continueFrameResizeBy({
+      deltaX: deltaX * canvasZoom,
+      deltaY: deltaY * canvasZoom,
+      pointerSteps
+    })
   }
 
   /** Продолжает активный drag crop-control до целевого результата в source-пикселях. */

--- a/e2e/models/crop.model.ts
+++ b/e2e/models/crop.model.ts
@@ -94,8 +94,13 @@ interface CreatedCropImage extends EditorObjectInfo {
   id: string
 }
 
-/** Параметры подготовки квадратного image crop в середине source. */
-type CenteredSmallSquareImageCropParams = {
+/** Параметры подготовки image crop для созданного изображения. */
+type ImageCropSetupParams = {
+  image: CreatedCropImage
+}
+
+/** Параметры переноса active image crop к правой границе source. */
+type MoveCropFrameToImageRightEdgeParams = {
   image: CreatedCropImage
 }
 
@@ -255,7 +260,7 @@ export class CropModel {
   /** Включает квадратный image crop, уменьшает его и переносит в середину source. */
   async startCenteredSmallSquareImageCrop({
     image
-  }: CenteredSmallSquareImageCropParams): Promise<CropStateInfo> {
+  }: ImageCropSetupParams): Promise<CropStateInfo> {
     const startedState = await this.startImageCrop({
       id: image.id,
       aspectRatio: {
@@ -277,6 +282,52 @@ export class CropModel {
     expect(startedState.options.preserveAspectRatio).toBe(true)
 
     return centeredState
+  }
+
+  /** Включает квадратный image crop 1:1 и переносит frame к правой границе source. */
+  async startSquareImageCropAtImageRightEdge({
+    image
+  }: ImageCropSetupParams): Promise<CropStateInfo> {
+    const startedState = await this.startImageCrop({
+      id: image.id,
+      aspectRatio: {
+        width: 1,
+        height: 1
+      },
+      allowFrameOverflow: false,
+      preserveAspectRatio: true
+    })
+
+    expect(startedState.options.allowFrameOverflow).toBe(false)
+    expect(startedState.options.preserveAspectRatio).toBe(true)
+
+    return this.moveActiveCropFrameToImageRightEdge({ image })
+  }
+
+  /** Переносит active crop frame к правой границе изображения и завершает drag. */
+  async moveActiveCropFrameToImageRightEdge({
+    image
+  }: MoveCropFrameToImageRightEdgeParams): Promise<CropStateInfo> {
+    const state = await this.requireState()
+    const sourceDeltaX = image.width - state.rect.left - state.rect.width
+    const scaleX = Math.abs(state.frame.scaleX ?? 1)
+
+    expect(sourceDeltaX, 'crop frame должен находиться левее правой границы source').toBeGreaterThanOrEqual(0)
+    expect(scaleX, 'scaleX crop frame должен быть больше нуля для переноса к source-границе').toBeGreaterThan(0)
+    if (sourceDeltaX < 0 || scaleX <= 0) {
+      throw new Error('Нельзя перенести crop frame к правой границе source из текущего состояния')
+    }
+
+    await this.dragFrameByOffset({
+      deltaX: sourceDeltaX * scaleX,
+      deltaY: 0
+    })
+    const movedState = await this.finishFrameMove()
+
+    expect(Math.round(movedState.rect.left + movedState.rect.width)).toBe(image.width)
+    expect(Math.round(movedState.rect.height)).toBe(Math.round(state.rect.height))
+
+    return movedState
   }
 
   /** Задаёт размер активной crop-области через публичный API редактора. */
@@ -414,16 +465,15 @@ export class CropModel {
       throw new Error('Source-смещение crop frame должно быть конечным числом')
     }
 
-    const canvasZoom = await this.getCanvasZoom()
-    expect(canvasZoom).toBeGreaterThan(0)
-    if (canvasZoom <= 0) {
-      throw new Error('Zoom canvas должен быть больше нуля для пересчёта source-пикселей')
-    }
+    const pointerDelta = await this.resolveSourcePixelPointerDelta({
+      deltaX,
+      deltaY
+    })
 
     return this.dragFrameControlBy({
       control,
-      deltaX: deltaX * canvasZoom,
-      deltaY: deltaY * canvasZoom,
+      deltaX: pointerDelta.deltaX,
+      deltaY: pointerDelta.deltaY,
       pointerSteps
     })
   }
@@ -541,15 +591,14 @@ export class CropModel {
       throw new Error('Source-смещение crop frame должно быть конечным числом')
     }
 
-    const canvasZoom = await this.getCanvasZoom()
-    expect(canvasZoom).toBeGreaterThan(0)
-    if (canvasZoom <= 0) {
-      throw new Error('Zoom canvas должен быть больше нуля для пересчёта source-пикселей')
-    }
+    const pointerDelta = await this.resolveSourcePixelPointerDelta({
+      deltaX,
+      deltaY
+    })
 
     return this.continueFrameResizeBy({
-      deltaX: deltaX * canvasZoom,
-      deltaY: deltaY * canvasZoom,
+      deltaX: pointerDelta.deltaX,
+      deltaY: pointerDelta.deltaY,
       pointerSteps
     })
   }
@@ -819,6 +868,31 @@ export class CropModel {
     }
 
     return zoom
+  }
+
+  /** Пересчитывает source-пиксели active crop frame в client-смещение pointer. */
+  private async resolveSourcePixelPointerDelta({
+    deltaX,
+    deltaY
+  }: {
+    deltaX: number
+    deltaY: number
+  }): Promise<CropFramePointerDelta> {
+    const state = await this.requireState()
+    const canvasZoom = await this.getCanvasZoom()
+    const scaleX = Math.abs(state.frame.scaleX ?? 1)
+    const scaleY = Math.abs(state.frame.scaleY ?? 1)
+
+    expect(scaleX, 'scaleX crop frame должен быть больше нуля для пересчёта source-пикселей').toBeGreaterThan(0)
+    expect(scaleY, 'scaleY crop frame должен быть больше нуля для пересчёта source-пикселей').toBeGreaterThan(0)
+    if (scaleX <= 0 || scaleY <= 0) {
+      throw new Error('Scale crop frame должен быть больше нуля для пересчёта source-пикселей')
+    }
+
+    return {
+      deltaX: deltaX * scaleX * canvasZoom,
+      deltaY: deltaY * scaleY * canvasZoom
+    }
   }
 
   /** Выполняет browser-side drag crop-control и возвращает pointer для завершения drag. */

--- a/e2e/tests/crop-manager/crop-size-indicator.spec.ts
+++ b/e2e/tests/crop-manager/crop-size-indicator.spec.ts
@@ -1,15 +1,19 @@
 import { test, expect } from '../../fixtures/editor.fixture'
 import {
   CROP_SIZE_INSIDE_SNAP_THRESHOLD,
+  DEFAULT_MONTAGE_SIZE,
   FULL_CROP_MONTAGE_SIZES,
   FULL_CROP_SNAP_THRESHOLD_CORNER_CASES,
   FULL_CROP_SNAP_THRESHOLD_SIDE_CASES,
+  FREE_CROP_CORNER_SNAP_AXIS_CASES,
   LARGER_CROP_TARGET_SIZE,
   SHRUNK_CROP_TARGET_SIZE,
   SMALLER_CROP_SIZE,
   SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS,
   SNAP_THRESHOLD_MONTAGE_SIZE,
-  SNAP_THRESHOLD_SCREEN_PIXELS
+  SNAP_THRESHOLD_SCREEN_PIXELS,
+  STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+  STRICT_FREE_CROP_VERTICAL_SNAP_CORNER_CASES
 } from '../../fixtures/data/crop-size-indicator.data'
 
 test.describe('Индикатор размеров crop-области', () => {
@@ -320,6 +324,221 @@ test.describe('Индикатор размеров crop-области', () => {
           expect(Math.round(releasedState.rect.height)).toBeLessThanOrEqual(
             SNAP_THRESHOLD_MONTAGE_SIZE - snapThresholdInSourcePixels
           )
+        })
+      })
+    }
+  })
+
+  test.describe('непропорциональный crop из угла около snap-порога', () => {
+    test.beforeEach(async({ crop }) => {
+      await crop.startCanvasCrop({
+        preserveAspectRatio: false
+      })
+    })
+
+    for (const cropCase of FREE_CROP_CORNER_SNAP_AXIS_CASES) {
+      test(`${cropCase.title} удерживает полный размер внутри snap-порога`, async({
+        editorModel,
+        crop
+      }) => {
+        const heldSize = {
+          width: DEFAULT_MONTAGE_SIZE,
+          height: DEFAULT_MONTAGE_SIZE
+        }
+        heldSize[cropCase.sizeProperty] += cropCase.directionMultiplier
+
+        const heldState = await test.step('Потянуть угловой control внутри snap-порога', async() => {
+          return crop.dragFrameFromControlToSize({
+            control: cropCase.control,
+            size: heldSize
+          })
+        })
+
+        const heldIndicator = await test.step('Получить индикатор пока snap держит край', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize', async() => {
+          await crop.finishFrameResize()
+        })
+
+        await test.step('Проверить удержание внутри snap-порога', () => {
+          expect(heldState.options.preserveAspectRatio).toBe(false)
+          expect(Math.round(heldState.rect.width)).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(Math.round(heldState.rect.height)).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(heldIndicator.width).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(heldIndicator.height).toBe(DEFAULT_MONTAGE_SIZE)
+        })
+      })
+
+      test(`${cropCase.title} отпускает размер после выхода из snap-порога`, async({
+        editorModel,
+        crop
+      }) => {
+        const canvasState = await test.step('Получить текущий zoom canvas', async() => {
+          return editorModel.getCanvasState()
+        })
+        expect(canvasState.zoom).toBeGreaterThan(0)
+        if (canvasState.zoom <= 0) {
+          throw new Error('Zoom canvas должен быть больше нуля для расчёта snap-порога')
+        }
+
+        const heldSize = {
+          width: DEFAULT_MONTAGE_SIZE,
+          height: DEFAULT_MONTAGE_SIZE
+        }
+        heldSize[cropCase.sizeProperty] += cropCase.directionMultiplier
+
+        await test.step('Начать resize внутри snap-порога', async() => {
+          await crop.dragFrameFromControlToSize({
+            control: cropCase.control,
+            size: heldSize
+          })
+        })
+
+        const snapThresholdInSourcePixels = Math.ceil(SNAP_THRESHOLD_SCREEN_PIXELS / canvasState.zoom)
+        const releasedSize = {
+          width: DEFAULT_MONTAGE_SIZE,
+          height: DEFAULT_MONTAGE_SIZE
+        }
+        releasedSize[cropCase.sizeProperty] += cropCase.directionMultiplier * (
+          snapThresholdInSourcePixels + SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS
+        )
+
+        const releasedState = await test.step('Продолжить движение за snap-порог', async() => {
+          return crop.continueFrameResizeFromControlToSize({
+            control: cropCase.control,
+            size: releasedSize
+          })
+        })
+
+        const releasedIndicator = await test.step('Получить индикатор после выхода из snap-порога', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize', async() => {
+          await crop.finishFrameResize()
+        })
+
+        await test.step('Проверить выход из snap-порога только по активной оси', () => {
+          const fixedSizeProperty = cropCase.sizeProperty === 'width' ? 'height' : 'width'
+          const activeSize = Math.round(releasedState.rect[cropCase.sizeProperty])
+          const fixedSize = Math.round(releasedState.rect[fixedSizeProperty])
+
+          expect(releasedState.options.preserveAspectRatio).toBe(false)
+          expect(fixedSize).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(releasedIndicator.width).toBe(Math.round(releasedState.rect.width))
+          expect(releasedIndicator.height).toBe(Math.round(releasedState.rect.height))
+
+          if (cropCase.directionMultiplier < 0) {
+            expect(activeSize).toBeLessThanOrEqual(
+              DEFAULT_MONTAGE_SIZE - snapThresholdInSourcePixels
+            )
+
+            return
+          }
+
+          expect(activeSize).toBeGreaterThanOrEqual(
+            DEFAULT_MONTAGE_SIZE + snapThresholdInSourcePixels
+          )
+        })
+      })
+    }
+  })
+
+  test.describe('непропорциональный crop без overflow из угла около snap-порога', () => {
+    test.beforeEach(async({ crop }) => {
+      await crop.startCanvasCrop({
+        allowFrameOverflow: false,
+        preserveAspectRatio: false
+      })
+    })
+
+    for (const cropCase of STRICT_FREE_CROP_VERTICAL_SNAP_CORNER_CASES) {
+      test(`при уменьшении высоты из ${cropCase.title} удерживает полный размер внутри snap-порога`, async({
+        editorModel,
+        crop
+      }) => {
+        const heldState = await test.step('Потянуть угловой control по высоте внутри snap-порога', async() => {
+          return crop.dragFrameControlBySourcePixels({
+            control: cropCase.control,
+            deltaX: 0,
+            deltaY: cropCase.shrinkDeltaY * STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+            pointerSteps: 1
+          })
+        })
+
+        const heldIndicator = await test.step('Получить индикатор пока snap держит край', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize', async() => {
+          await crop.finishFrameResize()
+        })
+
+        await test.step('Проверить удержание внутри snap-порога', () => {
+          expect(heldState.options.allowFrameOverflow).toBe(false)
+          expect(heldState.options.preserveAspectRatio).toBe(false)
+          expect(Math.round(heldState.rect.width)).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(Math.round(heldState.rect.height)).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(heldIndicator.width).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(heldIndicator.height).toBe(DEFAULT_MONTAGE_SIZE)
+        })
+      })
+
+      test(`при уменьшении высоты из ${cropCase.title} отпускает размер после выхода из snap-порога`, async({
+        editorModel,
+        crop
+      }) => {
+        const canvasState = await test.step('Получить текущий zoom canvas', async() => {
+          return editorModel.getCanvasState()
+        })
+        expect(canvasState.zoom).toBeGreaterThan(0)
+        if (canvasState.zoom <= 0) {
+          throw new Error('Zoom canvas должен быть больше нуля для расчёта snap-порога')
+        }
+
+        await test.step('Начать resize по высоте внутри snap-порога', async() => {
+          await crop.dragFrameControlBySourcePixels({
+            control: cropCase.control,
+            deltaX: 0,
+            deltaY: cropCase.shrinkDeltaY * STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+            pointerSteps: 1
+          })
+        })
+
+        const snapThresholdInSourcePixels = Math.ceil(SNAP_THRESHOLD_SCREEN_PIXELS / canvasState.zoom)
+        const releaseDelta = snapThresholdInSourcePixels + SNAP_RELEASE_MARGIN_IN_SOURCE_PIXELS
+        expect(releaseDelta).toBeGreaterThan(STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS)
+        if (releaseDelta <= STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS) {
+          throw new Error('Source-смещение для выхода из snap-порога должно быть больше начального шага')
+        }
+
+        const releasedState = await test.step('Продолжить движение по высоте за snap-порог', async() => {
+          return crop.continueFrameResizeBySourcePixels({
+            deltaX: 0,
+            deltaY: cropCase.shrinkDeltaY * (releaseDelta - STRICT_FREE_CROP_INSIDE_SNAP_DRAG_PIXELS),
+            pointerSteps: 8
+          })
+        })
+
+        const releasedIndicator = await test.step('Получить индикатор после выхода из snap-порога', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize', async() => {
+          await crop.finishFrameResize()
+        })
+
+        await test.step('Проверить выход из snap-порога только по высоте', () => {
+          expect(releasedState.options.allowFrameOverflow).toBe(false)
+          expect(releasedState.options.preserveAspectRatio).toBe(false)
+          expect(Math.round(releasedState.rect.width)).toBe(DEFAULT_MONTAGE_SIZE)
+          expect(Math.round(releasedState.rect.height)).toBeLessThanOrEqual(
+            DEFAULT_MONTAGE_SIZE - snapThresholdInSourcePixels
+          )
+          expect(releasedIndicator.width).toBe(Math.round(releasedState.rect.width))
+          expect(releasedIndicator.height).toBe(Math.round(releasedState.rect.height))
         })
       })
     }

--- a/e2e/tests/crop-manager/crop-size-indicator.spec.ts
+++ b/e2e/tests/crop-manager/crop-size-indicator.spec.ts
@@ -2,6 +2,14 @@ import { test, expect } from '../../fixtures/editor.fixture'
 import {
   CROP_SIZE_INSIDE_SNAP_THRESHOLD,
   DEFAULT_MONTAGE_SIZE,
+  EDGE_IMAGE_CROP_AXIS_BOUNDARY_DRAG_CASES,
+  EDGE_IMAGE_CROP_BOUNDARY_DRAG_CASES,
+  EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+  EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS,
+  EDGE_IMAGE_CROP_MIDDLE_GUIDE_DRAG_CASES,
+  EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE,
+  EDGE_IMAGE_CROP_SOURCE_SIZE,
+  EDGE_IMAGE_CROP_SQUARE_SIZE,
   FULL_CROP_MONTAGE_SIZES,
   FULL_CROP_SNAP_THRESHOLD_CORNER_CASES,
   FULL_CROP_SNAP_THRESHOLD_SIDE_CASES,
@@ -152,6 +160,331 @@ test.describe('Индикатор размеров crop-области', () => {
       expect(liveState.rect.height).toBeCloseTo(667, 5)
       expect(indicator.width).toBe(667)
       expect(indicator.height).toBe(667)
+    })
+  })
+
+  test.describe('image crop 1:1 у правой границы source', () => {
+    for (const cropCase of EDGE_IMAGE_CROP_BOUNDARY_DRAG_CASES) {
+      test(`при небольшом resize из ${cropCase.title} ${cropCase.directionTitle} показывает текущий квадрат без сдвига на пиксель`, async({
+        editorModel,
+        crop,
+        images
+      }) => {
+        const image = await test.step('Добавить изображение шире квадратной crop-области', async() => {
+          return images.checkCreation({
+            imageObject: await images.addFilledImage(EDGE_IMAGE_CROP_SOURCE_SIZE)
+          })
+        })
+
+        await test.step('Войти в image crop 1:1 у правой границы source', async() => {
+          const state = await crop.startSquareImageCropAtImageRightEdge({ image })
+
+          expect(Math.round(state.rect.left + state.rect.width)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.width)
+          expect(Math.round(state.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(Math.round(state.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+        })
+
+        const liveState = await test.step('Потянуть угол внутри snap-порога', async() => {
+          return crop.dragFrameControlBySourcePixels({
+            control: cropCase.control,
+            deltaX: cropCase.deltaX * EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+            deltaY: cropCase.deltaY * EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+            pointerSteps: 1
+          })
+        })
+
+        const indicator = await test.step('Получить индикатор пока snap держит crop-область', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize и закрыть crop mode', async() => {
+          await crop.finishFrameResize()
+          await crop.cancel()
+        })
+
+        await test.step('Проверить что indicator совпадает с текущим crop rect', () => {
+          expect(liveState.options.allowFrameOverflow).toBe(false)
+          expect(liveState.options.preserveAspectRatio).toBe(true)
+          expect(Math.round(liveState.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(Math.round(liveState.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(indicator.width).toBe(Math.round(liveState.rect.width))
+          expect(indicator.height).toBe(Math.round(liveState.rect.height))
+        })
+      })
+    }
+
+    for (const cropCase of EDGE_IMAGE_CROP_AXIS_BOUNDARY_DRAG_CASES) {
+      test(`при небольшом resize из ${cropCase.title} ${cropCase.directionTitle} показывает текущий квадрат без сдвига на пиксель`, async({
+        editorModel,
+        crop,
+        images
+      }) => {
+        const image = await test.step('Добавить изображение шире квадратной crop-области', async() => {
+          return images.checkCreation({
+            imageObject: await images.addFilledImage(EDGE_IMAGE_CROP_SOURCE_SIZE)
+          })
+        })
+
+        await test.step('Войти в image crop 1:1 у правой границы source', async() => {
+          const state = await crop.startSquareImageCropAtImageRightEdge({ image })
+
+          expect(Math.round(state.rect.left + state.rect.width)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.width)
+          expect(Math.round(state.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(Math.round(state.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+        })
+
+        const liveState = await test.step('Потянуть угол по одной оси внутри snap-порога', async() => {
+          return crop.dragFrameControlBy({
+            control: cropCase.control,
+            deltaX: cropCase.deltaX * EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS,
+            deltaY: cropCase.deltaY * EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS,
+            pointerSteps: 1
+          })
+        })
+
+        const indicator = await test.step('Получить индикатор пока snap держит crop-область', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize и закрыть crop mode', async() => {
+          await crop.finishFrameResize()
+          await crop.cancel()
+        })
+
+        await test.step('Проверить что indicator совпадает с текущим crop rect', () => {
+          expect(liveState.options.allowFrameOverflow).toBe(false)
+          expect(liveState.options.preserveAspectRatio).toBe(true)
+          expect(Math.round(liveState.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(Math.round(liveState.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(indicator.width).toBe(Math.round(liveState.rect.width))
+          expect(indicator.height).toBe(Math.round(liveState.rect.height))
+        })
+      })
+    }
+  })
+
+  test.describe('image crop 1:1 у серединных guide source', () => {
+    for (const cropCase of EDGE_IMAGE_CROP_MIDDLE_GUIDE_DRAG_CASES) {
+      test(`при уменьшении из ${cropCase.title} до серединных guide показывает половину source без сдвига на пиксель`, async({
+        editorModel,
+        crop,
+        images
+      }) => {
+        const image = await test.step('Добавить изображение шире квадратной crop-области', async() => {
+          return images.checkCreation({
+            imageObject: await images.addFilledImage(EDGE_IMAGE_CROP_SOURCE_SIZE)
+          })
+        })
+
+        await test.step('Войти в image crop 1:1 с запретом выхода за source', async() => {
+          const state = await crop.startImageCrop({
+            id: image.id,
+            aspectRatio: {
+              width: 1,
+              height: 1
+            },
+            allowFrameOverflow: false,
+            preserveAspectRatio: true
+          })
+
+          expect(Math.round(state.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(Math.round(state.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+        })
+
+        const liveState = await test.step('Потянуть угол к серединным guide source', async() => {
+          return crop.dragFrameControlBySourcePixels({
+            control: cropCase.control,
+            deltaX: cropCase.deltaX * (EDGE_IMAGE_CROP_SQUARE_SIZE / 2),
+            deltaY: cropCase.deltaY * (EDGE_IMAGE_CROP_SQUARE_SIZE / 2),
+            pointerSteps: 8
+          })
+        })
+
+        const indicator = await test.step('Получить индикатор во время snap к серединным guide', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize и закрыть crop mode', async() => {
+          await crop.finishFrameResize()
+          await crop.cancel()
+        })
+
+        await test.step('Проверить что indicator не перескочил через серединный guide', () => {
+          expect(liveState.options.allowFrameOverflow).toBe(false)
+          expect(liveState.options.preserveAspectRatio).toBe(true)
+          expect(Math.round(liveState.rect.width)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+          expect(Math.round(liveState.rect.height)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+          expect(indicator.width).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+          expect(indicator.height).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        })
+      })
+    }
+
+    for (const cropCase of EDGE_IMAGE_CROP_MIDDLE_GUIDE_DRAG_CASES) {
+      test(`при точном уменьшении до половины source из ${cropCase.title} не показывает плюс пиксель`, async({
+        editorModel,
+        crop,
+        images
+      }) => {
+        const image = await test.step('Добавить изображение шире квадратной crop-области', async() => {
+          return images.checkCreation({
+            imageObject: await images.addFilledImage(EDGE_IMAGE_CROP_SOURCE_SIZE)
+          })
+        })
+
+        await test.step('Войти в image crop 1:1 у правой границы source', async() => {
+          const state = await crop.startSquareImageCropAtImageRightEdge({ image })
+
+          expect(Math.round(state.rect.left + state.rect.width)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.width)
+          expect(Math.round(state.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+          expect(Math.round(state.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+        })
+
+        const liveState = await test.step('Уменьшить crop ровно до половины source', async() => {
+          return crop.dragFrameFromControlToSize({
+            control: cropCase.control,
+            size: {
+              width: EDGE_IMAGE_CROP_SQUARE_SIZE / 2,
+              height: EDGE_IMAGE_CROP_SQUARE_SIZE / 2
+            }
+          })
+        })
+
+        const indicator = await test.step('Получить индикатор во время resize', async() => {
+          return editorModel.requireObjectSizeIndicator()
+        })
+
+        await test.step('Завершить resize и закрыть crop mode', async() => {
+          await crop.finishFrameResize()
+          await crop.cancel()
+        })
+
+        await test.step('Проверить что indicator не округлил половину source вверх', () => {
+          expect(liveState.options.allowFrameOverflow).toBe(false)
+          expect(liveState.options.preserveAspectRatio).toBe(true)
+          expect(indicator.width).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+          expect(indicator.height).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        })
+      })
+    }
+
+    test('после snap к серединному guide не показывает плюс пиксель при микродвижении из левого верхнего угла', async({
+      editorModel,
+      crop,
+      images
+    }) => {
+      const image = await test.step('Добавить изображение шире квадратной crop-области', async() => {
+        return images.checkCreation({
+          imageObject: await images.addFilledImage(EDGE_IMAGE_CROP_SOURCE_SIZE)
+        })
+      })
+
+      await test.step('Войти в image crop 1:1 у правой границы source', async() => {
+        const state = await crop.startSquareImageCropAtImageRightEdge({ image })
+
+        expect(Math.round(state.rect.left + state.rect.width)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.width)
+        expect(Math.round(state.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+        expect(Math.round(state.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+      })
+
+      const snappedState = await test.step('Потянуть левый верхний угол к серединным guide source', async() => {
+        return crop.dragFrameControlBySourcePixels({
+          control: 'tl',
+          deltaX: EDGE_IMAGE_CROP_SQUARE_SIZE / 2,
+          deltaY: EDGE_IMAGE_CROP_SQUARE_SIZE / 2,
+          pointerSteps: 8
+        })
+      })
+      const heldState = await test.step('Продолжить движение наружу внутри snap-порога', async() => {
+        return crop.continueFrameResizeBy({
+          deltaX: -EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS,
+          deltaY: -EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS,
+          pointerSteps: 1
+        })
+      })
+
+      const indicator = await test.step('Получить индикатор после микродвижения внутри snap-порога', async() => {
+        return editorModel.requireObjectSizeIndicator()
+      })
+
+      await test.step('Завершить resize и закрыть crop mode', async() => {
+        await crop.finishFrameResize()
+        await crop.cancel()
+      })
+
+      await test.step('Проверить что indicator не перескочил через серединный guide', () => {
+        expect(snappedState.options.allowFrameOverflow).toBe(false)
+        expect(snappedState.options.preserveAspectRatio).toBe(true)
+        expect(Math.round(snappedState.rect.width)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(Math.round(snappedState.rect.height)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(Math.round(heldState.rect.width)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(Math.round(heldState.rect.height)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(indicator.width).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(indicator.height).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+      })
+    })
+
+    test('после snap к серединному guide не увеличивает crop из левого нижнего угла внутри snap-порога', async({
+      editorModel,
+      crop,
+      images
+    }) => {
+      const image = await test.step('Добавить изображение шире квадратной crop-области', async() => {
+        return images.checkCreation({
+          imageObject: await images.addFilledImage(EDGE_IMAGE_CROP_SOURCE_SIZE)
+        })
+      })
+
+      await test.step('Войти в image crop 1:1 у правой границы source', async() => {
+        const state = await crop.startSquareImageCropAtImageRightEdge({ image })
+
+        expect(Math.round(state.rect.left + state.rect.width)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.width)
+        expect(Math.round(state.rect.width)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+        expect(Math.round(state.rect.height)).toBe(EDGE_IMAGE_CROP_SQUARE_SIZE)
+      })
+
+      await test.step('Уменьшить crop до серединных guide source', async() => {
+        const state = await crop.dragFrameControlBySourcePixels({
+          control: 'tl',
+          deltaX: EDGE_IMAGE_CROP_SQUARE_SIZE / 2,
+          deltaY: EDGE_IMAGE_CROP_SQUARE_SIZE / 2,
+          pointerSteps: 8
+        })
+
+        expect(Math.round(state.rect.width)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(Math.round(state.rect.height)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+
+        await crop.finishFrameResize()
+      })
+
+      const heldState = await test.step('Потянуть левый нижний угол наружу внутри snap-порога', async() => {
+        return crop.dragFrameControlBySourcePixels({
+          control: 'bl',
+          deltaX: -EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+          deltaY: EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+          pointerSteps: 1
+        })
+      })
+
+      const indicator = await test.step('Получить индикатор после микродвижения внутри snap-порога', async() => {
+        return editorModel.requireObjectSizeIndicator()
+      })
+
+      await test.step('Завершить resize и закрыть crop mode', async() => {
+        await crop.finishFrameResize()
+        await crop.cancel()
+      })
+
+      await test.step('Проверить что right и bottom source не дали crop вырасти внутри snap-порога', () => {
+        expect(heldState.options.allowFrameOverflow).toBe(false)
+        expect(heldState.options.preserveAspectRatio).toBe(true)
+        expect(Math.round(heldState.rect.left + heldState.rect.width)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.width)
+        expect(Math.round(heldState.rect.top + heldState.rect.height)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.height)
+        expect(Math.round(heldState.rect.width)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(Math.round(heldState.rect.height)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(indicator.width).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+        expect(indicator.height).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+      })
     })
   })
 

--- a/specs/src/editor/crop-manager/crop-proportional-source-scale.spec.ts
+++ b/specs/src/editor/crop-manager/crop-proportional-source-scale.spec.ts
@@ -100,4 +100,24 @@ describe('ограничение proportional scale внутри source', () => 
     expect(scale).toBe(1)
     expect(667 * scale).toBe(667)
   })
+
+  it('не разрешает рост, если source-rect уже занял всю ширину source', () => {
+    const scale = resolveCropProportionalSourceScaleLimit({
+      sourceSize: {
+        width: 1000,
+        height: 667
+      },
+      startRect: {
+        left: -500,
+        top: -100,
+        width: 1000,
+        height: 200
+      },
+      anchorX: 'center',
+      anchorY: 'center'
+    })
+
+    expect(scale).toBe(1)
+    expect(1000 * scale).toBe(1000)
+  })
 })

--- a/specs/src/editor/snapping-manager/pixel-grid.spec.ts
+++ b/specs/src/editor/snapping-manager/pixel-grid.spec.ts
@@ -1,0 +1,36 @@
+import { applyScalingStep } from '../../../../src/editor/snapping-manager/pixel-grid'
+import {
+  createSourceScaledRect,
+  getRoundedDisplaySize
+} from '../../../test-utils/shared/pixel-grid'
+
+describe('SnappingManager pixel-grid contract', () => {
+  it('для source-size crop frame оставляет размер внутри guide вместо округления вверх', () => {
+    const target = createSourceScaledRect({
+      width: 667,
+      height: 667,
+      scaleX: 0.256,
+      scaleY: 0.256,
+      sourceScaleX: 0.512,
+      sourceScaleY: 0.512
+    })
+
+    applyScalingStep({
+      target,
+      snapGuards: [
+        {
+          type: 'horizontal',
+          edge: 'bottom',
+          position: 171
+        }
+      ]
+    })
+
+    const displaySize = getRoundedDisplaySize({ target })
+
+    expect(displaySize.width).toBe(333)
+    expect(displaySize.height).toBe(333)
+    expect(target.scaleX).toBeCloseTo(0.255616, 6)
+    expect(target.scaleY).toBeCloseTo(0.255616, 6)
+  })
+})

--- a/specs/src/editor/snapping-manager/scaling.spec.ts
+++ b/specs/src/editor/snapping-manager/scaling.spec.ts
@@ -1,4 +1,5 @@
 import {
+  resolveScaleAxisSnaps,
   resolveScaleUpdatePlan,
   shouldUseUniformScaleSnap
 } from '../../../../src/editor/snapping-manager/scaling'
@@ -49,6 +50,92 @@ describe('SnappingManager scaling contract', () => {
 
     expect(withoutShift).toBe(false)
     expect(withShift).toBe(true)
+  })
+
+  it('для corner-control crop frame с выключенным preserveAspectRatio включает uniform snap только с Shift', () => {
+    const target = createCropFrameTarget({
+      preserveAspectRatio: false
+    })
+
+    const withoutShift = shouldUseUniformScaleSnap({
+      target,
+      event: createScalingEvent(),
+      isCornerHandle: true
+    })
+    const withShift = shouldUseUniformScaleSnap({
+      target,
+      event: createScalingEvent({ shiftKey: true }),
+      isCornerHandle: true
+    })
+
+    expect(withoutShift).toBe(false)
+    expect(withShift).toBe(true)
+  })
+
+  it('для правого верхнего control использует верхнюю грань для snap по высоте, даже если originY уже указывает на top', () => {
+    const snapState = resolveScaleAxisSnaps({
+      bounds: createScalingBounds({
+        left: 0,
+        top: 2,
+        width: 512,
+        height: 510
+      }),
+      corner: 'tr',
+      originX: 'left',
+      originY: 'top',
+      shouldSnapX: true,
+      shouldSnapY: true,
+      threshold: 5,
+      anchors: {
+        vertical: [512],
+        horizontal: [0]
+      }
+    })
+
+    expect(snapState).not.toBeNull()
+    if (!snapState) {
+      throw new Error('Snap state для правого верхнего control должен существовать')
+    }
+
+    expect(snapState.verticalSnap.guidePosition).toBe(512)
+    expect(snapState.horizontalSnap.guidePosition).toBe(0)
+    expect(snapState.horizontalSnap.candidate).toEqual({
+      edge: 'top',
+      position: 2
+    })
+  })
+
+  it('для левого нижнего control использует нижнюю грань для snap по высоте, даже если originY уже указывает на bottom', () => {
+    const snapState = resolveScaleAxisSnaps({
+      bounds: createScalingBounds({
+        left: 2,
+        top: 0,
+        width: 510,
+        height: 510
+      }),
+      corner: 'bl',
+      originX: 'right',
+      originY: 'bottom',
+      shouldSnapX: true,
+      shouldSnapY: true,
+      threshold: 5,
+      anchors: {
+        vertical: [0],
+        horizontal: [512]
+      }
+    })
+
+    expect(snapState).not.toBeNull()
+    if (!snapState) {
+      throw new Error('Snap state для левого нижнего control должен существовать')
+    }
+
+    expect(snapState.verticalSnap.guidePosition).toBe(0)
+    expect(snapState.horizontalSnap.guidePosition).toBe(512)
+    expect(snapState.horizontalSnap.candidate).toEqual({
+      edge: 'bottom',
+      position: 510
+    })
   })
 
   it('при vertical snap side-control пересчитывает обе scale-оси одним коэффициентом', () => {

--- a/specs/src/editor/snapping-manager/scaling.spec.ts
+++ b/specs/src/editor/snapping-manager/scaling.spec.ts
@@ -171,6 +171,13 @@ describe('SnappingManager scaling contract', () => {
         position: 40
       }
     ])
+    expect(plan.snapGuards).toEqual([
+      {
+        type: 'horizontal',
+        edge: 'top',
+        position: 40
+      }
+    ])
     expect(plan.nextScaleX).toBeCloseTo(0.8, 5)
     expect(plan.nextScaleY).toBeCloseTo(0.8, 5)
   })
@@ -208,7 +215,126 @@ describe('SnappingManager scaling contract', () => {
         position: 40
       }
     ])
+    expect(plan.snapGuards).toEqual([
+      {
+        type: 'vertical',
+        edge: 'left',
+        position: 40
+      }
+    ])
     expect(plan.nextScaleX).toBeCloseTo(0.8, 5)
     expect(plan.nextScaleY).toBeCloseTo(0.8, 5)
+  })
+
+  it('при uniform snap по двум осям передаёт guards для обоих активных краёв', () => {
+    const plan = resolveScaleUpdatePlan({
+      target: createCropFrameTarget(),
+      bounds: createScalingBounds({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100
+      }),
+      originX: 'left',
+      originY: 'top',
+      scaleX: 1,
+      scaleY: 1,
+      shouldUseUniformScaleSnap: true,
+      verticalSnap: createAxisSnapResult({
+        edge: 'right',
+        position: 100,
+        guidePosition: 80
+      }),
+      horizontalSnap: createAxisSnapResult({
+        edge: 'bottom',
+        position: 100,
+        guidePosition: 80
+      })
+    })
+
+    expect(plan).not.toBeNull()
+    if (!plan) {
+      throw new Error('Scale plan для uniform snap по двум осям должен существовать')
+    }
+
+    expect(plan.guides).toEqual([
+      {
+        type: 'vertical',
+        position: 80
+      }
+    ])
+    expect(plan.snapGuards).toEqual([
+      {
+        type: 'vertical',
+        edge: 'right',
+        position: 80
+      },
+      {
+        type: 'horizontal',
+        edge: 'bottom',
+        position: 80
+      }
+    ])
+    expect(plan.nextScaleX).toBeCloseTo(0.8, 5)
+    expect(plan.nextScaleY).toBeCloseTo(0.8, 5)
+  })
+
+  it('при раздельном snap по осям передаёт guards для обоих активных краёв', () => {
+    const plan = resolveScaleUpdatePlan({
+      target: createCropFrameTarget({
+        preserveAspectRatio: false
+      }),
+      bounds: createScalingBounds({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100
+      }),
+      originX: 'left',
+      originY: 'top',
+      scaleX: 1,
+      scaleY: 1,
+      shouldUseUniformScaleSnap: false,
+      verticalSnap: createAxisSnapResult({
+        edge: 'right',
+        position: 100,
+        guidePosition: 80
+      }),
+      horizontalSnap: createAxisSnapResult({
+        edge: 'bottom',
+        position: 100,
+        guidePosition: 70
+      })
+    })
+
+    expect(plan).not.toBeNull()
+    if (!plan) {
+      throw new Error('Scale plan для раздельного snap по осям должен существовать')
+    }
+
+    expect(plan.guides).toEqual([
+      {
+        type: 'vertical',
+        position: 80
+      },
+      {
+        type: 'horizontal',
+        position: 70
+      }
+    ])
+    expect(plan.snapGuards).toEqual([
+      {
+        type: 'vertical',
+        edge: 'right',
+        position: 80
+      },
+      {
+        type: 'horizontal',
+        edge: 'bottom',
+        position: 70
+      }
+    ])
+    expect(plan.nextScaleX).toBeCloseTo(0.8, 5)
+    expect(plan.nextScaleY).toBeCloseTo(0.7, 5)
   })
 })

--- a/specs/test-utils/editor/editor-stub.ts
+++ b/specs/test-utils/editor/editor-stub.ts
@@ -302,6 +302,7 @@ export const createEditorStub = () => {
     cropManager: {
       isActive: false,
       isFrameOverflowingSource: jest.fn().mockReturnValue(false),
+      isFrameSourceScaleClamped: jest.fn().mockReturnValue(false),
       resetFrameToSource: jest.fn().mockReturnValue(null)
     },
     montageArea,

--- a/specs/test-utils/shared/pixel-grid.ts
+++ b/specs/test-utils/shared/pixel-grid.ts
@@ -1,0 +1,84 @@
+import { Rect } from 'fabric'
+
+import type { ObjectBounds } from '../../../src/editor/utils/geometry'
+
+type SourceScaledRect = Rect & {
+  cropSourceScaleX: number
+  cropSourceScaleY: number
+  getObjectDisplaySize(): { width: number; height: number }
+  getObjectSnappingBounds(): ObjectBounds
+}
+
+/** Создаёт Rect, чей display-size считается в source-пикселях. */
+export function createSourceScaledRect({
+  width,
+  height,
+  scaleX,
+  scaleY,
+  sourceScaleX,
+  sourceScaleY,
+  left = 0,
+  top = 0
+}: {
+  width: number
+  height: number
+  scaleX: number
+  scaleY: number
+  sourceScaleX: number
+  sourceScaleY: number
+  left?: number
+  top?: number
+}): SourceScaledRect {
+  const target = new Rect({
+    left,
+    top,
+    width,
+    height,
+    scaleX,
+    scaleY,
+    originX: 'left',
+    originY: 'top',
+    strokeWidth: 0
+  }) as SourceScaledRect
+
+  target.cropSourceScaleX = sourceScaleX
+  target.cropSourceScaleY = sourceScaleY
+  target.getObjectDisplaySize = () => {
+    return {
+      width: Math.max(1, (target.width * Math.abs(target.scaleX ?? 1)) / sourceScaleX),
+      height: Math.max(1, (target.height * Math.abs(target.scaleY ?? 1)) / sourceScaleY)
+    }
+  }
+  target.getObjectSnappingBounds = () => {
+    const boundsLeft = target.left ?? 0
+    const boundsTop = target.top ?? 0
+    const boundsWidth = Math.round(target.width * Math.abs(target.scaleX ?? 1))
+    const boundsHeight = Math.round(target.height * Math.abs(target.scaleY ?? 1))
+
+    return {
+      left: boundsLeft,
+      top: boundsTop,
+      right: boundsLeft + boundsWidth,
+      bottom: boundsTop + boundsHeight,
+      centerX: boundsLeft + (boundsWidth / 2),
+      centerY: boundsTop + (boundsHeight / 2)
+    }
+  }
+  target.setCoords()
+
+  return target
+}
+
+/** Возвращает display-size так, как его показывает object size indicator. */
+export function getRoundedDisplaySize({
+  target
+}: {
+  target: SourceScaledRect
+}): { width: number; height: number } {
+  const size = target.getObjectDisplaySize()
+
+  return {
+    width: Math.round(size.width),
+    height: Math.round(size.height)
+  }
+}

--- a/src/editor/crop-manager/domain/crop-proportional-source-scale.ts
+++ b/src/editor/crop-manager/domain/crop-proportional-source-scale.ts
@@ -33,6 +33,21 @@ export function resolveCropProportionalSourceScaleLimit({
   anchorX,
   anchorY
 }: ResolveCropProportionalSourceScaleLimitParams): number {
+  const startWidth = Math.max(1, startRect.width)
+  const startHeight = Math.max(1, startRect.height)
+
+  if (isSourceAxisVisiblyFilled({
+    sourceSize,
+    rect: startRect,
+    axis: 'x'
+  })) return 1
+
+  if (isSourceAxisVisiblyFilled({
+    sourceSize,
+    rect: startRect,
+    axis: 'y'
+  })) return 1
+
   const widthLimit = resolveAnchoredSourceSizeLimit({
     sourceSize,
     rect: startRect,
@@ -45,8 +60,7 @@ export function resolveCropProportionalSourceScaleLimit({
     axis: 'y',
     anchor: anchorY
   })
-  const startWidth = Math.max(1, startRect.width)
-  const startHeight = Math.max(1, startRect.height)
+
   const anchoredMaxScale = Math.min(
     widthLimit / startWidth,
     heightLimit / startHeight
@@ -61,6 +75,24 @@ export function resolveCropProportionalSourceScaleLimit({
   if (remainingGrowth <= SOURCE_BOUNDARY_SIZE_EPSILON) return 1
 
   return Math.max(1, maxScale)
+}
+
+/**
+ * Возвращает true, если crop rect уже занимает всю source-длину в отображаемых пикселях.
+ */
+function isSourceAxisVisiblyFilled({
+  sourceSize,
+  rect,
+  axis
+}: {
+  sourceSize: CropSize
+  rect: CropRect
+  axis: 'x' | 'y'
+}): boolean {
+  const sourceLength = axis === 'x' ? sourceSize.width : sourceSize.height
+  const rectLength = axis === 'x' ? rect.width : rect.height
+
+  return Math.round(rectLength) >= Math.round(sourceLength)
 }
 
 /**

--- a/src/editor/crop-manager/index.ts
+++ b/src/editor/crop-manager/index.ts
@@ -73,10 +73,19 @@ type CanvasWithTargetCache = Canvas & {
 }
 
 /**
+ * Scale, на котором proportional resize уже упёрся в source.
+ */
+type CropSourceBoundScale = {
+  scaleX: number
+  scaleY: number
+}
+
+/**
  * Fabric transform, который crop controls помечают при упоре proportional resize в source.
  */
 type CropSourceBoundTransform = Transform & {
   cropSourceScaleClamped?: boolean
+  cropSourceBoundScale?: CropSourceBoundScale | null
 }
 
 /**
@@ -156,6 +165,21 @@ export default class CropManager {
       || rect.top < minTop
       || rect.left + rect.width > maxRight
       || rect.top + rect.height > maxBottom
+  }
+
+  /** Возвращает true, если active crop frame уже зажат source-границей в текущем scale-step. */
+  public isFrameSourceScaleClamped({
+    target,
+    transform
+  }: {
+    target?: FabricObject | null
+    transform?: Transform | null
+  }): boolean {
+    const { _session: session } = this
+    if (!session || !target || !transform) return false
+    if (session.frame !== target) return false
+
+    return (transform as CropSourceBoundTransform).cropSourceScaleClamped === true
   }
 
   /**
@@ -524,7 +548,10 @@ export default class CropManager {
 
     this._clampFrameIfNeeded({
       session,
-      preserveAspectRatio: this._isSourceScaleClamped({ event })
+      preserveAspectRatio: this._shouldPreserveAspectRatioOnFrameClamp({
+        session,
+        event
+      })
     })
     if (!restoredSourceBoundFrame) {
       this._rememberSourceBoundFrameIfNeeded({
@@ -550,14 +577,42 @@ export default class CropManager {
       session.sourceBoundFrameState = null
       return false
     }
-    if (!session.sourceBoundFrameState) return false
+
+    const state = session.sourceBoundFrameState
+      ?? this._getSourceBoundFrameStateFromEvent({
+        session,
+        event
+      })
+    if (!state) return false
 
     this._applyFrameTransformState({
       session,
-      state: session.sourceBoundFrameState
+      state
     })
 
     return true
+  }
+
+  /**
+   * Возвращает frame state из текущего source-bound transform.
+   */
+  private _getSourceBoundFrameStateFromEvent({
+    session,
+    event
+  }: {
+    session: CropSession
+    event?: CropFrameChangeEvent
+  }): CropFrameTransformState | null {
+    const scale = event?.transform?.cropSourceBoundScale
+    if (!scale) return null
+    if (!Number.isFinite(scale.scaleX) || !Number.isFinite(scale.scaleY)) return null
+
+    return {
+      left: session.frame.left,
+      top: session.frame.top,
+      scaleX: scale.scaleX,
+      scaleY: scale.scaleY
+    }
   }
 
   /**
@@ -587,6 +642,24 @@ export default class CropManager {
     event?: CropFrameChangeEvent
   }): boolean {
     return event?.transform?.cropSourceScaleClamped === true
+  }
+
+  /**
+   * Возвращает true, если source-clamp текущего live-step должен сохранять пропорции crop frame.
+   */
+  private _shouldPreserveAspectRatioOnFrameClamp({
+    session,
+    event
+  }: {
+    session: CropSession
+    event?: CropFrameChangeEvent
+  }): boolean {
+    if (this._isSourceScaleClamped({ event })) return true
+
+    const isShiftPressed = Boolean(event?.e?.shiftKey)
+    if (!isShiftPressed) return session.options.preserveAspectRatio
+
+    return !session.options.preserveAspectRatio
   }
 
   /**

--- a/src/editor/crop-manager/index.ts
+++ b/src/editor/crop-manager/index.ts
@@ -55,6 +55,12 @@ const DEFAULT_CROP_SESSION_OPTIONS = {
 } satisfies CropSessionOptions
 
 /**
+ * Допуск для live-проверки выхода frame за source.
+ * Fabric может давать доли пикселя у frame, который визуально стоит на границе source.
+ */
+const SOURCE_BOUNDS_OVERFLOW_EPSILON = 0.5
+
+/**
  * Часть internal Fabric canvas state, нужная только чтобы погасить текущий pointer event.
  */
 type CanvasWithTargetCache = Canvas & {
@@ -141,10 +147,10 @@ export default class CropManager {
       frame: session.frame
     })
     const sourceSize = getSourceSize({ source: session.source })
-    const minLeft = -sourceSize.width / 2
-    const minTop = -sourceSize.height / 2
-    const maxRight = sourceSize.width / 2
-    const maxBottom = sourceSize.height / 2
+    const minLeft = (-sourceSize.width / 2) - SOURCE_BOUNDS_OVERFLOW_EPSILON
+    const minTop = (-sourceSize.height / 2) - SOURCE_BOUNDS_OVERFLOW_EPSILON
+    const maxRight = (sourceSize.width / 2) + SOURCE_BOUNDS_OVERFLOW_EPSILON
+    const maxBottom = (sourceSize.height / 2) + SOURCE_BOUNDS_OVERFLOW_EPSILON
 
     return rect.left < minLeft
       || rect.top < minTop

--- a/src/editor/crop-manager/interaction/crop-controls.ts
+++ b/src/editor/crop-manager/interaction/crop-controls.ts
@@ -42,6 +42,14 @@ const CROP_CORNER_CONTROL_KEYS = ['tl', 'tr', 'bl', 'br'] as const
 const CROP_SIDE_CONTROL_KEYS = ['ml', 'mr', 'mt', 'mb'] as const
 
 /**
+ * Scale, на котором proportional resize уже упёрся в source.
+ */
+type CropSourceBoundScale = {
+  scaleX: number
+  scaleY: number
+}
+
+/**
  * Transform с сохранённым стартовым знаком стороны во время scale.
  */
 type CropScaleTransform = Transform & {
@@ -49,6 +57,7 @@ type CropScaleTransform = Transform & {
   signY?: number
   cropProportionalSourceBounds?: CropProportionalSourceBounds | null
   cropSourceScaleClamped?: boolean
+  cropSourceBoundScale?: CropSourceBoundScale | null
 }
 
 /**
@@ -193,11 +202,13 @@ function scaleCropFrameProportionallyFromCorner({
   const cropTransform = transform as CropScaleTransform
   const { target } = cropTransform
   const { scaleX: currentScaleX = 1, scaleY: currentScaleY = 1 } = target
-  if (isPointerAtTransformStart({
+  const pointerAtStart = isPointerAtTransformStart({
     transform: cropTransform,
     x,
     y
-  })) {
+  })
+
+  if (pointerAtStart) {
     restoreOriginalScale({ transform: cropTransform })
 
     return true
@@ -695,9 +706,21 @@ function clampProportionalScale({
     })
   }
 
+  const scaleX = transform.original.scaleX * nextScale
+  const scaleY = transform.original.scaleY * nextScale
+
+  if (transform.cropSourceScaleClamped) {
+    transform.cropSourceBoundScale = {
+      scaleX,
+      scaleY
+    }
+  } else {
+    transform.cropSourceBoundScale = null
+  }
+
   return {
-    scaleX: transform.original.scaleX * nextScale,
-    scaleY: transform.original.scaleY * nextScale
+    scaleX,
+    scaleY
   }
 }
 
@@ -735,7 +758,7 @@ function getProportionalSourceBounds({
   target: FabricObject
   transform: CropScaleTransform
 }): CropProportionalSourceBounds | null {
-  if (transform.cropProportionalSourceBounds !== undefined) {
+  if (transform.cropProportionalSourceBounds) {
     return transform.cropProportionalSourceBounds
   }
 

--- a/src/editor/snapping-manager/index.ts
+++ b/src/editor/snapping-manager/index.ts
@@ -315,6 +315,13 @@ export default class SnappingManager {
       this._clearGuides()
       return
     }
+    if (!this._hasObjectScaleChanged({
+      target,
+      transform
+    })) {
+      this._clearGuides()
+      return
+    }
 
     const {
       shouldSnapX,
@@ -323,7 +330,11 @@ export default class SnappingManager {
     } = resolveScalingAxisState({ transform })
 
     if (!shouldSnapX && !shouldSnapY) {
-      this._clearGuides()
+      this._finishObjectScalingWithoutSnap({
+        target,
+        transform,
+        canApplyPixelScalingStep
+      })
       return
     }
 
@@ -338,7 +349,11 @@ export default class SnappingManager {
 
     const activeBounds = getObjectBounds({ object: target })
     if (!activeBounds) {
-      this._clearGuides()
+      this._finishObjectScalingWithoutSnap({
+        target,
+        transform,
+        canApplyPixelScalingStep
+      })
       return
     }
 
@@ -361,7 +376,11 @@ export default class SnappingManager {
     })
 
     if (!snapState) {
-      this._clearGuides()
+      this._finishObjectScalingWithoutSnap({
+        target,
+        transform,
+        canApplyPixelScalingStep
+      })
       return
     }
 
@@ -383,7 +402,11 @@ export default class SnappingManager {
     })
 
     if (!scalePlan) {
-      this._clearGuides()
+      this._finishObjectScalingWithoutSnap({
+        target,
+        transform,
+        canApplyPixelScalingStep
+      })
       return
     }
 
@@ -396,7 +419,26 @@ export default class SnappingManager {
     })
 
     if (canApplyPixelScalingStep) {
-      applyScalingStep({ target, transform })
+      const scaleStepPlacement = this.editor.canvasManager.getObjectPlacement({
+        object: target,
+        originX,
+        originY
+      })
+
+      applyScalingStep({
+        target,
+        transform,
+        preservePlacement: {
+          placement: scaleStepPlacement,
+          applyPlacement: (placement) => {
+            this.editor.canvasManager.applyObjectPlacement({
+              object: target,
+              placement
+            })
+          }
+        },
+        snapGuards: scalePlan.snapGuards
+      })
     }
 
     if (this._shouldHideOverflowingCropFrameGuides({ target })) return
@@ -439,6 +481,11 @@ export default class SnappingManager {
     event: TransformEvent
     canApplyPixelScalingStep: boolean
   }): boolean {
+    if (this.editor.cropManager.isFrameSourceScaleClamped({ target, transform })) {
+      this._clearGuides()
+      return true
+    }
+
     if (event.e?.ctrlKey) {
       this._clearGuides()
       if (canApplyPixelScalingStep) {
@@ -447,11 +494,39 @@ export default class SnappingManager {
       return true
     }
 
+    return false
+  }
+
+  /** Завершает scaling-шаг без snap-направляющих и сохраняет обычное pixel-rounding поведение. */
+  private _finishObjectScalingWithoutSnap({
+    target,
+    transform,
+    canApplyPixelScalingStep
+  }: {
+    target: FabricObject
+    transform: Transform
+    canApplyPixelScalingStep: boolean
+  }): void {
     if (canApplyPixelScalingStep) {
       applyScalingStep({ target, transform })
     }
 
-    return false
+    this._clearGuides()
+  }
+
+  /** Возвращает true, если текущий scale отличается от стартового scale Fabric transform. */
+  private _hasObjectScaleChanged({
+    target,
+    transform
+  }: {
+    target: FabricObject
+    transform: Transform
+  }): boolean {
+    const originalScaleX = transform.original?.scaleX
+    const originalScaleY = transform.original?.scaleY
+    if (typeof originalScaleX !== 'number' || typeof originalScaleY !== 'number') return true
+
+    return target.scaleX !== originalScaleX || target.scaleY !== originalScaleY
   }
 
   /** Скрывает направляющие для crop frame, если текущий шаг уже вышел за source и будет зажат clamp-ом. */

--- a/src/editor/snapping-manager/index.ts
+++ b/src/editor/snapping-manager/index.ts
@@ -351,6 +351,7 @@ export default class SnappingManager {
     } = resolveScalingTransformState({ target, transform })
     const snapState = resolveScaleAxisSnaps({
       bounds: activeBounds,
+      corner: transform.corner,
       originX,
       originY,
       shouldSnapX,
@@ -398,6 +399,8 @@ export default class SnappingManager {
       applyScalingStep({ target, transform })
     }
 
+    if (this._shouldHideOverflowingCropFrameGuides({ target })) return
+
     this._applyGuides({
       guides: scalePlan.guides,
       spacingGuides: []
@@ -424,7 +427,7 @@ export default class SnappingManager {
     })
   }
 
-  /** Возвращает true, если scaling нужно прервать до расчёта направляющих. */
+  /** Возвращает true, если scaling нужно прервать до расчёта snap-плана. */
   private _shouldAbortObjectScaling({
     target,
     transform,
@@ -448,7 +451,7 @@ export default class SnappingManager {
       applyScalingStep({ target, transform })
     }
 
-    return this._shouldHideOverflowingCropFrameGuides({ target })
+    return false
   }
 
   /** Скрывает направляющие для crop frame, если текущий шаг уже вышел за source и будет зажат clamp-ом. */

--- a/src/editor/snapping-manager/pixel-grid.ts
+++ b/src/editor/snapping-manager/pixel-grid.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-use-before-define -- Публичные pixel-grid функции держим выше private helpers. */
 import {
   FabricImage,
   FabricObject,
@@ -5,7 +6,75 @@ import {
   Transform
 } from 'fabric'
 
+import {
+  getObjectBounds,
+  type ObjectBounds
+} from '../utils/geometry'
 import { MOVE_SNAP_STEP } from './constants'
+
+/** Допуск сравнения guide с целой пиксельной координатой. */
+const SNAP_GUARD_INTEGER_POSITION_EPSILON = 0.01
+
+/** Допуск subpixel-дрейфа active edge вокруг guide после Fabric resize. */
+const SNAP_GUARD_POSITION_EPSILON = 0.1
+
+/** Допуск сравнения scale source-плоскости с scene-плоскостью. */
+const SOURCE_DISPLAY_SCALE_EPSILON = 0.000001
+
+/** Активное ребро, которое уже было приклеено к guide текущим scaling snap. */
+export type ScalingStepSnapGuard = {
+  type: 'vertical' | 'horizontal'
+  edge: 'left' | 'right' | 'top' | 'bottom'
+  position: number
+}
+
+/** Кандидат scale после округления display-size к целому пикселю. */
+type ScalingStepCandidate = {
+  scaleX: number
+  scaleY: number
+}
+
+/** Положение кандидата относительно snapped guide. */
+type ScalingStepCandidateSnapState = 'on-guide' | 'inside' | 'outside'
+
+/** Fixed anchor, который нужно сохранять во время post-snap округления scale. */
+type ScalingStepPlacement = {
+  left: number
+  top: number
+  originX: FabricObject['originX']
+  originY: FabricObject['originY']
+}
+
+/** Контракт восстановления fixed anchor во время одного шага pixel-grid округления. */
+type ScalingStepPlacementPreserver = {
+  placement: ScalingStepPlacement
+  applyPlacement: (placement: ScalingStepPlacement) => void
+}
+
+/** Параметры выбора pixel-scale, который сохраняет активные snap guards. */
+type GuardedScalingStepParams = {
+  target: FabricObject
+  rawScaleX: number
+  rawScaleY: number
+  effectiveWidth: number
+  effectiveHeight: number
+  fallbackScale: ScalingStepCandidate
+  isUniform: boolean
+  preservePlacement?: ScalingStepPlacementPreserver
+  snapGuards: ScalingStepSnapGuard[]
+}
+
+/** Оси scale, которые реально меняются в текущем Fabric transform. */
+type ScalingAxisRoundingState = {
+  shouldRoundScaleX: boolean
+  shouldRoundScaleY: boolean
+}
+
+/** Объект, у которого display-size может жить в source-пикселях, а не в scene-пикселях. */
+type SourceDisplaySizeTarget = FabricObject & {
+  cropSourceScaleX?: number
+  cropSourceScaleY?: number
+}
 
 /**
  * Возвращает true, если live-scaling объекта нужно округлять до целого пиксельного размера.
@@ -78,9 +147,51 @@ function resolveTextboxDimensions({ target }: { target: Textbox }): { width: num
 }
 
 /**
+ * Возвращает базовые размеры из доменного display-size, если объект сам определяет такую геометрию.
+ */
+function resolveDisplaySizeDimensions({
+  target,
+  scaleX,
+  scaleY
+}: {
+  target: FabricObject
+  scaleX: number
+  scaleY: number
+}): { width: number; height: number } | null {
+  const displaySize = target.getObjectDisplaySize?.()
+  if (!displaySize) return null
+
+  const absScaleX = Math.abs(scaleX)
+  const absScaleY = Math.abs(scaleY)
+  if (absScaleX <= 0 || absScaleY <= 0) return null
+  if (!Number.isFinite(displaySize.width) || !Number.isFinite(displaySize.height)) return null
+  if (displaySize.width <= 0 || displaySize.height <= 0) return null
+
+  return {
+    width: displaySize.width / absScaleX,
+    height: displaySize.height / absScaleY
+  }
+}
+
+/**
  * Возвращает эффективные размеры объекта без масштаба.
  */
-function resolveEffectiveDimensions({ target }: { target: FabricObject }): { width: number; height: number } {
+function resolveEffectiveDimensions({
+  target,
+  scaleX,
+  scaleY
+}: {
+  target: FabricObject
+  scaleX: number
+  scaleY: number
+}): { width: number; height: number } {
+  const displayDimensions = resolveDisplaySizeDimensions({
+    target,
+    scaleX,
+    scaleY
+  })
+  if (displayDimensions) return displayDimensions
+
   if (target instanceof Textbox) {
     return resolveTextboxDimensions({ target })
   }
@@ -100,62 +211,696 @@ function resolveEffectiveDimensions({ target }: { target: FabricObject }): { wid
 }
 
 /**
- * Округляет масштаб объекта так, чтобы его визуальный размер в пикселях был целым числом.
+ * Округляет масштаб объекта так, чтобы его измеряемый размер в пикселях был целым числом.
  */
 export function applyScalingStep({
   target,
-  transform
+  transform,
+  preservePlacement,
+  snapGuards = []
 }: {
   target: FabricObject
   transform?: Transform | null
+  preservePlacement?: ScalingStepPlacementPreserver
+  snapGuards?: ScalingStepSnapGuard[]
 }): void {
   const {
     scaleX: rawScaleX = 1,
     scaleY: rawScaleY = 1
   } = target
-  const { width: effectiveWidth, height: effectiveHeight } = resolveEffectiveDimensions({ target })
-  const isUniform = rawScaleX === rawScaleY
 
-  let snappedScaleX = rawScaleX
-  let snappedScaleY = rawScaleY
+  const roundingState = resolveScalingAxisRoundingState({
+    transform,
+    rawScaleX,
+    rawScaleY
+  })
+  if (!roundingState.shouldRoundScaleX && !roundingState.shouldRoundScaleY) return
 
-  if (isUniform) {
-    const candidateFromWidth = effectiveWidth > 0
-      ? Math.max(1, Math.round(effectiveWidth * rawScaleX)) / effectiveWidth
-      : rawScaleX
-    const candidateFromHeight = effectiveHeight > 0
-      ? Math.max(1, Math.round(effectiveHeight * rawScaleY)) / effectiveHeight
-      : rawScaleY
-    const errorX = Math.abs(candidateFromWidth - rawScaleX)
-    const errorY = Math.abs(candidateFromHeight - rawScaleY)
-    const uniformScale = errorX <= errorY ? candidateFromWidth : candidateFromHeight
+  const { width: effectiveWidth, height: effectiveHeight } = resolveEffectiveDimensions({
+    target,
+    scaleX: rawScaleX,
+    scaleY: rawScaleY
+  })
+  const snappedScale = resolveSnappedScalingStep({
+    target,
+    rawScaleX,
+    rawScaleY,
+    effectiveWidth,
+    effectiveHeight,
+    preservePlacement,
+    snapGuards
+  })
+  const nextScale = resolveScaleForRoundedAxes({
+    rawScaleX,
+    rawScaleY,
+    snappedScale,
+    roundingState
+  })
 
-    snappedScaleX = uniformScale
-    snappedScaleY = uniformScale
-  }
-
-  if (!isUniform) {
-    snappedScaleX = effectiveWidth > 0
-      ? Math.max(1, Math.round(effectiveWidth * rawScaleX)) / effectiveWidth
-      : rawScaleX
-    snappedScaleY = effectiveHeight > 0
-      ? Math.max(1, Math.round(effectiveHeight * rawScaleY)) / effectiveHeight
-      : rawScaleY
-  }
-
-  const isAlreadySnapped = snappedScaleX === rawScaleX && snappedScaleY === rawScaleY
+  const isAlreadySnapped = nextScale.scaleX === rawScaleX && nextScale.scaleY === rawScaleY
 
   if (isAlreadySnapped) return
 
+  applyResolvedScalingStep({
+    target,
+    transform,
+    preservePlacement,
+    scale: nextScale
+  })
+}
+
+/**
+ * Возвращает оси, которые можно округлять в текущем scaling-step.
+ */
+function resolveScalingAxisRoundingState({
+  transform,
+  rawScaleX,
+  rawScaleY
+}: {
+  transform?: Transform | null
+  rawScaleX: number
+  rawScaleY: number
+}): ScalingAxisRoundingState {
+  return {
+    shouldRoundScaleX: shouldRoundScalingAxis({
+      transform,
+      axis: 'x',
+      rawScale: rawScaleX
+    }),
+    shouldRoundScaleY: shouldRoundScalingAxis({
+      transform,
+      axis: 'y',
+      rawScale: rawScaleY
+    })
+  }
+}
+
+/**
+ * Оставляет raw scale на осях, которые Fabric transform не менял в этом шаге.
+ */
+function resolveScaleForRoundedAxes({
+  rawScaleX,
+  rawScaleY,
+  snappedScale,
+  roundingState
+}: {
+  rawScaleX: number
+  rawScaleY: number
+  snappedScale: ScalingStepCandidate
+  roundingState: ScalingAxisRoundingState
+}): ScalingStepCandidate {
+  const nextScale = {
+    ...snappedScale
+  }
+
+  if (!roundingState.shouldRoundScaleX) {
+    nextScale.scaleX = rawScaleX
+  }
+  if (!roundingState.shouldRoundScaleY) {
+    nextScale.scaleY = rawScaleY
+  }
+
+  return nextScale
+}
+
+/**
+ * Применяет округлённый scale к Fabric target, transform и fixed placement.
+ */
+function applyResolvedScalingStep({
+  target,
+  transform,
+  preservePlacement,
+  scale
+}: {
+  target: FabricObject
+  transform?: Transform | null
+  preservePlacement?: ScalingStepPlacementPreserver
+  scale: ScalingStepCandidate
+}): void {
   target.set({
-    scaleX: snappedScaleX,
-    scaleY: snappedScaleY
+    scaleX: scale.scaleX,
+    scaleY: scale.scaleY
   })
 
+  if (preservePlacement) {
+    preservePlacement.applyPlacement(preservePlacement.placement)
+  }
+
   if (transform) {
-    transform.scaleX = snappedScaleX
-    transform.scaleY = snappedScaleY
+    transform.scaleX = scale.scaleX
+    transform.scaleY = scale.scaleY
   }
 
   target.setCoords()
+}
+
+/**
+ * Возвращает true, если scale по оси реально изменился в текущем Fabric transform.
+ */
+function shouldRoundScalingAxis({
+  transform,
+  axis,
+  rawScale
+}: {
+  transform?: Transform | null
+  axis: 'x' | 'y'
+  rawScale: number
+}): boolean {
+  if (!transform) return true
+
+  const originalScale = axis === 'x'
+    ? transform.original?.scaleX
+    : transform.original?.scaleY
+  if (typeof originalScale !== 'number') return true
+
+  return originalScale !== rawScale
+}
+
+/**
+ * Возвращает итоговый scale после pixel-rounding и ограничений активных snap-guide.
+ */
+function resolveSnappedScalingStep({
+  target,
+  rawScaleX,
+  rawScaleY,
+  effectiveWidth,
+  effectiveHeight,
+  preservePlacement,
+  snapGuards
+}: {
+  target: FabricObject
+  rawScaleX: number
+  rawScaleY: number
+  effectiveWidth: number
+  effectiveHeight: number
+  preservePlacement?: ScalingStepPlacementPreserver
+  snapGuards: ScalingStepSnapGuard[]
+}): ScalingStepCandidate {
+  const roundedScale = resolveRoundedScalingStep({
+    rawScaleX,
+    rawScaleY,
+    effectiveWidth,
+    effectiveHeight
+  })
+
+  if (snapGuards.length === 0) return roundedScale
+
+  return resolveGuardedScalingStep({
+    target,
+    rawScaleX,
+    rawScaleY,
+    effectiveWidth,
+    effectiveHeight,
+    fallbackScale: roundedScale,
+    isUniform: rawScaleX === rawScaleY,
+    preservePlacement,
+    snapGuards
+  })
+}
+
+/**
+ * Возвращает ближайший scale, при котором display-size объекта становится целым.
+ */
+function resolveRoundedScalingStep({
+  rawScaleX,
+  rawScaleY,
+  effectiveWidth,
+  effectiveHeight
+}: {
+  rawScaleX: number
+  rawScaleY: number
+  effectiveWidth: number
+  effectiveHeight: number
+}): ScalingStepCandidate {
+  if (rawScaleX === rawScaleY) {
+    return resolveRoundedUniformScalingStep({
+      rawScale: rawScaleX,
+      effectiveWidth,
+      effectiveHeight
+    })
+  }
+
+  return {
+    scaleX: resolveRoundedAxisScale({
+      rawScale: rawScaleX,
+      effectiveSize: effectiveWidth
+    }),
+    scaleY: resolveRoundedAxisScale({
+      rawScale: rawScaleY,
+      effectiveSize: effectiveHeight
+    })
+  }
+}
+
+/**
+ * Возвращает uniform scale по той оси, где округление меньше двигает текущий scale.
+ */
+function resolveRoundedUniformScalingStep({
+  rawScale,
+  effectiveWidth,
+  effectiveHeight
+}: {
+  rawScale: number
+  effectiveWidth: number
+  effectiveHeight: number
+}): ScalingStepCandidate {
+  const candidateFromWidth = resolveRoundedAxisScale({
+    rawScale,
+    effectiveSize: effectiveWidth
+  })
+  const candidateFromHeight = resolveRoundedAxisScale({
+    rawScale,
+    effectiveSize: effectiveHeight
+  })
+  const widthError = Math.abs(candidateFromWidth - rawScale)
+  const heightError = Math.abs(candidateFromHeight - rawScale)
+  const scale = widthError <= heightError ? candidateFromWidth : candidateFromHeight
+
+  return {
+    scaleX: scale,
+    scaleY: scale
+  }
+}
+
+/**
+ * Возвращает scale одной оси для ближайшего целого display-size.
+ */
+function resolveRoundedAxisScale({
+  rawScale,
+  effectiveSize
+}: {
+  rawScale: number
+  effectiveSize: number
+}): number {
+  if (effectiveSize <= 0) return rawScale
+
+  return Math.max(1, Math.round(effectiveSize * rawScale)) / effectiveSize
+}
+
+/**
+ * Возвращает ближайший pixel-scale, который не переносит snapped edge за его guide.
+ */
+function resolveGuardedScalingStep({
+  target,
+  rawScaleX,
+  rawScaleY,
+  effectiveWidth,
+  effectiveHeight,
+  fallbackScale,
+  isUniform,
+  preservePlacement,
+  snapGuards
+}: GuardedScalingStepParams): ScalingStepCandidate {
+  if (shouldKeepCurrentIntegerGuideSnap({
+    target,
+    snapGuards
+  })) {
+    return {
+      scaleX: rawScaleX,
+      scaleY: rawScaleY
+    }
+  }
+
+  const candidates = collectScalingStepCandidates({
+    rawScaleX,
+    rawScaleY,
+    effectiveWidth,
+    effectiveHeight,
+    isUniform
+  })
+  const shouldPreferInsideCandidate = usesScaledDisplaySizeForSnapGuards({
+    target,
+    snapGuards
+  })
+  let onGuideCandidate: ScalingStepCandidate | null = null
+  let insideCandidate: ScalingStepCandidate | null = null
+
+  for (const candidate of candidates) {
+    const snapState = resolveScalingStepCandidateSnapState({
+      target,
+      candidate,
+      preservePlacement,
+      snapGuards
+    })
+
+    if (snapState === 'on-guide') {
+      if (!shouldPreferInsideCandidate) return candidate
+
+      if (!onGuideCandidate) {
+        onGuideCandidate = candidate
+      }
+    }
+    if (snapState === 'inside' && !insideCandidate) {
+      insideCandidate = candidate
+    }
+  }
+
+  if (insideCandidate) return insideCandidate
+  if (onGuideCandidate) return onGuideCandidate
+
+  return fallbackScale
+}
+
+/**
+ * Возвращает true, если raw scale уже удерживает edge на integer guide
+ * и display-size объекта живёт в той же pixel-плоскости, что и сам guide.
+ */
+function shouldKeepCurrentIntegerGuideSnap({
+  target,
+  snapGuards
+}: {
+  target: FabricObject
+  snapGuards: ScalingStepSnapGuard[]
+}): boolean {
+  if (usesScaledDisplaySizeForSnapGuards({ target, snapGuards })) return false
+
+  const bounds = getObjectBounds({ object: target })
+  if (!bounds) return false
+
+  for (const snapGuard of snapGuards) {
+    if (!isSnapGuardPositionPixelAligned({ snapGuard })) return false
+    if (!isObjectBoundsOnSnapGuide({ bounds, snapGuard })) return false
+    if (!hasValidRoundedBoundsSize({ bounds, snapGuard })) return false
+  }
+
+  return true
+}
+
+/**
+ * Возвращает true, если active snap axis показывает размер в source-пикселях с отдельным scale.
+ */
+function usesScaledDisplaySizeForSnapGuards({
+  target,
+  snapGuards
+}: {
+  target: FabricObject
+  snapGuards: ScalingStepSnapGuard[]
+}): boolean {
+  if (typeof target.getObjectDisplaySize !== 'function') return false
+
+  const displayTarget = target as SourceDisplaySizeTarget
+  const usesScaledX = snapGuards.some((snapGuard) => {
+    return snapGuard.type === 'vertical' && !isSceneDisplayScale({
+      scale: displayTarget.cropSourceScaleX
+    })
+  })
+  const usesScaledY = snapGuards.some((snapGuard) => {
+    return snapGuard.type === 'horizontal' && !isSceneDisplayScale({
+      scale: displayTarget.cropSourceScaleY
+    })
+  })
+
+  return usesScaledX || usesScaledY
+}
+
+/**
+ * Возвращает true, если display-size axis совпадает со scene pixel axis.
+ */
+function isSceneDisplayScale({ scale }: { scale?: number }): boolean {
+  const safeScale = Math.abs(scale ?? 1)
+
+  return Math.abs(safeScale - 1) <= SOURCE_DISPLAY_SCALE_EPSILON
+}
+
+/**
+ * Проверяет, что guide находится на целой пиксельной координате.
+ */
+function isSnapGuardPositionPixelAligned({
+  snapGuard
+}: {
+  snapGuard: ScalingStepSnapGuard
+}): boolean {
+  const integerPosition = Math.round(snapGuard.position)
+
+  return Math.abs(snapGuard.position - integerPosition) <= SNAP_GUARD_INTEGER_POSITION_EPSILON
+}
+
+/**
+ * Проверяет, что фактический bounds-size по оси snapped edge можно показать как валидный пиксельный размер.
+ */
+function hasValidRoundedBoundsSize({
+  bounds,
+  snapGuard
+}: {
+  bounds: ObjectBounds
+  snapGuard: ScalingStepSnapGuard
+}): boolean {
+  const boundsSize = snapGuard.type === 'vertical'
+    ? bounds.right - bounds.left
+    : bounds.bottom - bounds.top
+
+  if (!Number.isFinite(boundsSize) || boundsSize <= 0) return false
+
+  return Math.round(boundsSize) > 0
+}
+
+/**
+ * Собирает кандидаты округления scale, начиная с ближайших к текущему raw-scale.
+ */
+function collectScalingStepCandidates({
+  rawScaleX,
+  rawScaleY,
+  effectiveWidth,
+  effectiveHeight,
+  isUniform
+}: {
+  rawScaleX: number
+  rawScaleY: number
+  effectiveWidth: number
+  effectiveHeight: number
+  isUniform: boolean
+}): ScalingStepCandidate[] {
+  const scaleXCandidates = collectAxisScaleCandidates({
+    rawScale: rawScaleX,
+    effectiveSize: effectiveWidth
+  })
+  const scaleYCandidates = collectAxisScaleCandidates({
+    rawScale: rawScaleY,
+    effectiveSize: effectiveHeight
+  })
+
+  if (isUniform) {
+    return collectUniformScaleCandidates({
+      scaleXCandidates,
+      scaleYCandidates,
+      rawScale: rawScaleX
+    })
+  }
+
+  return collectAxisScaleCandidatePairs({
+    scaleXCandidates,
+    scaleYCandidates,
+    rawScaleX,
+    rawScaleY
+  })
+}
+
+/**
+ * Собирает scale-кандидаты одной оси через round/floor/ceil display-size.
+ */
+function collectAxisScaleCandidates({
+  rawScale,
+  effectiveSize
+}: {
+  rawScale: number
+  effectiveSize: number
+}): number[] {
+  if (effectiveSize <= 0) return [rawScale]
+
+  const scaleSign = rawScale < 0 ? -1 : 1
+  const rawDisplaySize = Math.abs(rawScale) * effectiveSize
+  const displaySizes = [
+    Math.round(rawDisplaySize),
+    Math.floor(rawDisplaySize),
+    Math.ceil(rawDisplaySize)
+  ]
+  const candidates: number[] = []
+
+  for (const displaySize of displaySizes) {
+    const safeDisplaySize = Math.max(1, displaySize)
+    addUniqueScaleCandidate({
+      candidates,
+      scale: (safeDisplaySize / effectiveSize) * scaleSign
+    })
+  }
+
+  candidates.sort((first, second) => {
+    return Math.abs(first - rawScale) - Math.abs(second - rawScale)
+  })
+
+  return candidates
+}
+
+/**
+ * Добавляет scale-кандидат без дублей от round/floor/ceil на целом значении.
+ */
+function addUniqueScaleCandidate({
+  candidates,
+  scale
+}: {
+  candidates: number[]
+  scale: number
+}): void {
+  if (!Number.isFinite(scale)) return
+  if (candidates.includes(scale)) return
+
+  candidates.push(scale)
+}
+
+/**
+ * Собирает uniform scale-кандидаты из обеих осей.
+ */
+function collectUniformScaleCandidates({
+  scaleXCandidates,
+  scaleYCandidates,
+  rawScale
+}: {
+  scaleXCandidates: number[]
+  scaleYCandidates: number[]
+  rawScale: number
+}): ScalingStepCandidate[] {
+  const scaleCandidates = [...scaleXCandidates]
+
+  for (const scale of scaleYCandidates) {
+    addUniqueScaleCandidate({
+      candidates: scaleCandidates,
+      scale
+    })
+  }
+
+  scaleCandidates.sort((first, second) => {
+    return Math.abs(first - rawScale) - Math.abs(second - rawScale)
+  })
+
+  return scaleCandidates.map((scale) => ({
+    scaleX: scale,
+    scaleY: scale
+  }))
+}
+
+/**
+ * Собирает пары scale-кандидатов для независимого scaling по осям.
+ */
+function collectAxisScaleCandidatePairs({
+  scaleXCandidates,
+  scaleYCandidates,
+  rawScaleX,
+  rawScaleY
+}: {
+  scaleXCandidates: number[]
+  scaleYCandidates: number[]
+  rawScaleX: number
+  rawScaleY: number
+}): ScalingStepCandidate[] {
+  const candidates: ScalingStepCandidate[] = []
+
+  for (const scaleX of scaleXCandidates) {
+    for (const scaleY of scaleYCandidates) {
+      candidates.push({ scaleX, scaleY })
+    }
+  }
+
+  candidates.sort((first, second) => {
+    const firstError = Math.abs(first.scaleX - rawScaleX) + Math.abs(first.scaleY - rawScaleY)
+    const secondError = Math.abs(second.scaleX - rawScaleX) + Math.abs(second.scaleY - rawScaleY)
+
+    return firstError - secondError
+  })
+
+  return candidates
+}
+
+/**
+ * Определяет положение rounded scale относительно snapped guide.
+ */
+function resolveScalingStepCandidateSnapState({
+  target,
+  candidate,
+  preservePlacement,
+  snapGuards
+}: {
+  target: FabricObject
+  candidate: ScalingStepCandidate
+  preservePlacement?: ScalingStepPlacementPreserver
+  snapGuards: ScalingStepSnapGuard[]
+}): ScalingStepCandidateSnapState {
+  const originalScaleX = target.scaleX ?? 1
+  const originalScaleY = target.scaleY ?? 1
+  let bounds: ObjectBounds | null = null
+
+  try {
+    target.set({
+      scaleX: candidate.scaleX,
+      scaleY: candidate.scaleY
+    })
+
+    if (preservePlacement) {
+      preservePlacement.applyPlacement(preservePlacement.placement)
+    } else {
+      target.setCoords()
+    }
+
+    bounds = getObjectBounds({ object: target })
+  } finally {
+    target.set({
+      scaleX: originalScaleX,
+      scaleY: originalScaleY
+    })
+
+    if (preservePlacement) {
+      preservePlacement.applyPlacement(preservePlacement.placement)
+    } else {
+      target.setCoords()
+    }
+  }
+
+  if (!bounds) return 'outside'
+
+  let isOnGuide = true
+  for (const snapGuard of snapGuards) {
+    if (!isObjectBoundsInsideSnapGuard({ bounds, snapGuard })) return 'outside'
+    if (!isObjectBoundsOnSnapGuide({ bounds, snapGuard })) {
+      isOnGuide = false
+    }
+  }
+
+  return isOnGuide ? 'on-guide' : 'inside'
+}
+
+/**
+ * Проверяет одно активное ребро относительно guide после округления.
+ */
+function isObjectBoundsInsideSnapGuard({
+  bounds,
+  snapGuard
+}: {
+  bounds: ObjectBounds
+  snapGuard: ScalingStepSnapGuard
+}): boolean {
+  const { edge, position } = snapGuard
+
+  if (edge === 'left') return bounds.left >= position - SNAP_GUARD_POSITION_EPSILON
+  if (edge === 'right') return bounds.right <= position + SNAP_GUARD_POSITION_EPSILON
+  if (edge === 'top') return bounds.top >= position - SNAP_GUARD_POSITION_EPSILON
+
+  return bounds.bottom <= position + SNAP_GUARD_POSITION_EPSILON
+}
+
+/**
+ * Проверяет, стоит ли active edge ровно на guide после округления.
+ */
+function isObjectBoundsOnSnapGuide({
+  bounds,
+  snapGuard
+}: {
+  bounds: ObjectBounds
+  snapGuard: ScalingStepSnapGuard
+}): boolean {
+  const { edge, position } = snapGuard
+
+  if (edge === 'left') return Math.abs(bounds.left - position) <= SNAP_GUARD_POSITION_EPSILON
+  if (edge === 'right') return Math.abs(bounds.right - position) <= SNAP_GUARD_POSITION_EPSILON
+  if (edge === 'top') return Math.abs(bounds.top - position) <= SNAP_GUARD_POSITION_EPSILON
+
+  return Math.abs(bounds.bottom - position) <= SNAP_GUARD_POSITION_EPSILON
 }

--- a/src/editor/snapping-manager/scaling.ts
+++ b/src/editor/snapping-manager/scaling.ts
@@ -11,6 +11,7 @@ import type {
   Bounds,
   GuideLine
 } from './types'
+import type { ScalingStepSnapGuard } from './pixel-grid'
 
 type AxisSnapEdge = 'left' | 'right' | 'top' | 'bottom'
 
@@ -24,6 +25,9 @@ type AxisSnapResult = {
   guidePosition: number | null
   candidate: AxisSnapCandidate | null
 }
+
+/** Допуск сравнения uniform scale-factor для осей одного scaling-step. */
+const UNIFORM_SCALE_FACTOR_EPSILON = 0.000001
 
 export type ScalingAxisState = {
   isCornerHandle: boolean
@@ -50,6 +54,7 @@ export type ScaleAxisSnapState = {
 
 export type ScaleUpdatePlan = {
   guides: GuideLine[]
+  snapGuards: ScalingStepSnapGuard[]
   nextScaleX: number | null
   nextScaleY: number | null
 }
@@ -76,11 +81,19 @@ interface ScaleUpdatePlanParams extends ScaleSnapContext {
 
 type AxisScaleUpdate = {
   guide: GuideLine
+  snapGuard: ScalingStepSnapGuard
   nextScale: number
 }
 
 type UniformScaleResult = {
   guide: GuideLine
+  snapGuards: ScalingStepSnapGuard[]
+  scaleFactor: number
+}
+
+type UniformScaleSnap = {
+  guide: GuideLine
+  snapGuard: ScalingStepSnapGuard
   scaleFactor: number
 }
 
@@ -284,10 +297,15 @@ function resolveUniformScaleUpdatePlan({
 
   if (!uniformResult) return null
 
-  const { guide, scaleFactor } = uniformResult
+  const {
+    guide,
+    scaleFactor,
+    snapGuards
+  } = uniformResult
 
   return {
     guides: [guide],
+    snapGuards,
     nextScaleX: scaleX * scaleFactor,
     nextScaleY: scaleY * scaleFactor
   }
@@ -300,21 +318,25 @@ function resolveAxisScaleUpdatePlan(params: ScaleSnapContext): ScaleUpdatePlan |
   if (!scaleXUpdate && !scaleYUpdate) return null
 
   const guides: GuideLine[] = []
+  const snapGuards: ScalingStepSnapGuard[] = []
   let nextScaleX: number | null = null
   let nextScaleY: number | null = null
 
   if (scaleXUpdate) {
     guides.push(scaleXUpdate.guide)
+    snapGuards.push(scaleXUpdate.snapGuard)
     nextScaleX = scaleXUpdate.nextScale
   }
 
   if (scaleYUpdate) {
     guides.push(scaleYUpdate.guide)
+    snapGuards.push(scaleYUpdate.snapGuard)
     nextScaleY = scaleYUpdate.nextScale
   }
 
   return {
     guides,
+    snapGuards,
     nextScaleX,
     nextScaleY
   }
@@ -349,8 +371,15 @@ function resolveScaleXUpdate({
   })
   if (absNextScaleX === null) return null
 
+  const snapGuard = createScaleSnapGuard({
+    type: 'vertical',
+    snap: verticalSnap
+  })
+  if (!snapGuard) return null
+
   return {
     nextScale: absNextScaleX * (scaleX < 0 ? -1 : 1),
+    snapGuard,
     guide: {
       type: 'vertical',
       position: guidePosition
@@ -387,8 +416,15 @@ function resolveScaleYUpdate({
   })
   if (absNextScaleY === null) return null
 
+  const snapGuard = createScaleSnapGuard({
+    type: 'horizontal',
+    snap: horizontalSnap
+  })
+  if (!snapGuard) return null
+
   return {
     nextScale: absNextScaleY * (scaleY < 0 ? -1 : 1),
+    snapGuard,
     guide: {
       type: 'horizontal',
       position: guidePosition
@@ -604,28 +640,155 @@ function resolveUniformScale({
     verticalSnap,
     horizontalSnap
   })
+  let primarySnap: UniformScaleSnap | null = null
 
-  if (chosenAxis === 'x' && scaleFactorX !== null && verticalSnap.guidePosition !== null) {
-    return {
+  if (chosenAxis === 'x') {
+    primarySnap = createUniformScaleSnap({
+      type: 'vertical',
       scaleFactor: scaleFactorX,
-      guide: {
-        type: 'vertical',
-        position: verticalSnap.guidePosition
-      }
-    }
+      snap: verticalSnap
+    })
   }
 
-  if (chosenAxis === 'y' && scaleFactorY !== null && horizontalSnap.guidePosition !== null) {
-    return {
+  if (chosenAxis === 'y') {
+    primarySnap = createUniformScaleSnap({
+      type: 'horizontal',
       scaleFactor: scaleFactorY,
-      guide: {
-        type: 'horizontal',
-        position: horizontalSnap.guidePosition
-      }
-    }
+      snap: horizontalSnap
+    })
   }
 
-  return null
+  if (!primarySnap) return null
+
+  const snapGuards = collectMatchingUniformScaleSnapGuards({
+    scaleFactor: primarySnap.scaleFactor,
+    scaleFactorX,
+    scaleFactorY,
+    verticalSnap,
+    horizontalSnap
+  })
+  if (snapGuards.length === 0) return null
+
+  return {
+    guide: primarySnap.guide,
+    snapGuards,
+    scaleFactor: primarySnap.scaleFactor
+  }
+}
+
+/**
+ * Создаёт snap-результат для одной оси uniform scaling.
+ */
+function createUniformScaleSnap({
+  type,
+  scaleFactor,
+  snap
+}: {
+  type: GuideLine['type']
+  scaleFactor: number | null
+  snap: AxisSnapResult
+}): UniformScaleSnap | null {
+  const { guidePosition } = snap
+  if (scaleFactor === null || guidePosition === null) return null
+
+  const snapGuard = createScaleSnapGuard({
+    type,
+    snap
+  })
+  if (!snapGuard) return null
+
+  return {
+    scaleFactor,
+    snapGuard,
+    guide: {
+      type,
+      position: guidePosition
+    }
+  }
+}
+
+/**
+ * Собирает guards для осей, которые совпадают с выбранным uniform scale-factor.
+ */
+function collectMatchingUniformScaleSnapGuards({
+  scaleFactor,
+  scaleFactorX,
+  scaleFactorY,
+  verticalSnap,
+  horizontalSnap
+}: {
+  scaleFactor: number
+  scaleFactorX: number | null
+  scaleFactorY: number | null
+  verticalSnap: AxisSnapResult
+  horizontalSnap: AxisSnapResult
+}): ScalingStepSnapGuard[] {
+  const snapGuards: ScalingStepSnapGuard[] = []
+
+  addUniformScaleSnapGuardIfMatching({
+    snapGuards,
+    scaleFactor,
+    axisScaleFactor: scaleFactorX,
+    type: 'vertical',
+    snap: verticalSnap
+  })
+  addUniformScaleSnapGuardIfMatching({
+    snapGuards,
+    scaleFactor,
+    axisScaleFactor: scaleFactorY,
+    type: 'horizontal',
+    snap: horizontalSnap
+  })
+
+  return snapGuards
+}
+
+/**
+ * Добавляет guard только если ось реально попала в выбранный uniform scale.
+ */
+function addUniformScaleSnapGuardIfMatching({
+  snapGuards,
+  scaleFactor,
+  axisScaleFactor,
+  type,
+  snap
+}: {
+  snapGuards: ScalingStepSnapGuard[]
+  scaleFactor: number
+  axisScaleFactor: number | null
+  type: GuideLine['type']
+  snap: AxisSnapResult
+}): void {
+  if (axisScaleFactor === null) return
+  if (Math.abs(axisScaleFactor - scaleFactor) > UNIFORM_SCALE_FACTOR_EPSILON) return
+
+  const snapGuard = createScaleSnapGuard({
+    type,
+    snap
+  })
+  if (!snapGuard) return
+
+  snapGuards.push(snapGuard)
+}
+
+/**
+ * Создаёт guard для последующего pixel-grid округления уже приклеенного active edge.
+ */
+function createScaleSnapGuard({
+  type,
+  snap
+}: {
+  type: GuideLine['type']
+  snap: AxisSnapResult
+}): ScalingStepSnapGuard | null {
+  const { candidate, guidePosition } = snap
+  if (!candidate || guidePosition === null) return null
+
+  return {
+    type,
+    edge: candidate.edge,
+    position: guidePosition
+  }
 }
 
 function resolveUniformScaleFactorForWidth({
@@ -719,11 +882,11 @@ function resolveDesiredWidth({
   const { edge } = candidate
   let desiredWidth: number | null = null
 
-  if (resolvedOriginX === 'left' && edge === 'right') {
-    desiredWidth = guidePosition - left
-  }
-  if (resolvedOriginX === 'right' && edge === 'left') {
+  if (resolvedOriginX !== 'center' && edge === 'left') {
     desiredWidth = right - guidePosition
+  }
+  if (resolvedOriginX !== 'center' && edge === 'right') {
+    desiredWidth = guidePosition - left
   }
   if (resolvedOriginX === 'center' && edge === 'left') {
     desiredWidth = (centerX - guidePosition) * 2
@@ -762,11 +925,11 @@ function resolveDesiredHeight({
   const { edge } = candidate
   let desiredHeight: number | null = null
 
-  if (resolvedOriginY === 'top' && edge === 'bottom') {
-    desiredHeight = guidePosition - top
-  }
-  if (resolvedOriginY === 'bottom' && edge === 'top') {
+  if (resolvedOriginY !== 'center' && edge === 'top') {
     desiredHeight = bottom - guidePosition
+  }
+  if (resolvedOriginY !== 'center' && edge === 'bottom') {
+    desiredHeight = guidePosition - top
   }
   if (resolvedOriginY === 'center' && edge === 'top') {
     desiredHeight = (centerY - guidePosition) * 2

--- a/src/editor/snapping-manager/scaling.ts
+++ b/src/editor/snapping-manager/scaling.ts
@@ -141,20 +141,22 @@ export function shouldUseUniformScaleSnap({
   event: { e?: TPointerEvent | null }
   isCornerHandle: boolean
 }): boolean {
-  if (isCornerHandle) return true
-
   const cropTarget = target as CropFrameSnapTarget
-  if (!cropTarget.cropSource) return false
+  if (cropTarget.cropSource) {
+    const preserveAspectRatio = cropTarget.preserveAspectRatio ?? true
 
-  const preserveAspectRatio = cropTarget.preserveAspectRatio ?? true
-  if (!event.e?.shiftKey) return preserveAspectRatio
+    if (!event.e?.shiftKey) return preserveAspectRatio
 
-  return !preserveAspectRatio
+    return !preserveAspectRatio
+  }
+
+  return isCornerHandle
 }
 
 /** Находит активные axis-snap кандидаты для текущего scaling-step. */
 export function resolveScaleAxisSnaps({
   bounds,
+  corner,
   originX,
   originY,
   shouldSnapX,
@@ -163,6 +165,7 @@ export function resolveScaleAxisSnaps({
   anchors
 }: {
   bounds: Bounds
+  corner?: string
   originX: Transform['originX']
   originY: Transform['originY']
   shouldSnapX: boolean
@@ -172,11 +175,13 @@ export function resolveScaleAxisSnaps({
 }): ScaleAxisSnapState | null {
   const verticalCandidates = collectVerticalSnapCandidates({
     bounds,
+    corner,
     originX,
     shouldSnapX
   })
   const horizontalCandidates = collectHorizontalSnapCandidates({
     bounds,
+    corner,
     originY,
     shouldSnapY
   })
@@ -396,10 +401,12 @@ function resolveScaleYUpdate({
  */
 function collectVerticalSnapCandidates({
   bounds,
+  corner = '',
   originX,
   shouldSnapX
 }: {
   bounds: Bounds
+  corner?: string
   originX: Transform['originX']
   shouldSnapX: boolean
 }): AxisSnapCandidate[] {
@@ -410,6 +417,16 @@ function collectVerticalSnapCandidates({
   let resolvedOriginX: 'left' | 'center' | 'right' = 'left'
   if (originX === 'center' || originX === 'right') {
     resolvedOriginX = originX
+  }
+
+  const controlEdge = resolveControlMovingXEdge({ controlKey: corner })
+  if (controlEdge && resolvedOriginX !== 'center') {
+    candidates.push({
+      edge: controlEdge,
+      position: controlEdge === 'left' ? left : right
+    })
+
+    return candidates
   }
 
   if (resolvedOriginX === 'left') {
@@ -445,10 +462,12 @@ function collectVerticalSnapCandidates({
  */
 function collectHorizontalSnapCandidates({
   bounds,
+  corner = '',
   originY,
   shouldSnapY
 }: {
   bounds: Bounds
+  corner?: string
   originY: Transform['originY']
   shouldSnapY: boolean
 }): AxisSnapCandidate[] {
@@ -459,6 +478,16 @@ function collectHorizontalSnapCandidates({
   let resolvedOriginY: 'top' | 'center' | 'bottom' = 'top'
   if (originY === 'center' || originY === 'bottom') {
     resolvedOriginY = originY
+  }
+
+  const controlEdge = resolveControlMovingYEdge({ controlKey: corner })
+  if (controlEdge && resolvedOriginY !== 'center') {
+    candidates.push({
+      edge: controlEdge,
+      position: controlEdge === 'top' ? top : bottom
+    })
+
+    return candidates
   }
 
   if (resolvedOriginY === 'top') {
@@ -487,6 +516,22 @@ function collectHorizontalSnapCandidates({
   }
 
   return candidates
+}
+
+/** Возвращает X-грань, которую пользователь двигает текущим resize-control. */
+function resolveControlMovingXEdge({ controlKey }: { controlKey: string }): 'left' | 'right' | null {
+  if (controlKey === 'tl' || controlKey === 'bl' || controlKey === 'ml') return 'left'
+  if (controlKey === 'tr' || controlKey === 'br' || controlKey === 'mr') return 'right'
+
+  return null
+}
+
+/** Возвращает Y-грань, которую пользователь двигает текущим resize-control. */
+function resolveControlMovingYEdge({ controlKey }: { controlKey: string }): 'top' | 'bottom' | null {
+  if (controlKey === 'tl' || controlKey === 'tr' || controlKey === 'mt') return 'top'
+  if (controlKey === 'bl' || controlKey === 'br' || controlKey === 'mb') return 'bottom'
+
+  return null
 }
 
 /**


### PR DESCRIPTION
## Кейс №1 ✅

Порядок воспроизведения.

1. Перейти в непропорциональный кроп режим монтажной области при размерах монтажной области 512х512px (скрин 1)

<img width="1919" height="894" alt="image" src="https://github.com/user-attachments/assets/c63082c7-8e6b-414d-9e3f-99e415553220" />

2. Выделить правый верхний контрол кроп-области и начать уменьшение или увеличение по вертикали. То есть, у нас есть возможность скейлинга и по ширине и по высоте, но мы стараемся делать его по вертикали.

Ожидаемое поведение.

Сработало удержание в пределах snap/release заданного внутри SnappingManager, и мы смогли уменьшить или увеличить кроп-область когда вышли за пределы заданных условных 5px.

Фактический результат.

Удержание и отпускание работает только для изменения ширины, а если мы меняем высоту, то оно не срабатывает и мы можем задать высоту 511 или 510px (скрины 2-3), или при увеличении 513-514 (скрины 4-5)

<img width="1920" height="887" alt="image" src="https://github.com/user-attachments/assets/d8ccd833-53b4-45dd-aab6-a404b829f8d6" />

<img width="1919" height="894" alt="image" src="https://github.com/user-attachments/assets/d88591a5-5c1a-4758-925c-cff8050263d4" />

<img width="1917" height="899" alt="image" src="https://github.com/user-attachments/assets/95119c48-01ca-486a-9e80-3eeac134ee81" />

<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/037550b3-98ce-4de9-b220-771dbba501ab" />

То же самое касается и изменения ширины объекта (скрины 6-7)

<img width="1919" height="893" alt="image" src="https://github.com/user-attachments/assets/b24c7a7c-7219-4923-8bf1-88ca105a22f1" />

<img width="1920" height="896" alt="image" src="https://github.com/user-attachments/assets/4921f37d-8079-4e8f-96cb-7f66e5d5935e" />

При скейлинге по горизонтали и по вертикали за неугловые контролы всё работает как положено. Проблема только при диагональном скейлинге за угловые контролы при отключенном сохранении пропорций.

## Кейс №2 ✅

Порядок воспроизведения:

1. Перейти в непропорциональный кроп режим монтажной области при размерах монтажной области 512х512px с выключенным флагом allowFrameOverflow (скрин 1)

<img width="1919" height="898" alt="image" src="https://github.com/user-attachments/assets/2895bb8b-6a18-491e-957a-886cff2d1a01" />

2. Выделить правый верхний контрол кроп-области и начать уменьшение по вертикали. То есть, у нас есть возможность скейлинга и по ширине и по высоте, но мы стараемся делать его по вертикали.

Ожидаемое поведение.

Сработало удержание в пределах snap/release заданного внутри SnappingManager, и мы смогли уменьшить или увеличить кроп-область когда вышли за пределы заданных условных 5px.

Фактический результат.

Удержание и отпускание работает только для изменения ширины, а если мы меняем высоту, то оно не срабатывает и мы можем задать высоту 511 или 510px (скрины 2-3)

<img width="1919" height="900" alt="image" src="https://github.com/user-attachments/assets/6aa1d77d-2af2-4356-bed4-355d9332c8eb" />

<img width="1920" height="888" alt="image" src="https://github.com/user-attachments/assets/e09e8224-4a32-4ffa-a297-5996c965f554" />

При этом, если тянуть влево или влево-вниз по диагонали, то как будто всё работает. Проблема воспроизводится именно если выделить контрол и тянуть вниз, чтобы уменьшать высоту. То же самое воспроизводится с других углов (скрины 4-5)

<img width="1919" height="894" alt="image" src="https://github.com/user-attachments/assets/4972f6fe-dd4d-42a6-9271-ae2c3c90f4f9" />

<img width="1916" height="892" alt="image" src="https://github.com/user-attachments/assets/dba249ba-7f33-4b9b-9c5c-d66c145d57f6" />

## Кейс №3 ✅

Порядок воспроизведения.

1. Добавить изображение с размерами 1000х667 и перейти в пропорциональный кроп режим изображения (скрин 1)

<img width="1919" height="877" alt="image" src="https://github.com/user-attachments/assets/91194d83-3cd8-4cb5-b639-c8b011b5aad1" />

2. Выделить правый верхний контрол кроп-области и совсем немного потянуть курсор влево-вниз чтобы сделать уменьшение по диагонали.

Ожидаемое поведение.

Сработало удержание в пределах snap/release заданного внутри SnappingManager, и мы смогли уменьшить или увеличить кроп-область когда вышли за пределы заданных условных 5px.

Фактический результат.

Удержание и отпускание работает, но как будто рывками, всё постоянно дёргается. Могут возникнуть ситуации когда отпускание срабатывает раньше времени и мы увидим размеры  кроп-области 998x666, что явно не соответствует тем лимитам которые заданы в SnappingManager.

<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/7f0f5594-1257-49bb-b3b6-63b3e4a259b1" />

## Кейс №4 ✅

Порядок воспроизведения.

1. Добавить изображение с размерами 1000х667 и перейти в пропорциональный кроп-режим изображения с пропорциями 1:1 и отключенным флагом allowFrameOverflow, а затем сдвинуть кроп-область право чтобы она упрёрлась в края изображения (скрин 1)

<img width="1919" height="897" alt="image" src="https://github.com/user-attachments/assets/9c3ebe04-4920-4a7c-8eb2-61056e5f9e6f" />

2. Попытаться выполнить небольшое уменьшение кроп-области путём скейлинга по диагонали за правый верхний угол 

Ожидаемое поведение.

Сработало удержание в пределах snap/release заданного внутри SnappingManager, и мы смогли уменьшить или увеличить кроп-область когда вышли за пределы заданных условных 5px.

Фактический результат.

Удержание и отпускание работает, но в objectSizeIndicator происходит сдвиг на 1 px (скрин 2). То же самое если делать скейлинг с нижнего правого угла, или нижнего левого (скрины 3-4). Если пытаться делать уменьшение с левого верхнего угла, то ситуация ещё интереснее, в какой-то момент мы можем увидеть размеры на 1px меньше 666х666 px (скрин 5). После попыток скейлинга снизу слева значение сверху слева нормализуется, но значения в индикаторе становятся ещё более разными (скрины 5-6)

<img width="1919" height="896" alt="image" src="https://github.com/user-attachments/assets/8a10ede3-a11d-497d-9e55-398182725d13" />

<img width="1919" height="892" alt="image" src="https://github.com/user-attachments/assets/90079142-0951-4359-9b43-ca8d48139ffd" />

<img width="1919" height="893" alt="image" src="https://github.com/user-attachments/assets/cc695cad-62cc-4296-bdf0-9ddfdfa1de47" />

<img width="1919" height="893" alt="image" src="https://github.com/user-attachments/assets/c2e475b0-d6f1-47eb-bee5-7923e42d360e" />

<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/743173a8-a7a2-4063-8624-5ce8a8835b28" />

<img width="1919" height="894" alt="image" src="https://github.com/user-attachments/assets/e61cedad-25f8-4c7e-9360-e62d65b774bc" />

Важно чтобы значения в индикаторе соответствовали текущим размерам кроп-области, чтобы сохранялись пропорции. Важно что если кроп-область растянута на всю ширину и высоту изображения пропорционально, то размеры должны соответствовать размерам изображения, а не как описано выше.

## Кейс №5 ✅

Порядок воспроизведения.

1. Добавить изображение с размерами 1000х667 и перейти в пропорциональный кроп-режим изображения с пропорциями 1:1 и отключенным флагом allowFrameOverflow, а затем сдвинуть кроп-область право чтобы она упрёрлась в края изображения (скрин 1)

<img width="1920" height="894" alt="image" src="https://github.com/user-attachments/assets/dcdeef8b-8b2f-4d1b-9f4b-348209ab6171" />

2. Выполнить уменьшение кроп-области путём скейлинга по диагонали за левый верхний угол, так чтобы сработало прилипание по к вертикальному гайду посередине монтажной области (скрин 2)

<img width="1919" height="879" alt="image" src="https://github.com/user-attachments/assets/83d10bdc-a29b-45cc-b984-9f00c8628884" />

3. Сделать минимальный скейл на увеличение за левый верхний угол

Ожидаемое поведение.

Сработало удержание в пределах snap/release заданного внутри SnappingManager, и мы смогли уменьшить или увеличить кроп-область когда вышли за пределы заданных условных 5px. В objectSizeIndicator нет никаких увеличений или уменьшений высоты или ширины на 1px.

Фактический результат.

Сработало удержание в пределах snap/release заданного внутри SnappingManager, и мы смогли уменьшить или увеличить кроп-область когда вышли за пределы заданных условных 5px. В objectSizeIndicator появляется увеличение высоты и ширины на 1 px (скрин 3). Кроме того, если попытаться увеличить кроп-область путём скейлинга за нижний левый угол, то произойдёт увеличение кроп-области несмотря на то что мы уже упёрлись в нижний и правые края монтажной области (скрин 4). Если после этого отпустить ЛКМ, а затем уменьшить и снова увеличить кроп-область за тот же левый нижний угол, то она смещается вверх (скрин 5). Если отпустить ЛКМ и снова попытаться увеличить, то она увеличится в размерах (скрин 6). Выглядит так, как будто нижняя граница изображения пытается притянуть (snap) к себе кроп-область, что конфликтует с правой границей, из-за чего и происходит сдвиг.

<img width="1920" height="892" alt="image" src="https://github.com/user-attachments/assets/66c6b83b-83cd-4b24-97eb-35ede82bc135" />

<img width="1919" height="893" alt="image" src="https://github.com/user-attachments/assets/54e0158b-2f14-4247-b5e3-2d9c63e958f4" />

<img width="1919" height="893" alt="image" src="https://github.com/user-attachments/assets/4389c2ee-8c66-4205-9db1-bd69a5f249e6" />

<img width="1920" height="894" alt="image" src="https://github.com/user-attachments/assets/bab55374-599a-49ab-8613-0480c28ca2e2" />

---

FIXED.