### PR TITLE
SnappingManager. Правим очередной баг когда при уменьшении кроп-области при активном snap возможен нежеательный шаг скейлинга на 1px

### DIFF
--- a/e2e/fixtures/data/crop-size-indicator.data.ts
+++ b/e2e/fixtures/data/crop-size-indicator.data.ts
@@ -45,6 +45,17 @@ export const EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS = 1
 /** Размер crop-области после уменьшения квадратного image crop до серединных guide source. */
 export const EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE = Math.floor(EDGE_IMAGE_CROP_SQUARE_SIZE / 2)
 
+const EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_HEIGHT = Math.floor(EDGE_IMAGE_CROP_SOURCE_SIZE.height / 2)
+
+/** Размер пропорционального image crop после прилипания верхней стороны к середине source. */
+export const EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE = {
+  height: EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_HEIGHT,
+  width: Math.round(
+    (EDGE_IMAGE_CROP_SOURCE_SIZE.width * EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_HEIGHT)
+    / EDGE_IMAGE_CROP_SOURCE_SIZE.height
+  )
+} as const
+
 /** Размеры монтажной области, на которых полный crop не должен терять пиксель. */
 export const FULL_CROP_MONTAGE_SIZES = [
   {

--- a/e2e/tests/crop-manager/crop-size-indicator.spec.ts
+++ b/e2e/tests/crop-manager/crop-size-indicator.spec.ts
@@ -3,6 +3,7 @@ import {
   CROP_SIZE_INSIDE_SNAP_THRESHOLD,
   DEFAULT_MONTAGE_SIZE,
   EDGE_IMAGE_CROP_AXIS_BOUNDARY_DRAG_CASES,
+  EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE,
   EDGE_IMAGE_CROP_BOUNDARY_DRAG_CASES,
   EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
   EDGE_IMAGE_CROP_INSIDE_SNAP_SCREEN_PIXELS,
@@ -484,6 +485,82 @@ test.describe('Индикатор размеров crop-области', () => {
         expect(Math.round(heldState.rect.height)).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
         expect(indicator.width).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
         expect(indicator.height).toBe(EDGE_IMAGE_CROP_MIDDLE_GUIDE_SIZE)
+      })
+    })
+  })
+
+  test.describe('пропорциональный image crop у серединного guide source', () => {
+    test('после прилипания верхней стороны к середине изображения не уменьшается внутри snap-порога', async({
+      editorModel,
+      crop,
+      images,
+      snapping
+    }) => {
+      const image = await test.step('Добавить изображение 1000x667', async() => {
+        return images.checkCreation({
+          imageObject: await images.addFilledImage(EDGE_IMAGE_CROP_SOURCE_SIZE)
+        })
+      })
+
+      const initialState = await test.step('Войти в image crop с сохранением пропорций и запретом выхода за source', async() => {
+        return crop.startImageCrop({
+          id: image.id,
+          allowFrameOverflow: false,
+          preserveAspectRatio: true
+        })
+      })
+
+      const snappedState = await test.step('Потянуть правый верхний угол к горизонтальному guide посередине source', async() => {
+        return crop.dragFrameControlBySourcePixels({
+          control: 'tr',
+          deltaX: -(EDGE_IMAGE_CROP_SOURCE_SIZE.width - EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.width),
+          deltaY: EDGE_IMAGE_CROP_SOURCE_SIZE.height - EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.height,
+          pointerSteps: 8
+        })
+      })
+      const guideState = await snapping.getGuideState()
+
+      const heldState = await test.step('Продолжить уменьшение внутри snap-порога', async() => {
+        return crop.continueFrameResizeBySourcePixels({
+          deltaX: -EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+          deltaY: EDGE_IMAGE_CROP_INSIDE_SNAP_DRAG_PIXELS,
+          pointerSteps: 1
+        })
+      })
+      const guideStateAfterHold = await snapping.getGuideState()
+
+      const indicator = await test.step('Получить индикатор после микродвижения внутри snap-порога', async() => {
+        return editorModel.requireObjectSizeIndicator()
+      })
+
+      await test.step('Завершить resize и закрыть crop mode', async() => {
+        await crop.finishFrameResize()
+        await crop.cancel()
+      })
+
+      await test.step('Проверить что snap удержал размер на нижней границе source', () => {
+        expect(initialState.options.allowFrameOverflow).toBe(false)
+        expect(initialState.options.preserveAspectRatio).toBe(true)
+        expect(Math.round(initialState.rect.width)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.width)
+        expect(Math.round(initialState.rect.height)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.height)
+        expect(guideState.guides).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            type: 'horizontal'
+          })
+        ]))
+        expect(guideStateAfterHold.guides).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            type: 'horizontal'
+          })
+        ]))
+        expect(Math.round(snappedState.rect.width)).toBe(EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.width)
+        expect(Math.round(snappedState.rect.height)).toBe(EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.height)
+        expect(Math.round(snappedState.rect.top + snappedState.rect.height)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.height)
+        expect(Math.round(heldState.rect.width)).toBe(EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.width)
+        expect(Math.round(heldState.rect.height)).toBe(EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.height)
+        expect(Math.round(heldState.rect.top + heldState.rect.height)).toBe(EDGE_IMAGE_CROP_SOURCE_SIZE.height)
+        expect(indicator.width).toBe(EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.width)
+        expect(indicator.height).toBe(EDGE_IMAGE_CROP_ASPECT_MIDDLE_GUIDE_SIZE.height)
       })
     })
   })

--- a/specs/src/editor/snapping-manager/pixel-grid.spec.ts
+++ b/specs/src/editor/snapping-manager/pixel-grid.spec.ts
@@ -14,6 +14,16 @@ const SOURCE_BOUNDS = {
   centerY: 171
 } as const
 
+/** Source bounds прямоугольного изображения 1000x667 после scale 0.512 и округления source guides. */
+const RECTANGULAR_SOURCE_BOUNDS = {
+  left: 0,
+  top: 0,
+  right: 512,
+  bottom: 342,
+  centerX: 256,
+  centerY: 171
+} as const
+
 /** Внешние source-границы, которые test fixture может проверить без отдельной placement-модели. */
 const SOURCE_BOUNDARY_GUIDE_CASES = [
   {
@@ -87,6 +97,36 @@ describe('SnappingManager pixel-grid contract', () => {
     const displaySize = getRoundedDisplaySize({ target })
 
     expect(displaySize.width).toBe(333)
+    expect(displaySize.height).toBe(333)
+    expect(target.scaleX).toBeCloseTo(0.255616, 6)
+    expect(target.scaleY).toBeCloseTo(0.255616, 6)
+  })
+
+  it('для прямоугольного crop frame у внутреннего guide не выбирает меньший соседний пиксель', () => {
+    const target = createSourceScaledRect({
+      width: 1000,
+      height: 667,
+      scaleX: 0.25560881346968983,
+      scaleY: 0.25560881346968983,
+      sourceScaleX: 0.512,
+      sourceScaleY: 0.512,
+      sourceBounds: RECTANGULAR_SOURCE_BOUNDS
+    })
+
+    applyScalingStep({
+      target,
+      snapGuards: [
+        {
+          type: 'horizontal',
+          edge: 'bottom',
+          position: 171
+        }
+      ]
+    })
+
+    const displaySize = getRoundedDisplaySize({ target })
+
+    expect(displaySize.width).toBe(499)
     expect(displaySize.height).toBe(333)
     expect(target.scaleX).toBeCloseTo(0.255616, 6)
     expect(target.scaleY).toBeCloseTo(0.255616, 6)

--- a/src/editor/crop-manager/README.md
+++ b/src/editor/crop-manager/README.md
@@ -1,0 +1,48 @@
+# CropManager
+
+`CropManager` управляет временным crop mode для монтажной области и изображения. Его главная задача не в том, чтобы хранить итоговый crop, а в том, чтобы безопасно провести live-сессию: создать `CropFrame`, ограничить его source-границами, отдать наружу текущее состояние и затем либо применить результат, либо отменить сессию.
+
+## Что здесь считается source of truth
+
+- Активная сессия живёт в `CropManager._session`. Это transient runtime-state: он не сериализуется, не попадает в history и не должен утекать в persisted model.
+- Публичное состояние crop mode возвращает `getState()`. Итоговый прямоугольник считается не из сырой геометрии Fabric frame, а через `getCropSessionResultRect()`.
+- `CropFrame` тоже runtime-объект. Он помечен `excludeFromExport` и существует только внутри активной crop session.
+
+## Важные runtime-контракты
+
+- `CropFrame` хранит `cropSource`, `cropAllowFrameOverflow`, `cropSourceScaleX`, `cropSourceScaleY` и `preserveAspectRatio`.
+  Эти поля определяют не только UI, но и то, как resize/snap должны интерпретировать размер frame.
+- `CropFrame.scaleX/scaleY` на старте совпадают со scale source.
+  Поэтому обычный Fabric bounds живёт в scene-пикселях, а `frame.getObjectDisplaySize()` возвращает размер crop-результата в source-пикселях.
+- `frame.getObjectSnappingBounds()` намеренно исключает stroke.
+  Snapping должен работать по геометрии crop-результата, а не по визуальной обводке frame.
+- `allowFrameOverflow = false` включает source-bound поведение.
+  В этом режиме clamp и scale-limit должны опираться на `getCropRectInSource()` и `getSourceSize()`, а не на сырой bounding box на canvas.
+- `preserveAspectRatio` по умолчанию включён. `Shift` не “добавляет” пропорции, а инвертирует текущее правило.
+  Этот контракт должен совпадать с `crop-controls` и `snapping-manager`.
+
+## Live resize и clamp
+
+- `crop-controls` вычисляет source-scale bounds и помечает текущий `Transform` служебными флагами:
+  `cropSourceScaleClamped`, `cropSourceBoundScale`, `cropSourceScalePreserveAspectRatio`.
+- Эти поля существуют только внутри live resize-сессии.
+  Их нельзя рассматривать как persisted state и нельзя переносить в доменную модель.
+- `CropManager._handleCropFrameChanged()` сначала пытается восстановить geometry предыдущего source-bound step, потом делает clamp, потом при необходимости запоминает первое состояние на границе source.
+  Это нужно для “удержания” frame на source-boundary после materialization Fabric.
+
+## Что здесь легко сломать
+
+- Смешать source-пиксели и scene-пиксели в одном сравнении.
+- Перенести transient transform metadata в session/model “для удобства”.
+- Починить только один live-path и забыть про `apply`, `cancel`, повторный `start*Crop()` и восстановление geometry после clamp.
+- Изменить правило `Shift` только в одном месте.
+
+## Перед правкой
+
+- Сначала определяй, где живёт проблема: в session lifecycle, в geometry/clamp или в snapping.
+- Если меняется поведение `CropFrame`, проверяй оба контракта:
+  размер индикатора через `getObjectDisplaySize()` и snapping bounds через `getObjectSnappingBounds()`.
+- Если меняется source-bound resize, сразу перечитывай:
+  [`domain/crop-frame.ts`](./domain/crop-frame.ts),
+  [`interaction/crop-controls.ts`](./interaction/crop-controls.ts),
+  [`index.ts`](./index.ts).

--- a/src/editor/snapping-manager/README.md
+++ b/src/editor/snapping-manager/README.md
@@ -1,0 +1,50 @@
+# SnappingManager
+
+`SnappingManager` отвечает за live snap во время перемещения и scale. Для crop-сценариев важно помнить, что он работает сразу в двух плоскостях: scene-пиксели для направляющих и bounds, и source-пиксели для display-size crop frame.
+
+## Как разделена ответственность
+
+- [`scaling.ts`](./scaling.ts) решает, к каким guide можно приклеиться на текущем live-step, и должен ли scale быть uniform.
+- [`pixel-grid.ts`](./pixel-grid.ts) запускается после snap и квантует scale так, чтобы итоговый display-size был пиксельным и уже приклеенный edge не перелетел через guide.
+- [`index.ts`](./index.ts) оркестрирует общий flow и вызывает pixel-step только там, где это входит в контракт target.
+
+## Ключевые контракты
+
+- `snapGuards` описывают уже приклеенный active edge.
+  Для отладки важно смотреть не на направление курсора, а на то, какая грань реально удерживается guide.
+- Для обычных объектов bounds и display-size живут в одной scene-плоскости.
+  Для crop frame это не так: `getObjectSnappingBounds()` остаётся в scene-пикселях, а `getObjectDisplaySize()` может жить в source-пикселях через `cropSourceScaleX/Y`.
+- `shouldUseUniformScaleSnap()` для crop frame обязан зеркалить правило `preserveAspectRatio` из `CropManager`, включая инверсию по `Shift`.
+- Pixel rounding не должен менять нецелевую ось и не должен переносить snapped edge за его guide.
+
+## Source-scaled crop frame
+
+- Если active snap axis использует `getObjectDisplaySize()` в source-пикселях, `pixel-grid` не может обращаться с ним как с обычным scene-size.
+- Для внутренних guide у source-scaled crop frame приоритет у inside-candidate.
+  Это удерживает размер “внутри” guide и не даёт лишний +1 пиксель от округления.
+- Но `inside-candidate` не должен быть просто первым ближайшим к raw pointer scale.
+  Если `on-guide` уже даёт целый source display-size и не превышает source-часть по внутреннюю сторону guide, нужно оставить `on-guide`; иначе микродвижение внутри snap-порога может съесть лишний пиксель.
+- Для внешней границы source правило другое: приоритет у on-guide candidate.
+  Иначе snap на границе source съедает 1 пиксель и индикатор показывает `666` вместо `667`.
+- Одних `round/floor/ceil` для display-size недостаточно.
+  В guarded rounding нужно рассматривать и соседние пиксельные размеры, иначе корректный кандидат около guide может вообще не попасть в перебор.
+
+## Что здесь легко сломать
+
+- Сравнить source-size с scene-guide без явного преобразования.
+- Привязать логику к направлению pointer вместо active edge из `snapGuards`.
+- Починить boundary-case и случайно сломать middle-guide-case, или наоборот.
+- Считать, что green e2e уже доказал корневой контракт.
+  Для source-scaled rounding надёжнее держать отдельный unit-regression на уровне `pixel-grid`.
+
+## Перед правкой
+
+- Сначала фиксируй, где именно баг:
+  в поиске guide, в выборе uniform snap, в guarded pixel rounding или в browser-side interaction protocol.
+- Если правка касается crop frame, сразу перечитывай:
+  [`scaling.ts`](./scaling.ts),
+  [`pixel-grid.ts`](./pixel-grid.ts),
+  [`../crop-manager/domain/crop-frame.ts`](../crop-manager/domain/crop-frame.ts).
+- Для регрессий вокруг source boundary опирайся на unit-контракты в:
+  [`../../../specs/src/editor/snapping-manager/scaling.spec.ts`](../../../specs/src/editor/snapping-manager/scaling.spec.ts),
+  [`../../../specs/src/editor/snapping-manager/pixel-grid.spec.ts`](../../../specs/src/editor/snapping-manager/pixel-grid.spec.ts).

--- a/src/editor/snapping-manager/pixel-grid.ts
+++ b/src/editor/snapping-manager/pixel-grid.ts
@@ -18,6 +18,12 @@ const SNAP_GUARD_INTEGER_POSITION_EPSILON = 0.01
 /** Допуск subpixel-дрейфа active edge вокруг guide после Fabric resize. */
 const SNAP_GUARD_POSITION_EPSILON = 0.1
 
+/** Допуск сравнения source display-size с целым пикселем. */
+const DISPLAY_SIZE_INTEGER_EPSILON = 0.000001
+
+/** Допуск materialization-дрейфа display-size после snap-плана. */
+const SNAP_PLAN_DISPLAY_SIZE_EPSILON = 0.02
+
 /** Допуск сравнения scale source-плоскости с scene-плоскостью. */
 const SOURCE_DISPLAY_SCALE_EPSILON = 0.000001
 
@@ -36,6 +42,12 @@ type ScalingStepCandidate = {
 
 /** Положение кандидата относительно snapped guide. */
 type ScalingStepCandidateSnapState = 'on-guide' | 'inside' | 'outside'
+
+/** Проверка кандидата относительно snapped guide. */
+type ScalingStepCandidateSnapMatch = {
+  state: ScalingStepCandidateSnapState
+  distance: number
+}
 
 /** Fixed anchor, который нужно сохранять во время post-snap округления scale. */
 type ScalingStepPlacement = {
@@ -61,6 +73,19 @@ type GuardedScalingStepParams = {
   fallbackScale: ScalingStepCandidate
   isUniform: boolean
   preservePlacement?: ScalingStepPlacementPreserver
+  snapGuards: ScalingStepSnapGuard[]
+}
+
+/** Параметры выбора candidate, который сохраняет active snap guards. */
+type GuardedScalingCandidateSelectorParams = {
+  target: FabricObject
+  rawScaleX: number
+  rawScaleY: number
+  effectiveWidth: number
+  effectiveHeight: number
+  candidates: ScalingStepCandidate[]
+  preservePlacement?: ScalingStepPlacementPreserver
+  shouldPreferInsideCandidate: boolean
   snapGuards: ScalingStepSnapGuard[]
 }
 
@@ -533,33 +558,216 @@ function resolveGuardedScalingStep({
     target,
     snapGuards
   })
+
+  const guardedCandidate = selectGuardedScalingCandidate({
+    target,
+    rawScaleX,
+    rawScaleY,
+    effectiveWidth,
+    effectiveHeight,
+    candidates,
+    preservePlacement,
+    shouldPreferInsideCandidate,
+    snapGuards
+  })
+
+  return guardedCandidate ?? fallbackScale
+}
+
+/**
+ * Выбирает candidate, который остаётся внутри active snap guards.
+ */
+function selectGuardedScalingCandidate({
+  target,
+  rawScaleX,
+  rawScaleY,
+  effectiveWidth,
+  effectiveHeight,
+  candidates,
+  preservePlacement,
+  shouldPreferInsideCandidate,
+  snapGuards
+}: GuardedScalingCandidateSelectorParams): ScalingStepCandidate | null {
   let onGuideCandidate: ScalingStepCandidate | null = null
   let insideCandidate: ScalingStepCandidate | null = null
+  let insideCandidateDistance = Number.POSITIVE_INFINITY
 
   for (const candidate of candidates) {
-    const snapState = resolveScalingStepCandidateSnapState({
+    const snapMatch = resolveScalingStepCandidateSnapMatch({
       target,
       candidate,
       preservePlacement,
       snapGuards
     })
 
-    if (snapState === 'on-guide') {
+    if (snapMatch.state === 'on-guide') {
       if (!shouldPreferInsideCandidate) return candidate
 
       if (!onGuideCandidate) {
         onGuideCandidate = candidate
       }
     }
-    if (snapState === 'inside' && !insideCandidate) {
-      insideCandidate = candidate
+    if (snapMatch.state === 'inside') {
+      if (!shouldPreferInsideCandidate && !insideCandidate) {
+        insideCandidate = candidate
+      }
+      if (shouldPreferInsideCandidate && snapMatch.distance < insideCandidateDistance) {
+        insideCandidate = candidate
+        insideCandidateDistance = snapMatch.distance
+      }
     }
   }
+
+  if (onGuideCandidate && shouldKeepOnGuideScalingCandidate({
+    target,
+    candidate: onGuideCandidate,
+    rawScaleX,
+    rawScaleY,
+    effectiveWidth,
+    effectiveHeight,
+    snapGuards
+  })) return onGuideCandidate
 
   if (insideCandidate) return insideCandidate
   if (onGuideCandidate) return onGuideCandidate
 
-  return fallbackScale
+  return null
+}
+
+/**
+ * Оставляет on-guide candidate, если активные source display-оси уже попали в целый пиксель.
+ */
+function shouldKeepOnGuideScalingCandidate({
+  target,
+  candidate,
+  rawScaleX,
+  rawScaleY,
+  effectiveWidth,
+  effectiveHeight,
+  snapGuards
+}: {
+  target: FabricObject
+  candidate: ScalingStepCandidate
+  rawScaleX: number
+  rawScaleY: number
+  effectiveWidth: number
+  effectiveHeight: number
+  snapGuards: ScalingStepSnapGuard[]
+}): boolean {
+  for (const snapGuard of snapGuards) {
+    const displaySize = snapGuard.type === 'vertical'
+      ? Math.abs(candidate.scaleX) * effectiveWidth
+      : Math.abs(candidate.scaleY) * effectiveHeight
+    const rawDisplaySize = snapGuard.type === 'vertical'
+      ? Math.abs(rawScaleX) * effectiveWidth
+      : Math.abs(rawScaleY) * effectiveHeight
+
+    if (!isIntegerDisplaySize({ displaySize })) return false
+    if (!isSameSnappedDisplaySize({
+      displaySize,
+      rawDisplaySize
+    })) return false
+    if (!isInsideSourceGuideDisplayLimit({
+      target,
+      displaySize,
+      snapGuard
+    })) return false
+  }
+
+  return true
+}
+
+/**
+ * Проверяет, что source display-size уже совпадает с целым пикселем.
+ */
+function isIntegerDisplaySize({ displaySize }: { displaySize: number }): boolean {
+  const integerSize = Math.round(displaySize)
+
+  return Math.abs(displaySize - integerSize) <= DISPLAY_SIZE_INTEGER_EPSILON
+}
+
+/**
+ * Проверяет, что on-guide candidate не увеличивает source display-size, а только убирает float-дрейф.
+ */
+function isSameSnappedDisplaySize({
+  displaySize,
+  rawDisplaySize
+}: {
+  displaySize: number
+  rawDisplaySize: number
+}): boolean {
+  return Math.abs(displaySize - rawDisplaySize) <= SNAP_PLAN_DISPLAY_SIZE_EPSILON
+}
+
+/**
+ * Проверяет, что on-guide candidate не стал больше source-части, внутри которой удерживается crop frame.
+ */
+function isInsideSourceGuideDisplayLimit({
+  target,
+  displaySize,
+  snapGuard
+}: {
+  target: FabricObject
+  displaySize: number
+  snapGuard: ScalingStepSnapGuard
+}): boolean {
+  const sourceDisplayLimit = resolveSourceGuideDisplayLimit({
+    target,
+    snapGuard
+  })
+  if (sourceDisplayLimit === null) return false
+
+  return Math.round(displaySize) <= sourceDisplayLimit
+}
+
+/**
+ * Возвращает максимальный source display-size для части source по внутреннюю сторону guide.
+ */
+function resolveSourceGuideDisplayLimit({
+  target,
+  snapGuard
+}: {
+  target: FabricObject
+  snapGuard: ScalingStepSnapGuard
+}): number | null {
+  const displayTarget = target as SourceDisplaySizeTarget
+  const { cropSource } = displayTarget
+  if (!cropSource) return null
+
+  const sourceBounds = getObjectBounds({ object: cropSource })
+  if (!sourceBounds) return null
+
+  const sourceScale = snapGuard.type === 'vertical'
+    ? Math.abs(displayTarget.cropSourceScaleX ?? 1)
+    : Math.abs(displayTarget.cropSourceScaleY ?? 1)
+  if (!Number.isFinite(sourceScale) || sourceScale <= 0) return null
+
+  const sceneLength = getSourceGuideSceneLength({
+    sourceBounds,
+    snapGuard
+  })
+  if (!Number.isFinite(sceneLength) || sceneLength <= 0) return null
+
+  return Math.floor((sceneLength / sourceScale) + DISPLAY_SIZE_INTEGER_EPSILON)
+}
+
+/**
+ * Возвращает scene-длину между внутренним guide и внешней границей source по стороне crop frame.
+ */
+function getSourceGuideSceneLength({
+  sourceBounds,
+  snapGuard
+}: {
+  sourceBounds: ObjectBounds
+  snapGuard: ScalingStepSnapGuard
+}): number {
+  const { edge, position } = snapGuard
+
+  if (edge === 'left') return sourceBounds.right - position
+  if (edge === 'right') return position - sourceBounds.left
+  if (edge === 'top') return sourceBounds.bottom - position
+
+  return position - sourceBounds.top
 }
 
 /**
@@ -894,9 +1102,9 @@ function collectAxisScaleCandidatePairs({
 }
 
 /**
- * Определяет положение rounded scale относительно snapped guide.
+ * Проверяет rounded scale относительно snapped guide.
  */
-function resolveScalingStepCandidateSnapState({
+function resolveScalingStepCandidateSnapMatch({
   target,
   candidate,
   preservePlacement,
@@ -906,7 +1114,38 @@ function resolveScalingStepCandidateSnapState({
   candidate: ScalingStepCandidate
   preservePlacement?: ScalingStepPlacementPreserver
   snapGuards: ScalingStepSnapGuard[]
-}): ScalingStepCandidateSnapState {
+}): ScalingStepCandidateSnapMatch {
+  const bounds = readScalingStepCandidateBounds({
+    target,
+    candidate,
+    preservePlacement
+  })
+
+  if (!bounds) {
+    return {
+      state: 'outside',
+      distance: Number.POSITIVE_INFINITY
+    }
+  }
+
+  return resolveBoundsSnapMatch({
+    bounds,
+    snapGuards
+  })
+}
+
+/**
+ * Читает bounds candidate, временно применяя scale и возвращая target в исходное состояние.
+ */
+function readScalingStepCandidateBounds({
+  target,
+  candidate,
+  preservePlacement
+}: {
+  target: FabricObject
+  candidate: ScalingStepCandidate
+  preservePlacement?: ScalingStepPlacementPreserver
+}): ObjectBounds | null {
   const originalScaleX = target.scaleX ?? 1
   const originalScaleY = target.scaleY ?? 1
   let bounds: ObjectBounds | null = null
@@ -937,17 +1176,64 @@ function resolveScalingStepCandidateSnapState({
     }
   }
 
-  if (!bounds) return 'outside'
+  return bounds
+}
 
+/**
+ * Проверяет candidate bounds относительно всех active snap guards.
+ */
+function resolveBoundsSnapMatch({
+  bounds,
+  snapGuards
+}: {
+  bounds: ObjectBounds
+  snapGuards: ScalingStepSnapGuard[]
+}): ScalingStepCandidateSnapMatch {
   let isOnGuide = true
+  let distance = 0
   for (const snapGuard of snapGuards) {
-    if (!isObjectBoundsInsideSnapGuard({ bounds, snapGuard })) return 'outside'
+    if (!isObjectBoundsInsideSnapGuard({ bounds, snapGuard })) {
+      return {
+        state: 'outside',
+        distance: Number.POSITIVE_INFINITY
+      }
+    }
     if (!isObjectBoundsOnSnapGuide({ bounds, snapGuard })) {
       isOnGuide = false
     }
+
+    distance = Math.max(
+      distance,
+      getObjectBoundsSnapGuardDistance({
+        bounds,
+        snapGuard
+      })
+    )
   }
 
-  return isOnGuide ? 'on-guide' : 'inside'
+  return {
+    state: isOnGuide ? 'on-guide' : 'inside',
+    distance
+  }
+}
+
+/**
+ * Возвращает расстояние active edge кандидата до guide.
+ */
+function getObjectBoundsSnapGuardDistance({
+  bounds,
+  snapGuard
+}: {
+  bounds: ObjectBounds
+  snapGuard: ScalingStepSnapGuard
+}): number {
+  const { edge, position } = snapGuard
+
+  if (edge === 'left') return Math.abs(bounds.left - position)
+  if (edge === 'right') return Math.abs(bounds.right - position)
+  if (edge === 'top') return Math.abs(bounds.top - position)
+
+  return Math.abs(bounds.bottom - position)
 }
 
 /**


### PR DESCRIPTION
Порядок воспроизведения.

1. Добавить изображение с размерами 1000х667 и перейти в пропорциональный кроп-режим изображения с пропорциями 1:1 и отключенным флагом allowFrameOverflow (скрин 1)

<img width="1920" height="888" alt="image" src="https://github.com/user-attachments/assets/50c1f0a8-846f-4f94-9096-c755cee1f8d9" />

2. Уменьшить кроп-область так чтобы сработало прилипание к горизонтальному гайду посередине изображения (скрин 2)

<img width="1920" height="891" alt="image" src="https://github.com/user-attachments/assets/e26bf4cd-62c7-4bdc-adad-738926179502" />

3. Затем попытаться ещё немного уменьшить размер кроп-области продолжая уменьшение из пункта 1, но при этом не выходя за пределы прилипания к гайду

Ожидаемое поведение.

Ничего не произошло потому что работает удержание на нижней границе изображения, отображаемый размер такой же как и был в пункте 2 и равен 499х333. 

Фактический результат.

Произошёл небольшой скейл и в индикаторе отобразились размеры 498х332 (скрин 3)

<img width="1919" height="893" alt="image" src="https://github.com/user-attachments/assets/31763ddc-2a71-4420-ae80-dcdd85c636e4" />

---

FIXED.