### PR TITLE
TemplateManager & ImageManager. При применении темплейта кешируем картинки как blob-объекты

### DIFF
--- a/e2e/fixtures/data/image-source-restore.data.ts
+++ b/e2e/fixtures/data/image-source-restore.data.ts
@@ -1,0 +1,235 @@
+import { Buffer } from 'node:buffer'
+import type { CanvasFullState } from '../../../src/editor/history-manager'
+import type { TemplateDefinition } from '../../types'
+
+/** Описание source-кейса для e2e-проверки восстановления картинки. */
+type ImageSourceRestoreCase = {
+  historyForbiddenPayloads: readonly string[]
+  initialState: CanvasFullState
+  initialStateImageId: string
+  initialStateTestName: string
+  label: string
+  source: string
+  template: TemplateDefinition
+  templateTestName: string
+}
+
+/** Mock ответа для картинки, загружаемой по ссылке в e2e. */
+type ImageSourceRestoreRouteMock = {
+  body: string
+  contentType: string
+  url: string
+}
+
+/** SVG-разметка тестовой картинки для всех source-кейсов. */
+const IMAGE_SOURCE_RESTORE_MARKUP = [
+  '<svg xmlns="http://www.w3.org/2000/svg" width="160" height="120">',
+  '<rect width="160" height="120" fill="#f28f3b"/>',
+  '<rect x="80" width="80" height="120" fill="#2457ff"/>',
+  '</svg>'
+].join('')
+
+/** Разрешение монтажной области для source restore сценариев. */
+export const IMAGE_SOURCE_RESTORE_RESOLUTION = {
+  width: 400,
+  height: 300
+} as const
+
+/** Общие serialized-поля картинки, которые не зависят от lifecycle path. */
+const IMAGE_SOURCE_RESTORE_BASE_OBJECT = {
+  cropX: 0,
+  cropY: 0,
+  format: 'svg',
+  width: 160,
+  height: 120,
+  evented: true,
+  selectable: true,
+  lockMovementX: false,
+  lockMovementY: false,
+  lockRotation: false,
+  lockScalingX: false,
+  lockScalingY: false,
+  lockSkewingX: false,
+  lockSkewingY: false,
+  type: 'Image',
+  version: '7.2.0',
+  originX: 'left',
+  originY: 'top',
+  scaleX: 1,
+  scaleY: 1,
+  angle: 0,
+  flipX: false,
+  flipY: false,
+  opacity: 1,
+  visible: true,
+  crossOrigin: 'anonymous',
+  filters: []
+} as const
+
+/** Служебная монтажная область для initialState fixture. */
+const IMAGE_SOURCE_RESTORE_MONTAGE_OBJECT = {
+  id: 'montage-area',
+  type: 'Rect',
+  version: '7.2.0',
+  originX: 'center',
+  originY: 'center',
+  left: IMAGE_SOURCE_RESTORE_RESOLUTION.width / 2,
+  top: IMAGE_SOURCE_RESTORE_RESOLUTION.height / 2,
+  width: IMAGE_SOURCE_RESTORE_RESOLUTION.width,
+  height: IMAGE_SOURCE_RESTORE_RESOLUTION.height,
+  fill: '#ffffff',
+  stroke: null,
+  strokeWidth: 0,
+  selectable: false,
+  evented: false,
+  hasBorders: false,
+  hasControls: false,
+  objectCaching: false,
+  noScaleCache: true
+} as const
+
+/** Base64 source тестовой SVG-картинки. */
+const IMAGE_SOURCE_RESTORE_BASE64_SOURCE = `data:image/svg+xml;base64,${Buffer
+  .from(IMAGE_SOURCE_RESTORE_MARKUP)
+  .toString('base64')}`
+
+/** Data URL без base64 для тестовой SVG-картинки. */
+const IMAGE_SOURCE_RESTORE_DATA_URL_SOURCE = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+  IMAGE_SOURCE_RESTORE_MARKUP
+)}`
+
+/** CDN-like ссылка, которая в e2e всегда закрывается route mock-ом. */
+const IMAGE_SOURCE_RESTORE_REMOTE_SOURCE = 'https://static.insales-cdn.com/e2e/image-source-restore.svg'
+
+/** Количество объектов, ожидаемое после восстановления одного image source. */
+export const IMAGE_SOURCE_RESTORE_OBJECT_COUNT = 1
+
+/** Route mock для картинки по ссылке. */
+export const IMAGE_SOURCE_RESTORE_ROUTE_MOCK: ImageSourceRestoreRouteMock = {
+  body: IMAGE_SOURCE_RESTORE_MARKUP,
+  contentType: 'image/svg+xml',
+  url: IMAGE_SOURCE_RESTORE_REMOTE_SOURCE
+}
+
+/**
+ * Создаёт шаблон с одним image-объектом и заданным src.
+ */
+function createTemplateWithImageSource({
+  id,
+  src
+}: {
+  id: string
+  src: string
+}): TemplateDefinition {
+  return {
+    id,
+    meta: {
+      baseWidth: IMAGE_SOURCE_RESTORE_RESOLUTION.width,
+      baseHeight: IMAGE_SOURCE_RESTORE_RESOLUTION.height,
+      positionsNormalized: true
+    },
+    objects: [
+      {
+        ...IMAGE_SOURCE_RESTORE_BASE_OBJECT,
+        id: `${id}-image`,
+        left: 0.2,
+        top: 0.2,
+        src
+      }
+    ]
+  }
+}
+
+/**
+ * Создаёт initialState с одним image-объектом и заданным src.
+ */
+function createInitialStateWithImageSource({
+  id,
+  src
+}: {
+  id: string
+  src: string
+}): CanvasFullState {
+  return {
+    version: '7.2.0',
+    width: IMAGE_SOURCE_RESTORE_RESOLUTION.width,
+    height: IMAGE_SOURCE_RESTORE_RESOLUTION.height,
+    clipPath: null,
+    objects: [
+      IMAGE_SOURCE_RESTORE_MONTAGE_OBJECT,
+      {
+        ...IMAGE_SOURCE_RESTORE_BASE_OBJECT,
+        id: `${id}-image`,
+        left: 80,
+        top: 60,
+        src
+      }
+    ]
+  }
+}
+
+/** Кейсы image src, которые должны одинаково работать для шаблонов и initialState. */
+export const IMAGE_SOURCE_RESTORE_CASES: ImageSourceRestoreCase[] = [
+  {
+    initialStateImageId: 'initial-state-image-source-base64-image',
+    label: 'Картинка в base64',
+    source: IMAGE_SOURCE_RESTORE_BASE64_SOURCE,
+    historyForbiddenPayloads: [
+      IMAGE_SOURCE_RESTORE_BASE64_SOURCE,
+      'data:image/svg+xml;base64'
+    ],
+    templateTestName:
+      'картинка в base64 из шаблона после scale остаётся blob-ссылкой и не возвращает исходные данные в историю',
+    initialStateTestName:
+      'картинка в base64 из начального состояния загружается как blob-ссылка и не возвращает исходные данные в историю',
+    template: createTemplateWithImageSource({
+      id: 'template-image-source-base64',
+      src: IMAGE_SOURCE_RESTORE_BASE64_SOURCE
+    }),
+    initialState: createInitialStateWithImageSource({
+      id: 'initial-state-image-source-base64',
+      src: IMAGE_SOURCE_RESTORE_BASE64_SOURCE
+    })
+  },
+  {
+    initialStateImageId: 'initial-state-image-source-data-url-image',
+    label: 'Картинка из data URL без base64',
+    source: IMAGE_SOURCE_RESTORE_DATA_URL_SOURCE,
+    historyForbiddenPayloads: [
+      IMAGE_SOURCE_RESTORE_DATA_URL_SOURCE,
+      'data:image/svg+xml;charset=utf-8'
+    ],
+    templateTestName:
+      'картинка из data URL без base64 после scale остаётся blob-ссылкой и не возвращает исходные данные в историю',
+    // eslint-disable-next-line max-len
+    initialStateTestName: 'картинка из data URL без base64 в начальном состоянии загружается как blob-ссылка и не возвращает исходные данные в историю',
+    template: createTemplateWithImageSource({
+      id: 'template-image-source-data-url',
+      src: IMAGE_SOURCE_RESTORE_DATA_URL_SOURCE
+    }),
+    initialState: createInitialStateWithImageSource({
+      id: 'initial-state-image-source-data-url',
+      src: IMAGE_SOURCE_RESTORE_DATA_URL_SOURCE
+    })
+  },
+  {
+    initialStateImageId: 'initial-state-image-source-link-image',
+    label: 'Картинка по ссылке',
+    source: IMAGE_SOURCE_RESTORE_REMOTE_SOURCE,
+    historyForbiddenPayloads: [
+      IMAGE_SOURCE_RESTORE_REMOTE_SOURCE
+    ],
+    templateTestName:
+      'картинка по ссылке из шаблона после scale остаётся blob-ссылкой и не возвращает исходную ссылку в историю',
+    // eslint-disable-next-line max-len
+    initialStateTestName: 'картинка по ссылке из начального состояния загружается как blob-ссылка и не возвращает исходную ссылку в историю',
+    template: createTemplateWithImageSource({
+      id: 'template-image-source-link',
+      src: IMAGE_SOURCE_RESTORE_REMOTE_SOURCE
+    }),
+    initialState: createInitialStateWithImageSource({
+      id: 'initial-state-image-source-link',
+      src: IMAGE_SOURCE_RESTORE_REMOTE_SOURCE
+    })
+  }
+]

--- a/e2e/fixtures/editor.fixture.ts
+++ b/e2e/fixtures/editor.fixture.ts
@@ -42,13 +42,23 @@ interface EditorFixtures {
   crop: CropModel
 }
 
-interface EditorInternalFixtures {
-  holdBrowserAfterTest: void
+type EditorRouteMock = {
+  body: string
+  contentType: string
+  status?: number
+  url: string
 }
 
 type EditorDemoInitOptions = {
-  fonts: typeof E2E_EDITOR_FONTS
-  showToolbar: boolean
+  fonts?: typeof E2E_EDITOR_FONTS
+  initialState?: object | null
+  showToolbar?: boolean
+}
+
+interface EditorInternalFixtures {
+  editorInitOptions: EditorDemoInitOptions
+  editorRouteMocks: readonly EditorRouteMock[]
+  holdBrowserAfterTest: void
 }
 
 interface EditorDemoWindow extends Window {
@@ -56,6 +66,10 @@ interface EditorDemoWindow extends Window {
 }
 
 export const test = base.extend<EditorFixtures & EditorInternalFixtures>({
+  editorInitOptions: [{}, { option: true }],
+
+  editorRouteMocks: [[], { option: true }],
+
   holdBrowserAfterTest: [async({ page: _page }, use, testInfo) => {
     await use()
 
@@ -65,19 +79,38 @@ export const test = base.extend<EditorFixtures & EditorInternalFixtures>({
     await delay(holdMs)
   }, { auto: true }],
 
-  editorModel: async({ page }, use) => {
+  editorModel: async({
+    editorInitOptions,
+    editorRouteMocks,
+    page
+  }, use) => {
     const model = new EditorModel(page)
+    const demoInitOptions: EditorDemoInitOptions = {
+      ...editorInitOptions,
+      fonts: editorInitOptions.fonts ?? E2E_EDITOR_FONTS,
+      showToolbar: editorInitOptions.showToolbar ?? true
+    }
 
-    await page.addInitScript(({ fonts }) => {
+    await page.addInitScript(({ initOptions }) => {
       const demoWindow = window as EditorDemoWindow
 
-      demoWindow.__EDITOR_DEMO_INIT_OPTIONS = {
-        fonts,
-        showToolbar: true
-      }
+      demoWindow.__EDITOR_DEMO_INIT_OPTIONS = initOptions
     }, {
-      fonts: E2E_EDITOR_FONTS
+      initOptions: demoInitOptions
     })
+
+    for (const routeMock of editorRouteMocks) {
+      await page.route(routeMock.url, async(route) => {
+        await route.fulfill({
+          body: routeMock.body,
+          contentType: routeMock.contentType,
+          headers: {
+            'access-control-allow-origin': '*'
+          },
+          status: routeMock.status ?? 200
+        })
+      })
+    }
 
     await page.route('**/__e2e/fonts/**', async(route) => {
       const requestUrl = new URL(route.request().url())

--- a/e2e/models/history.model.ts
+++ b/e2e/models/history.model.ts
@@ -46,4 +46,23 @@ export class HistoryModel {
       return editor.historyManager.flushPendingSave()
     })
   }
+
+  /** Возвращает сериализованное состояние history для проверок persistence payload. */
+  async getSerializedState(): Promise<unknown> {
+    return this.page.evaluate(() => {
+      const { editor } = window as any
+      const { historyManager } = editor
+
+      return {
+        baseState: historyManager.baseState,
+        fullState: historyManager.getFullState(),
+        patches: historyManager.patches
+      }
+    })
+  }
+
+  /** Возвращает serialized history строкой для проверок payload. */
+  async getSerializedStateText(): Promise<string> {
+    return JSON.stringify(await this.getSerializedState())
+  }
 }

--- a/e2e/models/image.model.ts
+++ b/e2e/models/image.model.ts
@@ -15,6 +15,18 @@ type ImagePixelColor = {
   alpha: number
 }
 
+/** Источник live image-объекта в Fabric. */
+type ImageSourceInfo = {
+  id: string | null
+  src: string | null
+  elementSrc: string | null
+  runtimeSrc: string
+  width: number
+  height: number
+  sourceWidth: number
+  sourceHeight: number
+}
+
 export class ImageModel {
   private readonly page: Page
 
@@ -219,6 +231,43 @@ export class ImageModel {
     expect(snapshot, 'должен существовать snapshot изображения').not.toBeNull()
 
     return snapshot as SnappingObjectSnapshot
+  }
+
+  /** Возвращает runtime source изображения. */
+  async getSourceInfo(params: ObjectTargetParams = {}): Promise<ImageSourceInfo> {
+    const info = await this.page.evaluate((targetParams) => {
+      const runtimeWindow = window as any
+      const target = runtimeWindow.__editorHelpers.resolveCanvasObject(
+        targetParams.objectIndex,
+        targetParams.id
+      )
+      if (!target) return null
+
+      const source = target.getElement?.()
+      const elementSrc = typeof source?.src === 'string' ? source.src : null
+      const rawSrc = typeof target.getSrc === 'function'
+        ? target.getSrc()
+        : target.src ?? null
+      const src = typeof rawSrc === 'string' ? rawSrc : null
+
+      return {
+        id: target.id ?? null,
+        src,
+        elementSrc,
+        runtimeSrc: src ?? elementSrc ?? '',
+        width: target.width ?? 0,
+        height: target.height ?? 0,
+        sourceWidth: source?.naturalWidth ?? source?.width ?? 0,
+        sourceHeight: source?.naturalHeight ?? source?.height ?? 0
+      }
+    }, params)
+
+    expect(info, 'должно существовать runtime source-состояние изображения').not.toBeNull()
+    if (!info) {
+      throw new Error('Не удалось получить runtime source-состояние изображения')
+    }
+
+    return info
   }
 
   /** Масштабирует изображение вправо через реальную drag-сессию с фиксированной левой верхней точкой. */

--- a/e2e/tests/editor.spec.ts
+++ b/e2e/tests/editor.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect } from '../fixtures/editor.fixture'
+import { IMAGE_SCALING_FACTOR } from '../fixtures/data/image.data'
+import {
+  IMAGE_SOURCE_RESTORE_CASES,
+  IMAGE_SOURCE_RESTORE_OBJECT_COUNT,
+  IMAGE_SOURCE_RESTORE_ROUTE_MOCK
+} from '../fixtures/data/image-source-restore.data'
 
 test.describe('Инициализация редактора', () => {
   test('canvas создан и доступен', async({ editorModel }) => {
@@ -72,4 +78,87 @@ test.describe('Состояние canvas после инициализации',
       expect(state.zoom).toBeLessThanOrEqual(1)
     })
   })
+})
+
+test.describe('Картинка из начального состояния', () => {
+  for (const sourceCase of IMAGE_SOURCE_RESTORE_CASES) {
+    test.describe(sourceCase.label, () => {
+      test.use({
+        editorInitOptions: {
+          initialState: sourceCase.initialState
+        },
+        editorRouteMocks: [IMAGE_SOURCE_RESTORE_ROUTE_MOCK]
+      })
+
+      test(sourceCase.initialStateTestName, async({
+        editorModel,
+        history,
+        images
+      }) => {
+        const imageTarget = {
+          id: sourceCase.initialStateImageId
+        }
+
+        await test.step('Проверить что картинка появилась на canvas', async() => {
+          await editorModel.checkObjectCount({ count: IMAGE_SOURCE_RESTORE_OBJECT_COUNT })
+        })
+
+        await test.step('Проверить что картинка загружена как blob-ссылка', async() => {
+          const sourceInfo = await images.getSourceInfo(imageTarget)
+
+          expect(sourceInfo.runtimeSrc.startsWith('blob:')).toBe(true)
+          expect(sourceInfo.runtimeSrc).not.toBe(sourceCase.source)
+          expect(sourceInfo.sourceWidth).toBeGreaterThan(0)
+          expect(sourceInfo.sourceHeight).toBeGreaterThan(0)
+        })
+
+        await test.step('Проверить что история после init не содержит исходные данные картинки', async() => {
+          const serializedHistoryText = await history.getSerializedStateText()
+
+          expect(serializedHistoryText).toContain('blob:')
+
+          for (const forbiddenPayload of sourceCase.historyForbiddenPayloads) {
+            expect(serializedHistoryText).not.toContain(forbiddenPayload)
+          }
+        })
+
+        const initialSnapshot = await test.step('Получить геометрию до scale', async() => {
+          return images.getSnapshot(imageTarget)
+        })
+
+        await test.step('Масштабировать картинку вправо', async() => {
+          await images.scaleHorizontallyFromRight({
+            ...imageTarget,
+            scaleX: IMAGE_SCALING_FACTOR
+          })
+        })
+
+        const finalSnapshot = await test.step('Завершить scale и сохранить состояние', async() => {
+          const snapshot = await images.finishScale(imageTarget)
+
+          await history.saveState()
+
+          return snapshot
+        })
+
+        await test.step('Проверить что после scale картинка осталась blob-ссылкой', async() => {
+          const sourceInfo = await images.getSourceInfo(imageTarget)
+
+          expect(finalSnapshot.boundsWidth).toBeLessThan(initialSnapshot.boundsWidth)
+          expect(sourceInfo.runtimeSrc.startsWith('blob:')).toBe(true)
+          expect(sourceInfo.runtimeSrc).not.toBe(sourceCase.source)
+        })
+
+        await test.step('Проверить что история не содержит исходные данные картинки', async() => {
+          const serializedHistoryText = await history.getSerializedStateText()
+
+          expect(serializedHistoryText).toContain('blob:')
+
+          for (const forbiddenPayload of sourceCase.historyForbiddenPayloads) {
+            expect(serializedHistoryText).not.toContain(forbiddenPayload)
+          }
+        })
+      })
+    })
+  }
 })

--- a/e2e/tests/template-manager/index.spec.ts
+++ b/e2e/tests/template-manager/index.spec.ts
@@ -39,6 +39,13 @@ import {
   TEMPLATE_STANDALONE_TEXT_TALL_RESOLUTION,
   TEMPLATE_STANDALONE_TEXT_TEMPLATE
 } from '../../fixtures/data/template-manager.data'
+import { IMAGE_SCALING_FACTOR } from '../../fixtures/data/image.data'
+import {
+  IMAGE_SOURCE_RESTORE_CASES,
+  IMAGE_SOURCE_RESTORE_OBJECT_COUNT,
+  IMAGE_SOURCE_RESTORE_RESOLUTION,
+  IMAGE_SOURCE_RESTORE_ROUTE_MOCK
+} from '../../fixtures/data/image-source-restore.data'
 
 test.describe('Готовый шаблон', () => {
   test('готовый шаблон появляется внутри монтажной области', async({
@@ -306,6 +313,79 @@ test.describe('Картинка из шаблона после замены src'
           expect(Math.abs(image.centerY - expectedCenterY)).toBeLessThanOrEqual(TEMPLATE_BOUNDS_TOLERANCE)
         })
       }
+    })
+  }
+})
+
+test.describe('Картинка из шаблона после подготовки src', () => {
+  test.use({
+    editorRouteMocks: [IMAGE_SOURCE_RESTORE_ROUTE_MOCK]
+  })
+
+  for (const sourceCase of IMAGE_SOURCE_RESTORE_CASES) {
+    test(sourceCase.templateTestName, async({
+      canvas,
+      editorModel,
+      history,
+      images,
+      template
+    }) => {
+      await test.step('Применить шаблон с картинкой', async() => {
+        await canvas.setMontageResolution(IMAGE_SOURCE_RESTORE_RESOLUTION)
+
+        const insertedCount = await template.applyTemplate({
+          template: sourceCase.template
+        })
+
+        expect(insertedCount).toBe(IMAGE_SOURCE_RESTORE_OBJECT_COUNT)
+        await editorModel.checkObjectCount({ count: IMAGE_SOURCE_RESTORE_OBJECT_COUNT })
+      })
+
+      await test.step('Проверить что картинка загружена как blob-ссылка', async() => {
+        const sourceInfo = await images.getSourceInfo({ objectIndex: 0 })
+
+        expect(sourceInfo.runtimeSrc.startsWith('blob:')).toBe(true)
+        expect(sourceInfo.runtimeSrc).not.toBe(sourceCase.source)
+        expect(sourceInfo.sourceWidth).toBeGreaterThan(0)
+        expect(sourceInfo.sourceHeight).toBeGreaterThan(0)
+      })
+
+      const initialSnapshot = await test.step('Получить геометрию до scale', async() => {
+        return images.getSnapshot({ objectIndex: 0 })
+      })
+
+      await test.step('Масштабировать картинку вправо', async() => {
+        await images.scaleHorizontallyFromRight({
+          objectIndex: 0,
+          scaleX: IMAGE_SCALING_FACTOR
+        })
+      })
+
+      const finalSnapshot = await test.step('Завершить scale и сохранить состояние', async() => {
+        const snapshot = await images.finishScale({ objectIndex: 0 })
+
+        await history.saveState()
+
+        return snapshot
+      })
+
+      await test.step('Проверить что после scale картинка осталась blob-ссылкой', async() => {
+        const sourceInfo = await images.getSourceInfo({ objectIndex: 0 })
+
+        expect(finalSnapshot.boundsWidth).toBeLessThan(initialSnapshot.boundsWidth)
+        expect(sourceInfo.runtimeSrc.startsWith('blob:')).toBe(true)
+        expect(sourceInfo.runtimeSrc).not.toBe(sourceCase.source)
+      })
+
+      await test.step('Проверить что история не содержит исходные данные картинки', async() => {
+        const serializedHistoryText = await history.getSerializedStateText()
+
+        expect(serializedHistoryText).toContain('blob:')
+
+        for (const forbiddenPayload of sourceCase.historyForbiddenPayloads) {
+          expect(serializedHistoryText).not.toContain(forbiddenPayload)
+        }
+      })
     })
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.27",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.9.27",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.9.27",
+  "version": "0.10.0",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [
@@ -20,6 +20,7 @@
     "build:docs": "vite build --config vite.config.docs.js",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.{js,ts}\" \"e2e/**/*.{js,ts}\" \"specs/**/*.{js,ts}\"",
+    "typecheck": "tsc --noEmit --pretty false",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "test:ci": "jest --ci --coverage --watchAll=false",

--- a/specs/src/editor/image-manager/index.spec.ts
+++ b/specs/src/editor/image-manager/index.spec.ts
@@ -42,7 +42,16 @@ describe('ImageManager', () => {
     restoreGlobals()
   })
 
-  describe('prepareInitialState', () => {
+  describe('prepareSerializedImageSources', () => {
+    const createStateWithImageSrc = (src: string): any => ({
+      version: '5.0.0',
+      width: 100,
+      height: 100,
+      objects: [
+        { type: 'image', src }
+      ]
+    })
+
     it('заменяет src у image-объектов на blob URL и не мутирует исходный state', async() => {
       const initialState: any = {
         version: '5.0.0',
@@ -54,7 +63,7 @@ describe('ImageManager', () => {
         ]
       }
 
-      const prepared = await imageManager.prepareInitialState({ state: initialState })
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
 
       expect(initialState.objects[0].src).toBe('https://example.com/a.png')
       expect(prepared.objects?.[0].src).toMatch(/^blob:mock-\d+$/)
@@ -74,7 +83,7 @@ describe('ImageManager', () => {
         ]
       }
 
-      const prepared = await imageManager.prepareInitialState({ state: initialState })
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(mockCreateObjectURL).toHaveBeenCalledTimes(1)
@@ -97,29 +106,121 @@ describe('ImageManager', () => {
         ]
       }
 
-      const prepared = await imageManager.prepareInitialState({ state: initialState })
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
 
       const nestedSrc = prepared.objects?.[0]?.objects?.[0]?.src
       expect(nestedSrc).toMatch(/^blob:mock-\d+$/)
       expect(mockFetch).toHaveBeenCalledWith('https://example.com/nested.png', { mode: 'cors' })
     })
 
-    it('не трогает blob/data URL и не делает fetch', async() => {
+    it('не трогает blob URL и не делает fetch', async() => {
       const initialState: any = {
         version: '5.0.0',
         width: 100,
         height: 100,
         objects: [
-          { type: 'image', src: 'blob:already' },
-          { type: 'image', src: 'data:image/png;base64,abc' }
+          { type: 'image', src: 'blob:already' }
         ]
       }
 
-      const prepared = await imageManager.prepareInitialState({ state: initialState })
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
 
       expect(prepared.objects?.[0].src).toBe('blob:already')
-      expect(prepared.objects?.[1].src).toBe('data:image/png;base64,abc')
       expect(mockFetch).not.toHaveBeenCalled()
+      expect(mockCreateObjectURL).not.toHaveBeenCalled()
+    })
+
+    it('заменяет base64 data image src на blob URL', async() => {
+      const dataUrl = 'data:image/png;base64,bW9jaw=='
+      const initialState = createStateWithImageSrc(dataUrl)
+
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
+      const [createdBlob] = mockCreateObjectURL.mock.calls[0]
+
+      expect(initialState.objects[0].src).toBe(dataUrl)
+      expect(prepared.objects?.[0].src).toBe('blob:mock-1')
+      expect(createdBlob).toBeInstanceOf(Blob)
+      expect(createdBlob.type).toBe('image/png')
+      expect(mockCreateObjectURL).toHaveBeenCalledTimes(1)
+    })
+
+    it('заменяет url-encoded SVG data image src на blob URL', async() => {
+      const dataUrl = [
+        'data:image/svg+xml;charset=utf-8,',
+        encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>')
+      ].join('')
+      const initialState = createStateWithImageSrc(dataUrl)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        blob: async() => new Blob(['<svg></svg>'], { type: 'image/svg+xml' }),
+        headers: { get: jest.fn(() => 'image/svg+xml') }
+      })
+
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
+      const [createdBlob] = mockCreateObjectURL.mock.calls[0]
+
+      expect(prepared.objects?.[0].src).toBe('blob:mock-1')
+      expect(createdBlob).toBeInstanceOf(Blob)
+      expect(createdBlob.type).toBe('image/svg+xml')
+      expect(mockFetch).toHaveBeenCalledWith(dataUrl)
+    })
+
+    it('кеширует blob URL для одинаковых data image src', async() => {
+      const dataUrl = 'data:image/png;base64,bW9jaw=='
+      const initialState: any = {
+        version: '5.0.0',
+        width: 100,
+        height: 100,
+        objects: [
+          { type: 'image', src: dataUrl },
+          { type: 'image', src: dataUrl }
+        ]
+      }
+
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
+
+      expect(prepared.objects?.[0].src).toBe('blob:mock-1')
+      expect(prepared.objects?.[1].src).toBe('blob:mock-1')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(dataUrl)
+      expect(mockCreateObjectURL).toHaveBeenCalledTimes(1)
+    })
+
+    it('оставляет некорректные и не-image data URL без замены', async() => {
+      const textDataUrl = 'data:text/plain;base64,bW9jaw=='
+      const invalidImageDataUrl = 'data:image/png;base64,%'
+      const initialState: any = {
+        version: '5.0.0',
+        width: 100,
+        height: 100,
+        objects: [
+          { type: 'image', src: textDataUrl },
+          { type: 'image', src: invalidImageDataUrl }
+        ]
+      }
+      mockFetch.mockRejectedValueOnce(new TypeError('Invalid data URL'))
+
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
+
+      expect(prepared.objects?.[0].src).toBe(textDataUrl)
+      expect(prepared.objects?.[1].src).toBe(invalidImageDataUrl)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(invalidImageDataUrl)
+      expect(mockCreateObjectURL).not.toHaveBeenCalled()
+    })
+
+    it('не скрывает неожиданные ошибки подготовки data image src', async() => {
+      const dataUrl = 'data:image/png;base64,bW9jaw=='
+      const initialState = createStateWithImageSrc(dataUrl)
+      const unexpectedError = new Error('Unexpected decoder failure')
+      mockFetch.mockRejectedValueOnce(unexpectedError)
+
+      await expect(imageManager.prepareSerializedImageSources({ state: initialState })).rejects.toThrow(
+        unexpectedError
+      )
+
+      expect(initialState.objects[0].src).toBe(dataUrl)
+      expect(mockFetch).toHaveBeenCalledWith(dataUrl)
       expect(mockCreateObjectURL).not.toHaveBeenCalled()
     })
 
@@ -139,10 +240,30 @@ describe('ImageManager', () => {
         ]
       }
 
-      const prepared = await imageManager.prepareInitialState({ state: initialState })
+      const prepared = await imageManager.prepareSerializedImageSources({ state: initialState })
 
       expect(prepared.objects?.[0].src).toBe('https://example.com/fail.png')
       expect(mockCreateObjectURL).not.toHaveBeenCalled()
+    })
+
+    it('prepareSerializedImageSources подготавливает generic serialized state и не мутирует оригинал', async() => {
+      const dataUrl = 'data:image/png;base64,bW9jaw=='
+      const serializedState = {
+        id: 'template',
+        objects: [
+          { type: 'image', src: dataUrl }
+        ]
+      }
+
+      const prepared = await imageManager.prepareSerializedImageSources({ state: serializedState })
+
+      expect(serializedState.objects[0].src).toBe(dataUrl)
+      expect(prepared).toEqual({
+        id: 'template',
+        objects: [
+          { type: 'image', src: 'blob:mock-1' }
+        ]
+      })
     })
   })
 
@@ -711,7 +832,7 @@ describe('ImageManager', () => {
   })
 
   describe('revokeBlobUrls', () => {
-    it('освобождает blob URL, созданные при подготовке initial state', async() => {
+    it('освобождает blob URL, созданные при подготовке serialized state', async() => {
       const initialState: CanvasFullState = {
         clipPath: null,
         version: '5.0.0',
@@ -719,17 +840,19 @@ describe('ImageManager', () => {
         height: 100,
         objects: [
           { type: 'image', src: 'https://example.com/a.png' },
-          { type: 'image', src: 'https://example.com/b.png' }
+          { type: 'image', src: 'https://example.com/b.png' },
+          { type: 'image', src: 'data:image/png;base64,bW9jaw==' }
         ]
       }
 
-      await imageManager.prepareInitialState({ state: initialState })
+      await imageManager.prepareSerializedImageSources({ state: initialState })
 
       imageManager.revokeBlobUrls()
 
       expect(mockRevokeObjectURL).toHaveBeenNthCalledWith(1, 'blob:mock-1')
       expect(mockRevokeObjectURL).toHaveBeenNthCalledWith(2, 'blob:mock-2')
-      expect(mockRevokeObjectURL).toHaveBeenCalledTimes(2)
+      expect(mockRevokeObjectURL).toHaveBeenNthCalledWith(3, 'blob:mock-3')
+      expect(mockRevokeObjectURL).toHaveBeenCalledTimes(3)
 
       mockRevokeObjectURL.mockClear()
       imageManager.revokeBlobUrls()

--- a/specs/src/editor/index.spec.ts
+++ b/specs/src/editor/index.spec.ts
@@ -18,7 +18,7 @@ jest.mock('../../../src/editor/image-manager', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({
     importImage: jest.fn().mockResolvedValue(undefined),
-    prepareInitialState: jest.fn().mockImplementation(async({ state }) => state),
+    prepareSerializedImageSources: jest.fn().mockImplementation(async({ state }) => state),
     calculateScaleFactor: jest.fn().mockReturnValue(1),
     revokeBlobUrls: jest.fn()
   }))
@@ -205,16 +205,16 @@ describe('ImageEditor', () => {
       expect(editor.historyManager.loadStateFromFullState).toHaveBeenCalledWith({ test: 'state' })
     })
 
-    it('должен подготовить initialState через imageManager.prepareInitialState перед загрузкой в историю', async() => {
+    it('должен подготовить initialState через imageManager.prepareSerializedImageSources перед загрузкой в историю', async() => {
       const initialState = { test: 'state' }
       const preparedState = { prepared: true }
 
       const ImageManagerMock = jest.requireMock('../../../src/editor/image-manager').default as jest.Mock
-      const prepareInitialState = jest.fn().mockResolvedValue(preparedState)
+      const prepareSerializedImageSources = jest.fn().mockResolvedValue(preparedState)
 
       ImageManagerMock.mockImplementationOnce(() => ({
         importImage: jest.fn().mockResolvedValue(undefined),
-        prepareInitialState,
+        prepareSerializedImageSources,
         calculateScaleFactor: jest.fn().mockReturnValue(1),
         revokeBlobUrls: jest.fn()
       }))
@@ -235,7 +235,7 @@ describe('ImageEditor', () => {
       const editor = createEditorWithMocks({ initialState })
       await editor.init()
 
-      expect(prepareInitialState).toHaveBeenCalledWith({ state: initialState })
+      expect(prepareSerializedImageSources).toHaveBeenCalledWith({ state: initialState })
       expect(loadStateFromFullState).toHaveBeenCalledWith(preparedState)
       expect(suspendHistory).toHaveBeenCalled()
       expect(resumeHistory).toHaveBeenCalled()
@@ -247,11 +247,11 @@ describe('ImageEditor', () => {
 
       const ImageManagerMock = jest.requireMock('../../../src/editor/image-manager').default as jest.Mock
       const importImage = jest.fn().mockResolvedValue(undefined)
-      const prepareInitialState = jest.fn().mockResolvedValue(initialState)
+      const prepareSerializedImageSources = jest.fn().mockResolvedValue(initialState)
 
       ImageManagerMock.mockImplementationOnce(() => ({
         importImage,
-        prepareInitialState,
+        prepareSerializedImageSources,
         calculateScaleFactor: jest.fn().mockReturnValue(1),
         revokeBlobUrls: jest.fn()
       }))
@@ -285,7 +285,7 @@ describe('ImageEditor', () => {
 
       await editor.init()
 
-      expect(prepareInitialState).toHaveBeenCalledWith({ state: initialState })
+      expect(prepareSerializedImageSources).toHaveBeenCalledWith({ state: initialState })
       expect(importImage).toHaveBeenCalledWith({
         source: 'test-image.jpg',
         scale: 'image-contain',
@@ -307,11 +307,11 @@ describe('ImageEditor', () => {
 
       const ImageManagerMock = jest.requireMock('../../../src/editor/image-manager').default as jest.Mock
       const importImage = jest.fn().mockResolvedValue(undefined)
-      const prepareInitialState = jest.fn().mockResolvedValue(initialState)
+      const prepareSerializedImageSources = jest.fn().mockResolvedValue(initialState)
 
       ImageManagerMock.mockImplementationOnce(() => ({
         importImage,
-        prepareInitialState,
+        prepareSerializedImageSources,
         calculateScaleFactor: jest.fn().mockReturnValue(1),
         revokeBlobUrls: jest.fn()
       }))
@@ -343,11 +343,11 @@ describe('ImageEditor', () => {
 
       const ImageManagerMock = jest.requireMock('../../../src/editor/image-manager').default as jest.Mock
       const importImage = jest.fn().mockResolvedValue(undefined)
-      const prepareInitialState = jest.fn().mockResolvedValue(initialState)
+      const prepareSerializedImageSources = jest.fn().mockResolvedValue(initialState)
 
       ImageManagerMock.mockImplementationOnce(() => ({
         importImage,
-        prepareInitialState,
+        prepareSerializedImageSources,
         calculateScaleFactor: jest.fn().mockReturnValue(1),
         revokeBlobUrls: jest.fn()
       }))

--- a/specs/src/editor/template-manager/index.spec.ts
+++ b/specs/src/editor/template-manager/index.spec.ts
@@ -470,6 +470,84 @@ describe('TemplateManager', () => {
     expect(editor.errorManager.emitError).not.toHaveBeenCalled()
   })
 
+  it('готовит image src через ImageManager до восстановления Fabric-объектов', async() => {
+    const {
+      manager,
+      editor
+    } = createTemplateManagerTestSetup({
+      useRealCanvasManager: true,
+      montageBounds: {
+        left: 100,
+        top: 50,
+        width: 810,
+        height: 1080
+      }
+    })
+    const dataUrl = 'data:image/png;base64,bW9jaw=='
+    const template = {
+      id: 'template-data-image',
+      meta: {
+        baseWidth: 810,
+        baseHeight: 1080,
+        positionsNormalized: true
+      },
+      objects: [
+        {
+          type: 'image',
+          id: 'template-image',
+          src: dataUrl,
+          left: 0.2,
+          top: 0.1,
+          width: 300,
+          height: 300,
+          originX: 'left',
+          originY: 'top',
+          scaleX: 1,
+          scaleY: 1
+        }
+      ]
+    }
+    const preparedTemplate = {
+      ...template,
+      objects: [
+        {
+          ...template.objects[0],
+          src: 'blob:prepared-image'
+        }
+      ]
+    }
+    const revivedImage = createPlacementTestImage({
+      id: 'template-image',
+      left: 0.2,
+      top: 0.1,
+      width: 300,
+      height: 300,
+      intrinsicWidth: 300,
+      intrinsicHeight: 300
+    })
+    const prepareImageSourcesMock = editor.imageManager.prepareSerializedImageSources as jest.Mock
+    prepareImageSourcesMock.mockResolvedValue(preparedTemplate)
+
+    const enlivenObjectsSpy = jest.spyOn(util, 'enlivenObjects').mockResolvedValue([revivedImage as never])
+
+    const result = await manager.applyTemplate({ template })
+    const [serializedObjects] = enlivenObjectsSpy.mock.calls[0]
+    const [serializedImage] = serializedObjects as Array<Record<string, unknown>>
+
+    expect(result).toEqual([revivedImage])
+    expect(prepareImageSourcesMock).toHaveBeenCalledWith({ state: template })
+    expect(prepareImageSourcesMock.mock.invocationCallOrder[0]).toBeLessThan(
+      enlivenObjectsSpy.mock.invocationCallOrder[0]
+    )
+    expect(serializedImage.src).toBe('blob:prepared-image')
+    expect(template.objects[0].src).toBe(dataUrl)
+    expect(editor.canvas.fire).toHaveBeenCalledWith('editor:template-applied', expect.objectContaining({
+      template
+    }))
+    expect(editor.historyManager.saveState).toHaveBeenCalled()
+    expect(editor.errorManager.emitError).not.toHaveBeenCalled()
+  })
+
   it('после применения шаблона эмитит editor:template-applied с вставленными объектами и bounds монтажной области', async() => {
     const {
       manager,

--- a/specs/test-utils/editor/editor-stub.ts
+++ b/specs/test-utils/editor/editor-stub.ts
@@ -290,7 +290,8 @@ export const createEditorStub = () => {
     },
     imageManager: {
       calculateScaleFactor: jest.fn().mockReturnValue(1),
-      importImage: jest.fn()
+      importImage: jest.fn(),
+      prepareSerializedImageSources: jest.fn().mockImplementation(async({ state }) => state)
     },
     backgroundManager: {
       backgroundObject: null,

--- a/specs/test-utils/editor/editor-with-mocks.ts
+++ b/specs/test-utils/editor/editor-with-mocks.ts
@@ -21,7 +21,7 @@ export const createEditorWithMocks = (options: Partial<CanvasOptions> = {}) => {
 
   editor.imageManager = {
     importImage: jest.fn().mockResolvedValue(undefined),
-    prepareInitialState: jest.fn().mockImplementation(async({ state }) => state),
+    prepareSerializedImageSources: jest.fn().mockImplementation(async({ state }) => state),
     calculateScaleFactor: jest.fn().mockReturnValue(1)
   } as any
 

--- a/src/demo/js/index.js
+++ b/src/demo/js/index.js
@@ -4,9 +4,22 @@ import {
   loadEditorModule
 } from './editor-module-loader.js'
 
+/**
+ * Возвращает options, которые e2e может передать demo перед инициализацией редактора.
+ *
+ * @returns {Record<string, unknown>}
+ */
+function getDemoInitOptions() {
+  /** @type {Window & { __EDITOR_DEMO_INIT_OPTIONS?: Record<string, unknown> }} */
+  const demoWindow = window
+
+  return demoWindow.__EDITOR_DEMO_INIT_OPTIONS ?? {}
+}
+
 document.addEventListener('DOMContentLoaded', async() => {
   const { default: initEditor } = await loadEditorModule()
   const editorVersion = getRequestedEditorVersion() || 'local'
+  const demoInitOptions = getDemoInitOptions()
 
   console.info('[image-editor demo] editor version:', editorVersion)
 
@@ -15,7 +28,8 @@ document.addEventListener('DOMContentLoaded', async() => {
     montageAreaWidth: 512,
     montageAreaHeight: 512,
     editorContainerWidth: '100%',
-    editorContainerHeight: 'calc(100vh - 4rem)'
+    editorContainerHeight: 'calc(100vh - 4rem)',
+    ...demoInitOptions
   })
 
   initListeners(editorInstance)

--- a/src/editor/image-manager/README.md
+++ b/src/editor/image-manager/README.md
@@ -6,8 +6,8 @@ The main rule for this module is simple: keep the public user scenarios in [`ind
 
 ## Responsibility split
 
-- [`index.ts`](./index.ts) is the public scenario owner. It keeps `importImage()`, `prepareInitialState()`, `exportCanvasAsImageFile()`, `exportObjectAsImageFile()`, `resizeImageToBoundaries()`, content-type helpers, scale calculation, and blob URL cleanup.
-- [`import-image.ts`](./import-image.ts) contains the private import pipeline steps: request creation, source validation, Fabric image loading, import-time resize, placement, canvas insertion, history completion, error emission, and initial state image source replacement.
+- [`index.ts`](./index.ts) is the public scenario owner. It keeps `importImage()`, `prepareSerializedImageSources()`, `exportCanvasAsImageFile()`, `exportObjectAsImageFile()`, `resizeImageToBoundaries()`, content-type helpers, scale calculation, and blob URL cleanup.
+- [`import-image.ts`](./import-image.ts) contains the private import pipeline steps: request creation, source validation, Fabric image loading, import-time resize, placement, canvas insertion, history completion, error emission, and serialized image source replacement.
 - [`canvas-export.ts`](./canvas-export.ts) contains the private canvas export pipeline: export request normalization, cloned canvas preparation, montage-area snapshot creation, SVG/raster/PDF export branches, and `editor:canvas-exported` payload creation.
 - [`object-export.ts`](./object-export.ts) contains the private object export pipeline: selected-object request normalization, SVG export, direct image-element base64 export, rendered object export, crop-aware object rendering, and `editor:object-exported` payload creation.
 - [`export-utils.ts`](./export-utils.ts) contains export operations shared by canvas and object export: SVG string packaging and Blob-to-data-URL conversion through the worker.
@@ -47,13 +47,27 @@ The main rule for this module is simple: keep the public user scenarios in [`ind
 5. Otherwise render the Fabric object to an offscreen canvas so crop and other Fabric state are preserved.
 6. Fire `editor:object-exported`, or emit `IMAGE_EXPORT_FAILED` and return `null`.
 
+`ImageManager.prepareSerializedImageSources()` is the restore-time image source boundary:
+
+1. Deep-clone the serialized state or template passed by the caller.
+2. Walk `objects` recursively, including nested group objects.
+3. Leave `blob:` sources unchanged.
+4. Convert valid `data:image/...` sources to managed `blob:` URLs through `BlobUrlRegistry`.
+5. Fetch remote image URLs into managed `blob:` URLs when possible.
+6. Keep the original `src` when parsing or fetching fails.
+7. Return the prepared clone without mutating the caller's object.
+
 ## Important contracts
 
 - The public API is `editor.imageManager.*`. Do not move user-facing calls to helper modules.
 - Helper files must not accept `ImageManager` as an argument. Pass only the real dependencies a step needs: `editor`, `blobUrls`, `request`, `image`, or `acceptContentTypes`.
 - Do not duplicate format parsing. Use [`image-format.ts`](./image-format.ts) for `contentType -> format` and content-type detection.
 - Blob URLs created for import and state restore must go through `BlobUrlRegistry`, so `ImageManager.revokeBlobUrls()` can release them on editor destroy.
-- `prepareInitialState()` works on serialized state and replaces image `src` values with blob URLs when possible. It must not mutate the caller's original state object.
+- `prepareSerializedImageSources()` is the shared restore-time implementation for `initialState` and templates.
+- Runtime `blob:` URLs are not a persistence contract for library users. They are materialized state for the current editor instance and are released by `revokeBlobUrls()`.
+- `BlobUrlRegistry` reads `data:image/...` through browser `fetch().blob()`. Do not add a local base64 parser here.
+- Invalid or non-image `data:` URLs must not break restore. Leave them unchanged so Fabric or caller-side validation can handle them.
+- Recoverable browser read failures, such as CORS, invalid URL, or data URL decode failures, leave the original `src` unchanged. Unexpected errors should propagate.
 - Import history must be resumed on every path after `suspendHistory()`. A failed import must not leave history suspended.
 - Resize worker calls must check returned values. `resizeImage` is expected to return a `Blob`; `toDataURL` is expected to return a string.
 - Object export must preserve visible image crop. Direct image-element export is allowed only when the Fabric image is not visibly cropped.
@@ -86,7 +100,7 @@ The main rule for this module is simple: keep the public user scenarios in [`ind
 For focused changes in this folder, run:
 
 ```bash
-rtk ./node_modules/.bin/tsc --noEmit --pretty false
+npm run typecheck
 rtk ./node_modules/.bin/eslint src/editor/image-manager/**/*.ts
 rtk ./node_modules/.bin/playwright test e2e/tests/image-manager/index.spec.ts --project=chromium
 ```

--- a/src/editor/image-manager/blob-url-registry.ts
+++ b/src/editor/image-manager/blob-url-registry.ts
@@ -1,7 +1,22 @@
-/** Проверяет, что src уже является локальным blob/data URL и не требует fetch. */
-function isBlobOrDataUrl({ src }: { src: string }): boolean {
-  if (src.startsWith('blob:')) return true
-  if (src.startsWith('data:')) return true
+/** Проверяет, что src уже является локальным blob URL и не требует подготовки. */
+function isBlobUrl({ src }: { src: string }): boolean {
+  return src.startsWith('blob:')
+}
+
+/** Проверяет, что src является data URL и требует локальной подготовки. */
+function isDataUrl({ src }: { src: string }): boolean {
+  return src.toLowerCase().startsWith('data:')
+}
+
+/** Проверяет, что data URL заявлен как image. */
+function isImageDataUrl({ src }: { src: string }): boolean {
+  return src.toLowerCase().startsWith('data:image/')
+}
+
+/** Проверяет, что browser API не смог прочитать image src и можно оставить исходный src. */
+function isRecoverableImageReadError({ error }: { error: unknown }): boolean {
+  if (error instanceof TypeError) return true
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) return true
 
   return false
 }
@@ -26,7 +41,7 @@ export default class BlobUrlRegistry {
   }
 
   /**
-   * Возвращает blob/data URL как есть или создаёт blob URL для удалённого src с кешированием.
+   * Возвращает blob URL как есть или создаёт blob URL для data/remote src с кешированием.
    */
   public async getOrCreateForSource({
     src,
@@ -35,10 +50,18 @@ export default class BlobUrlRegistry {
     src: string
     cache: Map<string, string>
   }): Promise<string | null> {
-    if (isBlobOrDataUrl({ src })) return src
+    if (isBlobUrl({ src })) return src
 
-    if (cache.has(src)) {
-      return cache.get(src) ?? null
+    const cachedBlobUrl = cache.get(src)
+    if (cachedBlobUrl) return cachedBlobUrl
+
+    if (isDataUrl({ src })) {
+      const blobUrl = await this.createObjectUrlFromDataUrl({ src })
+      if (!blobUrl) return null
+
+      cache.set(src, blobUrl)
+
+      return blobUrl
     }
 
     const blobUrl = await this.fetchAsBlobUrl({ src })
@@ -50,7 +73,38 @@ export default class BlobUrlRegistry {
   }
 
   /**
-   * Загружает изображение по URL и возвращает blob URL. При ошибке возвращает null.
+   * Создаёт blob URL для image data URL. Если browser API не смог прочитать src, возвращает null.
+   */
+  public async createObjectUrlFromDataUrl({ src }: { src: string }): Promise<string | null> {
+    if (!isImageDataUrl({ src })) return null
+
+    const blob = await this.fetchImageDataUrlAsBlob({ src })
+    if (!blob) return null
+
+    return this.createObjectUrl({ source: blob })
+  }
+
+  /**
+   * Читает image data URL через browser fetch/blob API.
+   */
+  private async fetchImageDataUrlAsBlob({ src }: { src: string }): Promise<Blob | null> {
+    try {
+      const response = await fetch(src)
+      if (!response.ok) return null
+
+      const blob = await response.blob()
+      if (!blob.type.toLowerCase().startsWith('image/')) return null
+
+      return blob
+    } catch (error) {
+      if (!isRecoverableImageReadError({ error })) throw error
+
+      return null
+    }
+  }
+
+  /**
+   * Загружает изображение по URL и возвращает blob URL. Если browser API не смог прочитать src, возвращает null.
    */
   public async fetchAsBlobUrl({ src }: { src: string }): Promise<string | null> {
     try {
@@ -62,7 +116,9 @@ export default class BlobUrlRegistry {
       const blobUrl = this.createObjectUrl({ source: blob })
 
       return blobUrl
-    } catch {
+    } catch (error) {
+      if (!isRecoverableImageReadError({ error })) throw error
+
       return null
     }
   }

--- a/src/editor/image-manager/index.ts
+++ b/src/editor/image-manager/index.ts
@@ -1,6 +1,5 @@
 import { CanvasOptions, FabricObject, FabricImage } from 'fabric'
 
-import type { CanvasFullState } from '../history-manager'
 import BlobUrlRegistry from './blob-url-registry'
 import {
   createCanvasExportRequest,
@@ -93,15 +92,19 @@ export default class ImageManager {
   }
 
   /**
-   * Подготавливает initialState: заменяет src у изображений на blob-URL с кешированием.
+   * Подготавливает serialized state: заменяет src у изображений на blob URL с кешированием.
    * Если запрос не удался (например, CORS), src остаётся исходным.
    */
-  public async prepareInitialState({ state }: { state: CanvasFullState }): Promise<CanvasFullState> {
+  public async prepareSerializedImageSources<State extends { objects?: unknown[] } | null | undefined>({
+    state
+  }: {
+    state: State
+  }): Promise<State> {
     if (!state) return state
 
-    const clonedState = JSON.parse(JSON.stringify(state)) as CanvasFullState
+    const clonedState = JSON.parse(JSON.stringify(state)) as NonNullable<State>
     const cache = new Map<string, string>()
-    const { objects = [] } = clonedState
+    const objects = Array.isArray(clonedState.objects) ? clonedState.objects : []
 
     await replaceImageSrcInObjects({
       objects,
@@ -109,7 +112,7 @@ export default class ImageManager {
       blobUrls: this._blobUrls
     })
 
-    return clonedState
+    return clonedState as State
   }
 
   /**

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -317,7 +317,7 @@ export class ImageEditor {
       this.historyManager.suspendHistory()
 
       try {
-        const preparedState = await this.imageManager.prepareInitialState({
+        const preparedState = await this.imageManager.prepareSerializedImageSources({
           state: initialState as CanvasFullState
         })
 

--- a/src/editor/template-manager/README.md
+++ b/src/editor/template-manager/README.md
@@ -1,0 +1,38 @@
+# TemplateManager
+
+`TemplateManager` owns template serialization and template application. A template is serialized editor content, not a live Fabric object tree. The manager must prepare that serialized content before Fabric restores it and must leave the caller's template object unchanged.
+
+## Apply Flow
+
+`TemplateManager.applyTemplate()` is the transaction boundary:
+
+1. Validate that the template contains objects and that the montage area has usable bounds.
+2. Normalize template metadata and calculate the scale for the current montage area.
+3. Suspend history.
+4. Ask `ImageManager.prepareSerializedImageSources()` to prepare a cloned template.
+5. Restore Fabric objects from the prepared clone.
+6. Apply background objects through `BackgroundManager`; add content objects to the canvas.
+7. Rehydrate text and shape geometry before the objects are inserted.
+8. Materialize fresh object ids, render, fire `editor:template-applied`, resume history, and save state when something was inserted.
+
+The event payload keeps the original template object. Runtime-only `blob:` URLs from image source preparation must not be exposed as a new public template format.
+
+## Image Sources
+
+Image objects in templates can contain remote URLs, `blob:` URLs, or `data:image/...` URLs. `TemplateManager` does not parse or fetch those sources itself. It delegates to `ImageManager` so `initialState` restore and template restore use the same rules:
+
+- `blob:` stays unchanged;
+- valid `data:image/...` becomes a managed `blob:` URL before `fabric.util.enlivenObjects()`;
+- remote URLs are fetched into managed `blob:` URLs when possible;
+- invalid or non-image `data:` URLs remain unchanged;
+- the original template passed to `applyTemplate()` is not mutated.
+
+This keeps large base64 image payloads out of Fabric live objects and out of template-created history snapshots after user actions such as scaling.
+
+## When Changing This Manager
+
+- Keep restore-time source preparation before `_enlivenObjects()`. Fabric should receive already prepared image `src` values.
+- Do not add image-specific parsing here. If the rule is about image source materialization, it belongs in `ImageManager` or `BlobUrlRegistry`.
+- Keep geometry rehydration before `canvas.add()`. Text, shape, and image dimensions should be canonical before the object enters the live canvas.
+- Keep `editor:template-applied` stable for users: original template in the event, inserted Fabric objects in `objects`, montage bounds in `bounds`.
+- When changing apply behavior, test template insertion, background extraction, history save, object identity materialization, and image scaling after insertion.

--- a/src/editor/template-manager/index.ts
+++ b/src/editor/template-manager/index.ts
@@ -10,7 +10,7 @@ import {
 } from 'fabric'
 import { nanoid } from 'nanoid'
 
-import { ImageEditor } from '../index'
+import type { ImageEditor } from '../index'
 import { errorCodes } from '../error-manager/error-codes'
 import { OBJECT_SERIALIZATION_PROPS } from '../history-manager'
 import {
@@ -215,7 +215,8 @@ export default class TemplateManager {
       errorManager,
       backgroundManager,
       shapeManager,
-      textManager
+      textManager,
+      imageManager
     } = this.editor
 
     const { objects, meta: templateMeta, id: templateId } = template ?? {}
@@ -254,9 +255,12 @@ export default class TemplateManager {
     historyManager.suspendHistory()
 
     try {
+      const preparedTemplate = await imageManager.prepareSerializedImageSources({ state: template })
+      const preparedObjects = Array.isArray(preparedTemplate.objects) ? preparedTemplate.objects : []
+
       // Восстанавливаем Fabric-объекты из сохранённых данных шаблона
       const enlivenedObjects = await TemplateManager._enlivenObjects({
-        objects,
+        objects: preparedObjects,
         baseWidth: meta.baseWidth,
         baseHeight: meta.baseHeight,
         useRelativePositions


### PR DESCRIPTION
**Изменения**

- Перед восстановлением объектов при применении темплейтов кешируем их как blob-объекты
- `data:image/...` в `initialState` и шаблонах теперь заменяется на временный `blob:` URL.
- Исправлена проблема, при которой после масштабирования картинки из шаблона в историю мог возвращаться большой `base64` payload.
- Добавлена команда `npm run typecheck`.
- Обновлена документация по `ImageManager` и `TemplateManager`.

**Breaking Changes**
- Удалён метод `ImageManager.prepareInitialState()`.
- Вместо него нужно использовать `ImageManager.prepareSerializedImageSources({ state })`.
- Новый метод подходит и для `initialState`, и для шаблонов.