### PR TITLE
CropManager. Исправляем баг когда при прилипании к краю канваса и скейлинге кроп-области мог появляться сдвиг на 1px до срабатаывания snap-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/snapping-manager/pixel-grid.spec.ts
+++ b/specs/src/editor/snapping-manager/pixel-grid.spec.ts
@@ -4,8 +4,66 @@ import {
   getRoundedDisplaySize
 } from '../../../test-utils/shared/pixel-grid'
 
+/** Source bounds тестового изображения после пересчёта в scene-пиксели. */
+const SOURCE_BOUNDS = {
+  left: 0,
+  top: 0,
+  right: 342,
+  bottom: 342,
+  centerX: 171,
+  centerY: 171
+} as const
+
+/** Внешние source-границы, которые test fixture может проверить без отдельной placement-модели. */
+const SOURCE_BOUNDARY_GUIDE_CASES = [
+  {
+    title: 'нижней границы source',
+    snapGuard: {
+      type: 'horizontal',
+      edge: 'bottom',
+      position: SOURCE_BOUNDS.bottom
+    }
+  },
+  {
+    title: 'правой границы source',
+    snapGuard: {
+      type: 'vertical',
+      edge: 'right',
+      position: SOURCE_BOUNDS.right
+    }
+  }
+] as const
+
 describe('SnappingManager pixel-grid contract', () => {
-  it('для source-size crop frame оставляет размер внутри guide вместо округления вверх', () => {
+  for (const cropCase of SOURCE_BOUNDARY_GUIDE_CASES) {
+    it(`для crop frame с размером в source-пикселях у ${cropCase.title} удерживает размер на guide`, () => {
+      const target = createSourceScaledRect({
+        width: 667,
+        height: 667,
+        scaleX: 0.5112,
+        scaleY: 0.5112,
+        sourceScaleX: 0.512,
+        sourceScaleY: 0.512,
+        sourceBounds: SOURCE_BOUNDS
+      })
+
+      applyScalingStep({
+        target,
+        snapGuards: [
+          cropCase.snapGuard
+        ]
+      })
+
+      const displaySize = getRoundedDisplaySize({ target })
+
+      expect(displaySize.width).toBe(667)
+      expect(displaySize.height).toBe(667)
+      expect(target.scaleX).toBeCloseTo(0.512, 6)
+      expect(target.scaleY).toBeCloseTo(0.512, 6)
+    })
+  }
+
+  it('для crop frame с размером в source-пикселях оставляет размер внутри guide вместо округления вверх', () => {
     const target = createSourceScaledRect({
       width: 667,
       height: 667,

--- a/specs/test-utils/shared/pixel-grid.ts
+++ b/specs/test-utils/shared/pixel-grid.ts
@@ -2,11 +2,41 @@ import { Rect } from 'fabric'
 
 import type { ObjectBounds } from '../../../src/editor/utils/geometry'
 
+/** Rect fixture, который имитирует crop frame с display-size в source-пикселях. */
 type SourceScaledRect = Rect & {
+  cropSource?: Rect | null
   cropSourceScaleX: number
   cropSourceScaleY: number
   getObjectDisplaySize(): { width: number; height: number }
   getObjectSnappingBounds(): ObjectBounds
+}
+
+/** Параметры создания Rect, чей display-size считается в source-пикселях. */
+type SourceScaledRectParams = {
+  width: number
+  height: number
+  scaleX: number
+  scaleY: number
+  sourceScaleX: number
+  sourceScaleY: number
+  left?: number
+  top?: number
+  sourceBounds?: ObjectBounds
+}
+
+/** Создаёт source-объект с явными snapping-bounds для crop-frame тестов. */
+function createSourceBoundsRect({ bounds }: { bounds: ObjectBounds }): Rect {
+  const source = new Rect({
+    left: bounds.left,
+    top: bounds.top,
+    width: bounds.right - bounds.left,
+    height: bounds.bottom - bounds.top,
+    strokeWidth: 0
+  })
+
+  source.getObjectSnappingBounds = () => bounds
+
+  return source
 }
 
 /** Создаёт Rect, чей display-size считается в source-пикселях. */
@@ -18,17 +48,9 @@ export function createSourceScaledRect({
   sourceScaleX,
   sourceScaleY,
   left = 0,
-  top = 0
-}: {
-  width: number
-  height: number
-  scaleX: number
-  scaleY: number
-  sourceScaleX: number
-  sourceScaleY: number
-  left?: number
-  top?: number
-}): SourceScaledRect {
+  top = 0,
+  sourceBounds
+}: SourceScaledRectParams): SourceScaledRect {
   const target = new Rect({
     left,
     top,
@@ -43,6 +65,7 @@ export function createSourceScaledRect({
 
   target.cropSourceScaleX = sourceScaleX
   target.cropSourceScaleY = sourceScaleY
+  target.cropSource = sourceBounds ? createSourceBoundsRect({ bounds: sourceBounds }) : null
   target.getObjectDisplaySize = () => {
     return {
       width: Math.max(1, (target.width * Math.abs(target.scaleX ?? 1)) / sourceScaleX),

--- a/src/editor/snapping-manager/pixel-grid.ts
+++ b/src/editor/snapping-manager/pixel-grid.ts
@@ -72,6 +72,7 @@ type ScalingAxisRoundingState = {
 
 /** Объект, у которого display-size может жить в source-пикселях, а не в scene-пикселях. */
 type SourceDisplaySizeTarget = FabricObject & {
+  cropSource?: FabricObject | null
   cropSourceScaleX?: number
   cropSourceScaleY?: number
 }
@@ -528,7 +529,7 @@ function resolveGuardedScalingStep({
     effectiveHeight,
     isUniform
   })
-  const shouldPreferInsideCandidate = usesScaledDisplaySizeForSnapGuards({
+  const shouldPreferInsideCandidate = shouldPreferInsideScalingCandidate({
     target,
     snapGuards
   })
@@ -559,6 +560,22 @@ function resolveGuardedScalingStep({
   if (onGuideCandidate) return onGuideCandidate
 
   return fallbackScale
+}
+
+/**
+ * Возвращает true, если source-scaled display-size нужно удерживать внутри guide при округлении.
+ * Для внешней границы source приоритет остаётся у on-guide candidate, чтобы snap не съедал 1px.
+ */
+function shouldPreferInsideScalingCandidate({
+  target,
+  snapGuards
+}: {
+  target: FabricObject
+  snapGuards: ScalingStepSnapGuard[]
+}): boolean {
+  if (!usesScaledDisplaySizeForSnapGuards({ target, snapGuards })) return false
+
+  return !usesSourceBoundarySnapGuards({ target, snapGuards })
 }
 
 /**
@@ -611,6 +628,67 @@ function usesScaledDisplaySizeForSnapGuards({
   })
 
   return usesScaledX || usesScaledY
+}
+
+/**
+ * Возвращает true, если хотя бы один active snap guard приклеен к внешней границе crop source.
+ */
+function usesSourceBoundarySnapGuards({
+  target,
+  snapGuards
+}: {
+  target: FabricObject
+  snapGuards: ScalingStepSnapGuard[]
+}): boolean {
+  const displayTarget = target as SourceDisplaySizeTarget
+  const { cropSource } = displayTarget
+  if (!cropSource) return false
+
+  const sourceBounds = getObjectBounds({ object: cropSource })
+  if (!sourceBounds) return false
+
+  return snapGuards.some((snapGuard) => {
+    return isSnapGuardAtSourceBoundary({
+      snapGuard,
+      sourceBounds
+    })
+  })
+}
+
+/**
+ * Проверяет, совпадает ли snap guard с соответствующей внешней границей crop source.
+ */
+function isSnapGuardAtSourceBoundary({
+  snapGuard,
+  sourceBounds
+}: {
+  snapGuard: ScalingStepSnapGuard
+  sourceBounds: ObjectBounds
+}): boolean {
+  const { edge, position } = snapGuard
+  let boundary = sourceBounds.bottom
+
+  if (edge === 'left') boundary = sourceBounds.left
+  if (edge === 'right') boundary = sourceBounds.right
+  if (edge === 'top') boundary = sourceBounds.top
+
+  return isCloseToSourceBoundary({
+    position,
+    boundary
+  })
+}
+
+/**
+ * Сравнивает guide с source-boundary в той же scene-плоскости.
+ */
+function isCloseToSourceBoundary({
+  position,
+  boundary
+}: {
+  position: number
+  boundary: number
+}): boolean {
+  return Math.abs(position - boundary) <= SNAP_GUARD_POSITION_EPSILON
 }
 
 /**
@@ -696,7 +774,7 @@ function collectScalingStepCandidates({
 }
 
 /**
- * Собирает scale-кандидаты одной оси через round/floor/ceil display-size.
+ * Собирает scale-кандидаты одной оси через текущий display-size и соседние пиксельные размеры.
  */
 function collectAxisScaleCandidates({
   rawScale,
@@ -709,10 +787,15 @@ function collectAxisScaleCandidates({
 
   const scaleSign = rawScale < 0 ? -1 : 1
   const rawDisplaySize = Math.abs(rawScale) * effectiveSize
+  const roundedDisplaySize = Math.round(rawDisplaySize)
+  const floorDisplaySize = Math.floor(rawDisplaySize)
+  const ceilDisplaySize = Math.ceil(rawDisplaySize)
   const displaySizes = [
-    Math.round(rawDisplaySize),
-    Math.floor(rawDisplaySize),
-    Math.ceil(rawDisplaySize)
+    roundedDisplaySize,
+    floorDisplaySize,
+    ceilDisplaySize,
+    floorDisplaySize - 1,
+    ceilDisplaySize + 1
   ]
   const candidates: number[] = []
 
@@ -732,7 +815,7 @@ function collectAxisScaleCandidates({
 }
 
 /**
- * Добавляет scale-кандидат без дублей от round/floor/ceil на целом значении.
+ * Добавляет scale-кандидат без дублей от совпадающих display-size кандидатов.
  */
 function addUniqueScaleCandidate({
   candidates,


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить изображение с размерами 1000х667 и перейти в пропорциональный кроп-режим изображения с пропорциями 1:1 и отключенным флагом allowFrameOverflow, а затем сдвинуть её в влево до упора (скрин 1)

<img width="1920" height="893" alt="image" src="https://github.com/user-attachments/assets/a61963d0-983a-4420-9200-6a7807a9a6e0" />

4. Выполнить небольшое уменьшение-увеличение кроп-области в пределах одного пикселя путём скейлинга по диагонали за левый нижний угол

Ожидаемое поведение.

Ничего не произошло потому что работает удержание на нижней границе изображения. 

Фактический результат.

В индикаторе при небольшом скейлинге туда-сюда в пределах 1 пикселя меняются размеры с 667 px до 666 px (скрины 2-3)

<img width="1919" height="898" alt="image" src="https://github.com/user-attachments/assets/e5cf6162-5b7a-411b-af60-5e390de5041c" />

<img width="1920" height="896" alt="image" src="https://github.com/user-attachments/assets/17238475-a911-4d71-b4bc-43111a2635ae" />

При этом, если сделать скейлинг так чтобы отображалось 666 px, а затем отпустить контрол (ЛКМ) и заново выделить его до размер всегда будет 666 px, даже если тянуть за пределы кроп-области влево по диагонали (скрин 4)

<img width="1919" height="892" alt="image" src="https://github.com/user-attachments/assets/4da87ca4-2984-42be-adcf-03b13d4c7e11" />

---

FIXED.