### PR TITLE
DeletionManager & ClipboardManager. Добавляем возможность указывать правила для удаления объектов и их копирования/дублирования

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A modern, powerful browser-based image editor built with [FabricJS](https://fabr
 - **Font Loader** - FontManager handles Google Fonts + custom sources with automatic `@font-face` registration
 - **Configurable Toolbar** - Dynamic toolbar with context-sensitive actions
 - **Clipboard Integration** - Native copy/paste support with system clipboard
+- **Deletion Guards** - Application-defined rules can prevent user deletion for protected objects
+- **Clone Preparation** - Applications can sanitize object clones before copy, paste, duplicate, or cut
 
 ### Developer Features
 - **TypeScript Support** - Full type definitions included
@@ -71,6 +73,44 @@ document.addEventListener('DOMContentLoaded', async () => {
   console.log('Editor initialized:', editor)
 })
 ```
+
+### Deletion Guards and Clone Preparation
+
+The editor does not know application-specific object roles. If an application needs to protect a domain object from user deletion, pass a rule through `canDeleteObject`.
+
+```javascript
+const MAIN_IMAGE_HANDLE = 'main-image'
+
+const editor = await initEditor('editor', {
+  canDeleteObject: (object) => {
+    return object.customData?.handle !== MAIN_IMAGE_HANDLE
+  }
+})
+```
+
+The rule is checked by shared delete operations, so keyboard deletion, toolbar deletion, direct `DeletionManager` calls, and `cut()` use the same result. Locked objects are still skipped by the editor itself. If a technical operation must delete a protected object, call deletion with `ignoreDeleteGuard: true`.
+
+When deletion is skipped by the guard, the editor fires `editor:objects-delete-skipped`. The event is only a notification for UI code; it does not cancel deletion, because the decision was already made by `canDeleteObject`.
+
+```javascript
+editor.canvas.on('editor:objects-delete-skipped', ({ skippedObjects }) => {
+  console.log('Some objects were not deleted:', skippedObjects)
+})
+```
+
+Use `prepareObjectClone` when copied objects must not keep a domain marker from the source object. The callback receives only clones. The editor calls it for the root clone and for nested objects inside groups or active selections.
+
+```javascript
+const editor = await initEditor('editor', {
+  prepareObjectClone: (object) => {
+    if (object.customData?.handle !== MAIN_IMAGE_HANDLE) return
+
+    delete object.customData.handle
+  }
+})
+```
+
+This hook is used by `copy()`, `cut()`, `copyPaste()`, and `paste()`. Before the hook is called, the editor detaches `customData` on the clone so the callback does not accidentally mutate the original object.
 
 ### Working with Images
 
@@ -398,9 +438,9 @@ The editor follows a modular architecture with specialized managers:
 
 ### Utility Managers
 - **`SelectionManager`** - Object selection and multi-selection handling
-- **`ClipboardManager`** - Copy/paste with system clipboard integration
+- **`ClipboardManager`** - Copy/paste, cut, duplicate, clone preparation, and system clipboard integration
 - **`GroupingManager`** - Object grouping and ungrouping operations
-- **`DeletionManager`** - Object deletion with group handling
+- **`DeletionManager`** - Object deletion, delete guards, skipped-delete events, and group handling
 - **`ShapeManager`** - Preset-based shape groups with inner text, layout, scaling, and style controls
 - **`ObjectLockManager`** - Object locking and unlocking functionality
 - **`SnappingManager`** - Alignment guides and equal-spacing snaps while moving objects
@@ -451,7 +491,13 @@ initEditor(containerId, options): Promise<ImageEditor>
   acceptContentTypes: ['image/png', 'image/jpeg', 'image/svg+xml'],
 
   // Callback when ready
-  _onReadyCallback: (editor) => console.log('Ready!')
+  _onReadyCallback: (editor) => console.log('Ready!'),
+
+  // Optional user-delete rule. Return false to skip this object.
+  canDeleteObject: (object) => true,
+
+  // Optional clone preparation for copy, cut, duplicate, and paste.
+  prepareObjectClone: (object) => {}
 }
 ```
 

--- a/e2e/helpers/browser/editor-browser-helpers.installer.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.installer.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserDeleteSkippedEventRecord,
   BrowserEditorHelpers,
   BrowserSelectionScaleFromControlParams,
   BrowserSelectionScaleFromControlResult,
@@ -22,6 +23,13 @@ type BrowserControlPoint = {
   y: number
 }
 
+/** Browser-side payload события editor:objects-delete-skipped. */
+type BrowserDeleteSkippedEventPayload = {
+  requestedObjects?: unknown[]
+  skippedObjects?: unknown[]
+  withoutSave?: boolean
+}
+
 /** Window на момент установки helpers: editor может появиться после init приложения. */
 type BrowserEditorWindowInstallerTarget = Window & {
   editor?: BrowserEditorWindow['editor']
@@ -33,6 +41,8 @@ type BrowserEditorWindowInstallerTarget = Window & {
  */
 export function installEditorBrowserHelpers(): void {
   const browserWindow: BrowserEditorWindowInstallerTarget = window
+  let deleteSkippedEventRecords: BrowserDeleteSkippedEventRecord[] = []
+  let deleteSkippedEventHandler: ((event: BrowserDeleteSkippedEventPayload) => void) | null = null
 
   /**
    * Возвращает editor runtime после завершения init приложения.
@@ -120,6 +130,64 @@ export function installEditorBrowserHelpers(): void {
     if (typeof value === 'string') return value
 
     return null
+  }
+
+  /**
+   * Возвращает id объекта для компактной записи события.
+   */
+  function resolveObjectId({ value }: { value: unknown }): string | null {
+    const object = toBrowserObject({ value })
+
+    return resolveNullableString({
+      value: object.id
+    })
+  }
+
+  /**
+   * Создаёт сериализуемую запись события отказа удаления.
+   */
+  function createDeleteSkippedEventRecord({
+    payload
+  }: {
+    payload: BrowserDeleteSkippedEventPayload
+  }): BrowserDeleteSkippedEventRecord {
+    const requestedObjects = Array.isArray(payload.requestedObjects) ? payload.requestedObjects : []
+    const skippedObjects = Array.isArray(payload.skippedObjects) ? payload.skippedObjects : []
+
+    return {
+      requestedCount: requestedObjects.length,
+      requestedIds: requestedObjects.map((object) => resolveObjectId({ value: object })),
+      skippedCount: skippedObjects.length,
+      skippedIds: skippedObjects.map((object) => resolveObjectId({ value: object })),
+      withoutSave: typeof payload.withoutSave === 'boolean' ? payload.withoutSave : null
+    }
+  }
+
+  /**
+   * Начинает запись событий отказа удаления для текущего editor runtime.
+   */
+  function startDeleteSkippedEventRecording(): void {
+    const { canvas } = getEditorRuntime()
+
+    if (deleteSkippedEventHandler) {
+      canvas.off('editor:objects-delete-skipped', deleteSkippedEventHandler)
+    }
+
+    deleteSkippedEventRecords = []
+    deleteSkippedEventHandler = (payload) => {
+      deleteSkippedEventRecords.push(createDeleteSkippedEventRecord({
+        payload
+      }))
+    }
+
+    canvas.on('editor:objects-delete-skipped', deleteSkippedEventHandler)
+  }
+
+  /**
+   * Возвращает записанные события отказа удаления.
+   */
+  function getDeleteSkippedEventRecords(): BrowserDeleteSkippedEventRecord[] {
+    return [...deleteSkippedEventRecords]
   }
 
   /**
@@ -1207,6 +1275,12 @@ export function installEditorBrowserHelpers(): void {
       },
       getShapeTextSelectionStyles(params: BrowserTextSelectionStyleParams) {
         return getShapeTextSelectionStyles(params)
+      },
+      startDeleteSkippedEventRecording() {
+        startDeleteSkippedEventRecording()
+      },
+      getDeleteSkippedEventRecords() {
+        return getDeleteSkippedEventRecords()
       }
     }
 

--- a/e2e/helpers/browser/editor-browser-helpers.types.ts
+++ b/e2e/helpers/browser/editor-browser-helpers.types.ts
@@ -114,6 +114,15 @@ export type BrowserSnappingSpacingGuideInfo = {
   distance: number
 }
 
+/** Browser-side запись события о пропущенных при удалении объектах. */
+export type BrowserDeleteSkippedEventRecord = {
+  requestedCount: number
+  requestedIds: Array<string | null>
+  skippedCount: number
+  skippedIds: Array<string | null>
+  withoutSave: boolean | null
+}
+
 export type BrowserSnappingGuideState = {
   guides: BrowserSnappingGuideInfo[]
   spacingGuides: BrowserSnappingSpacingGuideInfo[]
@@ -170,6 +179,8 @@ export interface BrowserEditorHelpers {
   getSnappingGuideState: () => BrowserSnappingGuideState
   getTextSelectionStyles: (params: BrowserTextSelectionStyleParams) => BrowserTextSelectionStyleInfo | null
   getShapeTextSelectionStyles: (params: BrowserTextSelectionStyleParams) => BrowserTextSelectionStyleInfo | null
+  startDeleteSkippedEventRecording: () => void
+  getDeleteSkippedEventRecords: () => BrowserDeleteSkippedEventRecord[]
 }
 
 export interface BoundsInfo {
@@ -195,6 +206,8 @@ export interface BrowserEditorWindow extends Window {
         target?: unknown
       } | null
       getActiveObject: () => unknown
+      on: <EventPayload>(eventName: string, handler: (event: EventPayload) => void) => void
+      off: <EventPayload>(eventName: string, handler: (event: EventPayload) => void) => void
       __onMouseDown: (event: MouseEvent) => void
       __onMouseMove: (event: MouseEvent) => void
       upperCanvasEl: {

--- a/e2e/models/editor.model.ts
+++ b/e2e/models/editor.model.ts
@@ -12,6 +12,7 @@ import type {
   ViewportPanInfo,
   ViewportScrollbarInfo,
   ViewportBoundsInfo,
+  DeleteSkippedEventInfo,
   ObjectTargetParams,
   SnappingObjectSnapshot
 } from '../types'
@@ -154,6 +155,101 @@ export class EditorModel {
     })
 
     await waitForCanvasRender({ page: this.page })
+  }
+
+  /** Включает e2e-правило защиты объектов с заданным customData.handle. */
+  async useCustomDataDeleteGuard(params: { handle: string }): Promise<void> {
+    await this.page.evaluate(({ handle }) => {
+      const { editor } = window as any
+      const hasProtectedHandle = (object: any) => object?.customData?.handle === handle
+
+      editor.options.canDeleteObject = (object: any) => !hasProtectedHandle(object)
+      editor.options.prepareObjectClone = (rootObject: any) => {
+        const objectsToPrepare = [rootObject]
+
+        for (let index = 0; index < objectsToPrepare.length; index += 1) {
+          const object = objectsToPrepare[index]
+
+          if (hasProtectedHandle(object)) {
+            delete object.customData.handle
+          }
+
+          if (typeof object?.getObjects !== 'function') continue
+
+          const childObjects = object.getObjects()
+          if (!Array.isArray(childObjects)) continue
+
+          for (let childIndex = 0; childIndex < childObjects.length; childIndex += 1) {
+            objectsToPrepare.push(childObjects[childIndex])
+          }
+        }
+      }
+    }, params)
+  }
+
+  /** Начинает запись событий отказа удаления в browser-side e2e-хелпере. */
+  async startDeleteSkippedEventRecording(): Promise<void> {
+    await this.page.evaluate(() => {
+      const { __editorHelpers: helpers } = window as any
+
+      helpers.startDeleteSkippedEventRecording()
+    })
+  }
+
+  /** Возвращает записанные события отказа удаления. */
+  async getDeleteSkippedEvents(): Promise<DeleteSkippedEventInfo[]> {
+    return this.page.evaluate(() => {
+      const { __editorHelpers: helpers } = window as any
+
+      return helpers.getDeleteSkippedEventRecords()
+    })
+  }
+
+  /** Задаёт customData объекту на canvas через browser-side model boundary. */
+  async setObjectCustomData(params: ObjectTargetParams & { customData: Record<string, unknown> }): Promise<void> {
+    const updated = await this.page.evaluate(({ customData, id, objectIndex }) => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+      const target = helpers.resolveCanvasObject(objectIndex, id)
+
+      if (!target) return false
+
+      if (typeof target.set === 'function') {
+        target.set({ customData })
+      } else {
+        target.customData = customData
+      }
+
+      editor.canvas.requestRenderAll()
+      return true
+    }, params)
+
+    expect(updated, 'объект для установки customData должен существовать').toBe(true)
+    await waitForCanvasRender({ page: this.page })
+  }
+
+  /** Возвращает customData.handle объекта или null. */
+  async getObjectCustomDataHandle(params: ObjectTargetParams = {}): Promise<string | null> {
+    return this.page.evaluate(({ id, objectIndex }) => {
+      const { __editorHelpers: helpers } = window as any
+      const target = helpers.resolveCanvasObject(objectIndex, id)
+      const handle = target?.customData?.handle
+
+      return typeof handle === 'string' ? handle : null
+    }, params)
+  }
+
+  /** Считает пользовательские объекты с заданным customData.handle. */
+  async countObjectsByCustomDataHandle(params: { handle: string }): Promise<number> {
+    return this.page.evaluate(({ handle }) => {
+      const { editor } = window as any
+
+      return editor.canvasManager.getObjects().filter((object: any) => {
+        return object?.customData?.handle === handle
+      }).length
+    }, params)
   }
 
   /** Возвращает снимок текущего состояния canvas */
@@ -732,6 +828,24 @@ export class EditorModel {
     await this._pressEditorHotkey({
       key: 'd',
       code: 'KeyD'
+    })
+  }
+
+  /** Отправляет в редактор клавишу Delete через DOM-событие body. */
+  async pressDeleteKey(): Promise<void> {
+    await this._pressEditorHotkey({
+      key: 'Delete',
+      code: 'Delete',
+      ctrlKey: false
+    })
+  }
+
+  /** Отправляет в редактор клавишу Backspace через DOM-событие body. */
+  async pressBackspaceKey(): Promise<void> {
+    await this._pressEditorHotkey({
+      key: 'Backspace',
+      code: 'Backspace',
+      ctrlKey: false
     })
   }
 

--- a/e2e/tests/delete-guard.spec.ts
+++ b/e2e/tests/delete-guard.spec.ts
@@ -1,0 +1,350 @@
+import { test, expect } from '../fixtures/editor.fixture'
+
+const PROTECTED_HANDLE = 'main-image'
+
+test.describe('Защита объектов от удаления', () => {
+  test.beforeEach(async({ editorModel }) => {
+    await editorModel.useCustomDataDeleteGuard({
+      handle: PROTECTED_HANDLE
+    })
+    await editorModel.startDeleteSkippedEventRecording()
+  })
+
+  test('Delete оставляет защищённый объект на canvas и пишет событие отказа', async({
+    editorModel,
+    shapes
+  }) => {
+    const protectedShapeId = 'delete-protected-shape'
+
+    await test.step('Добавить и выделить защищённый объект', async() => {
+      const shape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          id: protectedShapeId,
+          left: 120,
+          top: 120
+        }
+      })
+
+      shapes.checkCreation({ shape, presetKey: 'square' })
+      await editorModel.setObjectCustomData({
+        id: protectedShapeId,
+        customData: {
+          handle: PROTECTED_HANDLE,
+          keep: 'asset-id'
+        }
+      })
+      await shapes.select({ id: protectedShapeId })
+    })
+
+    await test.step('Нажать Delete', async() => {
+      await editorModel.pressDeleteKey()
+    })
+
+    await test.step('Проверить что объект остался и событие записалось', async() => {
+      const handle = await editorModel.getObjectCustomDataHandle({ id: protectedShapeId })
+      const events = await editorModel.getDeleteSkippedEvents()
+
+      await editorModel.checkObjectCount({ count: 1 })
+      expect(handle).toBe(PROTECTED_HANDLE)
+      expect(events).toEqual([expect.objectContaining({
+        requestedCount: 1,
+        requestedIds: [protectedShapeId],
+        skippedCount: 1,
+        skippedIds: [protectedShapeId],
+        withoutSave: false
+      })])
+    })
+  })
+
+  test('Backspace оставляет защищённый объект на canvas и пишет событие отказа', async({
+    editorModel,
+    shapes
+  }) => {
+    const protectedShapeId = 'backspace-protected-shape'
+
+    await test.step('Добавить и выделить защищённый объект', async() => {
+      const shape = await shapes.add({
+        presetKey: 'circle',
+        options: {
+          id: protectedShapeId,
+          left: 160,
+          top: 140
+        }
+      })
+
+      shapes.checkCreation({ shape, presetKey: 'circle' })
+      await editorModel.setObjectCustomData({
+        id: protectedShapeId,
+        customData: {
+          handle: PROTECTED_HANDLE
+        }
+      })
+      await shapes.select({ id: protectedShapeId })
+    })
+
+    await test.step('Нажать Backspace', async() => {
+      await editorModel.pressBackspaceKey()
+    })
+
+    await test.step('Проверить что объект остался и событие записалось', async() => {
+      const protectedShape = await shapes.getObject({ id: protectedShapeId })
+      const events = await editorModel.getDeleteSkippedEvents()
+
+      expect(protectedShape).not.toBeNull()
+      await editorModel.checkObjectCount({ count: 1 })
+      expect(events).toEqual([expect.objectContaining({
+        requestedCount: 1,
+        requestedIds: [protectedShapeId],
+        skippedCount: 1,
+        skippedIds: [protectedShapeId],
+        withoutSave: false
+      })])
+    })
+  })
+
+  test('Ctrl+A и Delete удаляет обычные объекты и оставляет защищённый', async({
+    editorModel,
+    shapes
+  }) => {
+    const protectedShapeId = 'delete-selection-protected-shape'
+    const regularShapeId = 'delete-selection-regular-shape'
+
+    await test.step('Добавить защищённый и обычный объекты', async() => {
+      const protectedShape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          id: protectedShapeId,
+          left: 130,
+          top: 130
+        }
+      })
+      const regularShape = await shapes.add({
+        presetKey: 'circle',
+        options: {
+          id: regularShapeId,
+          left: 300,
+          top: 220
+        }
+      })
+
+      shapes.checkCreation({ shape: protectedShape, presetKey: 'square' })
+      shapes.checkCreation({ shape: regularShape, presetKey: 'circle' })
+      await editorModel.setObjectCustomData({
+        id: protectedShapeId,
+        customData: {
+          handle: PROTECTED_HANDLE
+        }
+      })
+    })
+
+    await test.step('Выделить всё и нажать Delete', async() => {
+      await editorModel.selectAllObjects()
+      await editorModel.pressDeleteKey()
+      await editorModel.waitForObjectCount({ count: 1 })
+    })
+
+    await test.step('Проверить что обычный объект удалён, а защищённый остался', async() => {
+      const protectedShape = await shapes.getObject({ id: protectedShapeId })
+      const regularShape = await shapes.getObject({ id: regularShapeId })
+      const events = await editorModel.getDeleteSkippedEvents()
+
+      expect(protectedShape).not.toBeNull()
+      expect(regularShape).toBeNull()
+      expect(events).toHaveLength(1)
+      expect(events[0]).toEqual(expect.objectContaining({
+        requestedCount: 2,
+        skippedCount: 1,
+        skippedIds: [protectedShapeId]
+      }))
+    })
+  })
+
+  test('кнопка "Удалить" удаляет из выделения только обычные объекты', async({
+    editorModel,
+    shapes,
+    toolbar
+  }) => {
+    const protectedShapeId = 'toolbar-protected-shape'
+    const regularShapeId = 'toolbar-regular-shape'
+
+    await test.step('Добавить защищённый и обычный объекты', async() => {
+      const protectedShape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          id: protectedShapeId,
+          left: 140,
+          top: 130
+        }
+      })
+      const regularShape = await shapes.add({
+        presetKey: 'circle',
+        options: {
+          id: regularShapeId,
+          left: 300,
+          top: 230
+        }
+      })
+
+      shapes.checkCreation({ shape: protectedShape, presetKey: 'square' })
+      shapes.checkCreation({ shape: regularShape, presetKey: 'circle' })
+      await editorModel.setObjectCustomData({
+        id: protectedShapeId,
+        customData: {
+          handle: PROTECTED_HANDLE
+        }
+      })
+    })
+
+    await test.step('Создать массовое выделение и нажать кнопку "Удалить"', async() => {
+      await editorModel.selectAllObjects()
+      await toolbar.waitUntilVisible()
+      await toolbar.clickAction({
+        name: 'Удалить'
+      })
+      await editorModel.waitForObjectCount({ count: 1 })
+    })
+
+    await test.step('Проверить что обычный объект удалён, а защищённый остался', async() => {
+      const protectedShape = await shapes.getObject({ id: protectedShapeId })
+      const regularShape = await shapes.getObject({ id: regularShapeId })
+      const events = await editorModel.getDeleteSkippedEvents()
+
+      expect(protectedShape).not.toBeNull()
+      expect(regularShape).toBeNull()
+      expect(events).toHaveLength(1)
+      expect(events[0]).toEqual(expect.objectContaining({
+        requestedCount: 2,
+        skippedCount: 1,
+        skippedIds: [protectedShapeId]
+      }))
+    })
+  })
+
+  test('Ctrl+X вырезает только обычные объекты и не создаёт второго защищённого после вставки', async({
+    clipboard,
+    editorModel,
+    shapes
+  }) => {
+    const protectedShapeId = 'cut-protected-shape'
+    const regularShapeId = 'cut-regular-shape'
+
+    await test.step('Добавить защищённый и обычный объекты', async() => {
+      const protectedShape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          id: protectedShapeId,
+          left: 120,
+          top: 130
+        }
+      })
+      const regularShape = await shapes.add({
+        presetKey: 'circle',
+        options: {
+          id: regularShapeId,
+          left: 300,
+          top: 220
+        }
+      })
+
+      shapes.checkCreation({ shape: protectedShape, presetKey: 'square' })
+      shapes.checkCreation({ shape: regularShape, presetKey: 'circle' })
+      await editorModel.setObjectCustomData({
+        id: protectedShapeId,
+        customData: {
+          handle: PROTECTED_HANDLE,
+          keep: 'asset-id'
+        }
+      })
+    })
+
+    await test.step('Выделить всё и нажать Ctrl+X', async() => {
+      await editorModel.selectAllObjects()
+      await editorModel.pressCutHotkey()
+      await editorModel.waitForObjectCount({ count: 1 })
+      await clipboard.waitForClipboardReady()
+    })
+
+    await test.step('Проверить что вырезался только обычный объект', async() => {
+      const protectedShape = await shapes.getObject({ id: protectedShapeId })
+      const regularShape = await shapes.getObject({ id: regularShapeId })
+      const events = await editorModel.getDeleteSkippedEvents()
+
+      expect(protectedShape).not.toBeNull()
+      expect(regularShape).toBeNull()
+      expect(events).toHaveLength(1)
+      expect(events[0]).toEqual(expect.objectContaining({
+        requestedCount: 2,
+        skippedCount: 1,
+        skippedIds: [protectedShapeId]
+      }))
+    })
+
+    await test.step('Вставить объект из буфера и проверить защищающий признак', async() => {
+      const pasted = await clipboard.paste()
+      const protectedObjectsCount = await editorModel.countObjectsByCustomDataHandle({
+        handle: PROTECTED_HANDLE
+      })
+
+      expect(pasted).toBe(true)
+      await editorModel.checkObjectCount({ count: 2 })
+      expect(protectedObjectsCount).toBe(1)
+    })
+  })
+
+  test('Ctrl+D создаёт копию защищённого объекта без защищающего признака', async({
+    editorModel,
+    shapes
+  }) => {
+    const protectedShapeId = 'duplicate-protected-shape'
+
+    await test.step('Добавить и выделить защищённый объект', async() => {
+      const shape = await shapes.add({
+        presetKey: 'square',
+        options: {
+          id: protectedShapeId,
+          left: 160,
+          top: 150
+        }
+      })
+
+      shapes.checkCreation({ shape, presetKey: 'square' })
+      await editorModel.setObjectCustomData({
+        id: protectedShapeId,
+        customData: {
+          handle: PROTECTED_HANDLE,
+          keep: 'asset-id'
+        }
+      })
+      await shapes.select({ id: protectedShapeId })
+    })
+
+    await test.step('Нажать Ctrl+D', async() => {
+      await editorModel.pressDuplicateHotkey()
+      await editorModel.waitForObjectCount({ count: 2 })
+    })
+
+    await test.step('Проверить что только исходный объект остался защищённым', async() => {
+      const shapeObjects = await shapes.getShapeObjects()
+      const duplicateShape = shapeObjects.find((shape) => shape.id !== protectedShapeId)
+      const originalHandle = await editorModel.getObjectCustomDataHandle({ id: protectedShapeId })
+      const protectedObjectsCount = await editorModel.countObjectsByCustomDataHandle({
+        handle: PROTECTED_HANDLE
+      })
+
+      expect(duplicateShape, 'после Ctrl+D должна появиться копия объекта').toBeDefined()
+
+      if (!duplicateShape?.id) {
+        throw new Error('У копии после Ctrl+D должен быть id')
+      }
+
+      const duplicateHandle = await editorModel.getObjectCustomDataHandle({
+        id: duplicateShape.id
+      })
+
+      expect(originalHandle).toBe(PROTECTED_HANDLE)
+      expect(duplicateHandle).toBeNull()
+      expect(protectedObjectsCount).toBe(1)
+    })
+  })
+})

--- a/e2e/types/editor.types.ts
+++ b/e2e/types/editor.types.ts
@@ -138,6 +138,15 @@ export interface ObjectTargetParams {
   id?: string
 }
 
+/** Событие о пропущенных при удалении объектах, записанное e2e-хелпером. */
+export interface DeleteSkippedEventInfo {
+  requestedCount: number
+  requestedIds: Array<string | null>
+  skippedCount: number
+  skippedIds: Array<string | null>
+  withoutSave: boolean | null
+}
+
 /** Параметры сериализации шаблона из текущего выделения */
 export interface SerializeTemplateParams {
   templateId?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.02",
+  "version": "0.10.03",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.10.02",
+      "version": "0.10.03",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",
@@ -67,13 +67,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -92,21 +92,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -123,14 +123,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -140,14 +140,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -167,29 +167,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -229,9 +229,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -239,27 +239,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -517,33 +517,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -551,14 +551,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -717,21 +717,21 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -740,9 +740,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1101,9 +1101,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1937,9 +1937,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -2004,9 +2004,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -2021,9 +2021,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -2038,9 +2038,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -2055,9 +2055,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -2072,13 +2072,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2089,13 +2092,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2106,13 +2112,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,13 +2132,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,13 +2152,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2157,13 +2172,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2174,9 +2192,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -2191,9 +2209,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -2201,21 +2219,23 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -2227,9 +2247,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -2244,9 +2264,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -2261,9 +2281,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2331,9 +2351,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3474,9 +3494,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.9",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.9.tgz",
-      "integrity": "sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==",
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3555,9 +3575,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -3575,11 +3595,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3714,9 +3734,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
         {
@@ -4189,9 +4209,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -4221,9 +4241,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.388",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
+      "integrity": "sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==",
       "dev": true,
       "license": "ISC"
     },
@@ -5085,9 +5105,9 @@
       }
     },
     "node_modules/fabric": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/fabric/-/fabric-7.2.0.tgz",
-      "integrity": "sha512-XSYmSqSMrlbCg+/j7/uU/PFeZuA5hHRDp7sGbDlMvz/T6BHt2MQSOYtz/AIdr+kmReA1s5jTzHJ8AjHwYUcmfQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-7.4.0.tgz",
+      "integrity": "sha512-NalYDc3eifTl1C33zryQwpH6+XA/2ClxQrH9vkASkZw3tbkRmorpikhYMmxhUTmi7O3e9ODz0vOT8qfaCh9IVA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -7594,10 +7614,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8330,11 +8360,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8899,9 +8932,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -8942,9 +8975,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -9397,14 +9430,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -9413,21 +9446,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -10179,14 +10212,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -10778,17 +10811,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -10804,7 +10837,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.02",
+  "version": "0.10.03",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/clipboard-manager/index.spec.ts
+++ b/specs/src/editor/clipboard-manager/index.spec.ts
@@ -24,6 +24,14 @@ type ClipboardTextObject = {
   uppercase?: boolean
 }
 
+type ClipboardCustomDataObject = {
+  customData?: {
+    handle?: string
+    keep?: string
+  }
+  id?: string
+}
+
 type AddedCanvasObject = {
   id?: string
   evented?: boolean
@@ -112,6 +120,78 @@ describe('ClipboardManager', () => {
       expect(clipboardManager.clipboard).toBeNull()
       expect(mockCanvas.fire).not.toHaveBeenCalled()
     })
+
+    it('перед сохранением в буфер подготавливает клон, а не исходный объект', async() => {
+      const mockObject = createMockFabricObject({
+        type: 'image',
+        id: 'main-image',
+        customData: {
+          handle: 'main-image',
+          keep: 'asset-id'
+        }
+      })
+
+      mockEditor.options.prepareObjectClone = jest.fn((object: ClipboardCustomDataObject) => {
+        if (object.customData?.handle !== 'main-image') return
+
+        delete object.customData.handle
+      })
+      mockCanvas.getActiveObject.mockReturnValue(mockObject)
+
+      clipboardManager.copy()
+      await new Promise(process.nextTick)
+
+      const clipboardObject = clipboardManager.clipboard as ClipboardCustomDataObject | null
+
+      expect(mockEditor.options.prepareObjectClone).toHaveBeenCalledTimes(1)
+      expect(clipboardObject?.customData).toEqual({
+        keep: 'asset-id'
+      })
+      expect(mockObject.customData).toEqual({
+        handle: 'main-image',
+        keep: 'asset-id'
+      })
+    })
+
+    it('отделяет customData клона перед внешней подготовкой', async() => {
+      const sharedCustomData = {
+        handle: 'main-image',
+        keep: 'asset-id'
+      }
+      const sourceObject = createMockFabricObject({
+        type: 'image',
+        id: 'source-main-image',
+        customData: sharedCustomData
+      })
+      const clonedObject = createMockFabricObject({
+        type: 'image',
+        id: 'cloned-main-image',
+        customData: sharedCustomData
+      })
+
+      sourceObject.clone.mockResolvedValue(clonedObject)
+      mockEditor.options.prepareObjectClone = jest.fn((object: ClipboardCustomDataObject) => {
+        if (object.customData?.handle !== 'main-image') return
+
+        delete object.customData.handle
+      })
+      mockCanvas.getActiveObject.mockReturnValue(sourceObject)
+
+      clipboardManager.copy()
+      await new Promise(process.nextTick)
+
+      const clipboardObject = clipboardManager.clipboard as ClipboardCustomDataObject | null
+
+      expect(clipboardObject).toBe(clonedObject)
+      expect(clipboardObject?.customData).toEqual({
+        keep: 'asset-id'
+      })
+      expect(sourceObject.customData).toEqual({
+        handle: 'main-image',
+        keep: 'asset-id'
+      })
+      expect(clipboardObject?.customData).not.toBe(sourceObject.customData)
+    })
   })
 
   describe('cut', () => {
@@ -190,6 +270,75 @@ describe('ClipboardManager', () => {
         message: 'Ошибка клонирования объекта для внутреннего буфера',
         data: expect.any(Error)
       })
+    })
+
+    it('вырезает из массового выделения только объекты, которые реально можно удалить', async() => {
+      const removableObject = createMockFabricObject({
+        type: 'rect',
+        id: 'cut-removable-object'
+      })
+      const protectedObject = createMockFabricObject({
+        type: 'image',
+        id: 'cut-protected-object',
+        customData: {
+          handle: 'main-image'
+        }
+      })
+      const selectedObjects = [removableObject, protectedObject]
+      const selection = createMockActiveSelection(selectedObjects, { left: 100, top: 100 })
+
+      mockCanvas.getActiveObject.mockReturnValue(selection)
+      mockEditor.deletionManager.resolveDeleteTargets.mockReturnValue({
+        requestedObjects: selectedObjects,
+        deletableObjects: [removableObject],
+        skippedObjects: [protectedObject]
+      })
+      mockEditor.deletionManager.deleteSelectedObjects.mockReturnValue({
+        objects: [removableObject],
+        withoutSave: false
+      })
+
+      const result = await clipboardManager.cut()
+      const clipboardObject = clipboardManager.clipboard as ClipboardCustomDataObject | null
+
+      expect(result).toBe(true)
+      expect(clipboardObject?.id).toBe('cut-removable-object')
+      expect(clipboardObject?.customData?.handle).toBeUndefined()
+      expect(mockEditor.deletionManager.deleteSelectedObjects).toHaveBeenCalledWith({
+        objects: selectedObjects
+      })
+      expect(mockCanvas.fire).toHaveBeenCalledWith('editor:object-copied', {
+        object: expect.objectContaining({
+          id: 'cut-removable-object'
+        })
+      })
+    })
+
+    it('не заполняет буфер, если в выделении нет удаляемых объектов', async() => {
+      const protectedObject = createMockFabricObject({
+        type: 'image',
+        id: 'cut-protected-object',
+        customData: {
+          handle: 'main-image'
+        }
+      })
+
+      mockCanvas.getActiveObject.mockReturnValue(protectedObject)
+      mockEditor.deletionManager.resolveDeleteTargets.mockReturnValue({
+        requestedObjects: [protectedObject],
+        deletableObjects: [],
+        skippedObjects: [protectedObject]
+      })
+      mockEditor.deletionManager.deleteSelectedObjects.mockReturnValue(null)
+
+      const result = await clipboardManager.cut()
+
+      expect(result).toBe(false)
+      expect(clipboardManager.clipboard).toBeNull()
+      expect(mockEditor.deletionManager.deleteSelectedObjects).toHaveBeenCalledWith({
+        objects: [protectedObject]
+      })
+      expect(mockCanvas.fire).not.toHaveBeenCalledWith('editor:object-copied', expect.any(Object))
     })
   })
 
@@ -348,6 +497,52 @@ describe('ClipboardManager', () => {
       expect(commitStandaloneTextScaleMock.mock.invocationCallOrder[0]).toBeLessThan(
         mockCanvas.add.mock.invocationCallOrder[0]
       )
+    })
+
+    it('при дублировании выделения подготавливает каждый вложенный клон', async() => {
+      const protectedObject = createMockFabricObject({
+        type: 'image',
+        id: 'duplicate-protected-object',
+        customData: {
+          handle: 'main-image',
+          keep: 'asset-id'
+        }
+      })
+      const regularObject = createMockFabricObject({
+        type: 'rect',
+        id: 'duplicate-regular-object',
+        customData: {
+          keep: 'regular-id'
+        }
+      })
+      const selection = createMockActiveSelection([protectedObject, regularObject], {
+        left: 100,
+        top: 80
+      })
+
+      mockEditor.options.prepareObjectClone = jest.fn((object: ClipboardCustomDataObject) => {
+        if (object.customData?.handle !== 'main-image') return
+
+        delete object.customData.handle
+      })
+      mockCanvas.getActiveObject.mockReturnValue(selection)
+
+      const result = await clipboardManager.copyPaste()
+      const addedObjects = (mockCanvas.add.mock.calls as Array<[ClipboardCustomDataObject]>).map(([object]) => object)
+
+      expect(result).toBe(true)
+      expect(mockEditor.options.prepareObjectClone).toHaveBeenCalledTimes(3)
+      expect(addedObjects).toHaveLength(2)
+      expect(addedObjects[0].customData).toEqual({
+        keep: 'asset-id'
+      })
+      expect(addedObjects[1].customData).toEqual({
+        keep: 'regular-id'
+      })
+      expect(protectedObject.customData).toEqual({
+        handle: 'main-image',
+        keep: 'asset-id'
+      })
     })
   })
 
@@ -638,6 +833,37 @@ describe('ClipboardManager', () => {
       expect(commitStandaloneTextScaleMock.mock.invocationCallOrder[0]).toBeLessThan(
         mockCanvas.add.mock.invocationCallOrder[0]
       )
+    })
+
+    it('при вставке подготавливает клон из старого внутреннего буфера', async() => {
+      const clipboardObject = createMockFabricObject({
+        type: 'image',
+        id: 'clipboard-main-image',
+        customData: {
+          handle: 'main-image',
+          keep: 'asset-id'
+        }
+      })
+
+      mockEditor.options.prepareObjectClone = jest.fn((object: ClipboardCustomDataObject) => {
+        if (object.customData?.handle !== 'main-image') return
+
+        delete object.customData.handle
+      })
+      clipboardManager.clipboard = clipboardObject
+
+      const result = await clipboardManager.paste()
+      const addedObject = mockCanvas.add.mock.calls[0][0] as ClipboardCustomDataObject
+
+      expect(result).toBe(true)
+      expect(mockEditor.options.prepareObjectClone).toHaveBeenCalledTimes(1)
+      expect(addedObject.customData).toEqual({
+        keep: 'asset-id'
+      })
+      expect(clipboardObject.customData).toEqual({
+        handle: 'main-image',
+        keep: 'asset-id'
+      })
     })
   })
 

--- a/specs/src/editor/deletion-manager/index.spec.ts
+++ b/specs/src/editor/deletion-manager/index.spec.ts
@@ -40,6 +40,54 @@ describe('DeletionManager', () => {
     })
   })
 
+  it('при удалении из режима редактирования текста удаляет владельца текста', () => {
+    const editingTextNode = createMockFabricObject({
+      type: 'textbox',
+      id: 'shape-text-node'
+    })
+    const shapeToDelete = createMockFabricObject({
+      type: 'shape-group',
+      id: 'shape-to-delete'
+    })
+
+    mockEditor.textManager.getActiveTextEditingOwner.mockReturnValue(shapeToDelete)
+    mockCanvas.getActiveObjects.mockReturnValue([editingTextNode])
+
+    const result = deletionManager.deleteSelectedObjects()
+
+    expect(mockEditor.textManager.getActiveTextEditingOwner).toHaveBeenCalledTimes(1)
+    expect(mockEditor.textManager.exitActiveTextEditing).toHaveBeenCalledTimes(1)
+    expect(mockCanvas.getActiveObjects).not.toHaveBeenCalled()
+    expect(mockCanvas.remove).toHaveBeenCalledWith(shapeToDelete)
+    expect(mockCanvas.remove).not.toHaveBeenCalledWith(editingTextNode)
+    expect(result).toEqual({
+      objects: [shapeToDelete],
+      withoutSave: false
+    })
+  })
+
+  it('не завершает редактирование текста, если удаление владельца запрещено', () => {
+    const protectedShape = createMockFabricObject({
+      type: 'shape-group',
+      id: 'protected-shape'
+    })
+
+    mockEditor.options.canDeleteObject = jest.fn(() => false)
+    mockEditor.textManager.getActiveTextEditingOwner.mockReturnValue(protectedShape)
+
+    const result = deletionManager.deleteSelectedObjects()
+
+    expect(result).toBeNull()
+    expect(mockEditor.textManager.exitActiveTextEditing).not.toHaveBeenCalled()
+    expect(mockCanvas.remove).not.toHaveBeenCalled()
+    expect(mockEditor.historyManager.saveState).not.toHaveBeenCalled()
+    expect(mockCanvas.fire).toHaveBeenCalledWith('editor:objects-delete-skipped', {
+      skippedObjects: [protectedShape],
+      requestedObjects: [protectedShape],
+      withoutSave: false
+    })
+  })
+
   it('при удалении без сохранения не завершает редактирование текста отдельно', () => {
     const objectToDelete = {
       id: 'object-1',

--- a/specs/src/editor/deletion-manager/index.spec.ts
+++ b/specs/src/editor/deletion-manager/index.spec.ts
@@ -93,4 +93,122 @@ describe('DeletionManager', () => {
       withoutSave: false
     })
   })
+
+  it('не удаляет объект, запрещённый правилом удаления, и сообщает о пропуске', () => {
+    const protectedObject = createMockFabricObject({
+      type: 'image',
+      id: 'protected-object'
+    })
+
+    mockEditor.options.canDeleteObject = jest.fn(() => false)
+    mockCanvas.getActiveObjects.mockReturnValue([protectedObject])
+
+    const result = deletionManager.deleteSelectedObjects()
+
+    expect(result).toBeNull()
+    expect(mockCanvas.remove).not.toHaveBeenCalled()
+    expect(mockEditor.textManager.exitActiveTextEditing).not.toHaveBeenCalled()
+    expect(mockEditor.historyManager.saveState).not.toHaveBeenCalled()
+    expect(mockCanvas.fire).toHaveBeenCalledWith('editor:objects-delete-skipped', {
+      skippedObjects: [protectedObject],
+      requestedObjects: [protectedObject],
+      withoutSave: false
+    })
+    expect(mockCanvas.fire).not.toHaveBeenCalledWith('editor:objects-deleted', expect.any(Object))
+  })
+
+  it('при массовом удалении удаляет разрешённые объекты и сообщает о запрещённых', () => {
+    const removableObject = createMockFabricObject({
+      type: 'rect',
+      id: 'removable-object'
+    })
+    const protectedObject = createMockFabricObject({
+      type: 'image',
+      id: 'protected-object'
+    })
+
+    mockEditor.options.canDeleteObject = jest.fn((object) => object !== protectedObject)
+    mockCanvas.getActiveObjects.mockReturnValue([removableObject, protectedObject])
+
+    const result = deletionManager.deleteSelectedObjects()
+
+    expect(result).toEqual({
+      objects: [removableObject],
+      withoutSave: false
+    })
+    expect(mockCanvas.remove).toHaveBeenCalledWith(removableObject)
+    expect(mockCanvas.remove).not.toHaveBeenCalledWith(protectedObject)
+    expect(mockEditor.historyManager.saveState).toHaveBeenCalledTimes(1)
+    expect(mockCanvas.fire).toHaveBeenCalledWith('editor:objects-delete-skipped', {
+      skippedObjects: [protectedObject],
+      requestedObjects: [removableObject, protectedObject],
+      withoutSave: false
+    })
+    expect(mockCanvas.fire).toHaveBeenCalledWith('editor:objects-deleted', {
+      objects: [removableObject],
+      withoutSave: false
+    })
+  })
+
+  it('удаляет запрещённый объект при явном обходе правила удаления', () => {
+    const protectedObject = createMockFabricObject({
+      type: 'image',
+      id: 'protected-object'
+    })
+    const canDeleteObject = jest.fn(() => false)
+
+    mockEditor.options.canDeleteObject = canDeleteObject
+
+    const result = deletionManager.deleteSelectedObjects({
+      objects: [protectedObject],
+      ignoreDeleteGuard: true
+    })
+
+    expect(result).toEqual({
+      objects: [protectedObject],
+      withoutSave: false
+    })
+    expect(canDeleteObject).not.toHaveBeenCalled()
+    expect(mockCanvas.remove).toHaveBeenCalledWith(protectedObject)
+    expect(mockEditor.historyManager.saveState).toHaveBeenCalledTimes(1)
+    expect(mockCanvas.fire).not.toHaveBeenCalledWith('editor:objects-delete-skipped', expect.any(Object))
+  })
+
+  it('при удалении группы оставляет запрещённые дочерние объекты', () => {
+    const protectedChild = createMockFabricObject({
+      type: 'image',
+      id: 'protected-child'
+    })
+    const removableChild = createMockFabricObject({
+      type: 'rect',
+      id: 'removable-child'
+    })
+    const groupToDelete = createMockGroup([protectedChild, removableChild], {
+      id: 'mixed-group'
+    })
+
+    mockEditor.options.canDeleteObject = jest.fn((object) => object !== protectedChild)
+    mockCanvas.getActiveObjects.mockReturnValue([groupToDelete])
+    mockEditor.groupingManager.ungroup.mockReturnValue({
+      ungroupedObjects: [protectedChild, removableChild]
+    })
+
+    const result = deletionManager.deleteSelectedObjects()
+
+    expect(mockEditor.groupingManager.ungroup).toHaveBeenCalledWith({
+      target: groupToDelete,
+      withoutSave: true
+    })
+    expect(mockCanvas.remove).toHaveBeenCalledWith(removableChild)
+    expect(mockCanvas.remove).not.toHaveBeenCalledWith(protectedChild)
+    expect(result).toEqual({
+      objects: [groupToDelete, removableChild],
+      withoutSave: false
+    })
+    expect(mockCanvas.fire).toHaveBeenCalledWith('editor:objects-delete-skipped', {
+      skippedObjects: [protectedChild],
+      requestedObjects: [groupToDelete],
+      withoutSave: false
+    })
+  })
 })

--- a/specs/test-utils/editor/editor-stub.ts
+++ b/specs/test-utils/editor/editor-stub.ts
@@ -295,6 +295,7 @@ export const createEditorStub = () => {
     textManager: {
       isTextEditingActive: false,
       commitStandaloneTextScale: jest.fn(),
+      getActiveTextEditingOwner: jest.fn().mockReturnValue(null),
       exitActiveTextEditing: jest.fn().mockReturnValue(false)
     },
     errorManager: {

--- a/specs/test-utils/editor/editor-stub.ts
+++ b/specs/test-utils/editor/editor-stub.ts
@@ -1,4 +1,5 @@
 import { Point } from 'fabric'
+import type { FabricObject } from 'fabric'
 import { createCanvasStub } from '../canvas/canvas-stub'
 
 type PlacementOriginX = 'left' | 'center' | 'right'
@@ -274,7 +275,19 @@ export const createEditorStub = () => {
     },
     layerManager: { bringToFront: jest.fn() },
     selectionManager: { selectAll: jest.fn() },
-    deletionManager: { deleteSelectedObjects: jest.fn() },
+    deletionManager: {
+      deleteSelectedObjects: jest.fn(),
+      resolveDeleteTargets: jest.fn(({ objects }: { objects?: FabricObject[] } = {}) => {
+        const requestedObjects = objects ?? canvas.getActiveObjects()
+        const deletableObjects = requestedObjects.filter((object: FabricObject) => !object.locked)
+
+        return {
+          requestedObjects,
+          deletableObjects,
+          skippedObjects: []
+        }
+      })
+    },
     clipboardManager: { copy: jest.fn(), handlePasteEvent: jest.fn() },
     objectLockManager: {
       lockObject: jest.fn()

--- a/specs/test-utils/fabric/objects.ts
+++ b/specs/test-utils/fabric/objects.ts
@@ -4,6 +4,17 @@ import {
 } from 'fabric'
 
 /**
+ * Возвращает глубокую копию customData, если объект хранит её как plain object.
+ */
+const cloneCustomData = (object: any) => {
+  if (!object.customData || typeof object.customData !== 'object') {
+    return object.customData
+  }
+
+  return JSON.parse(JSON.stringify(object.customData))
+}
+
+/**
  * Создаёт базовый fabric-like object с clone/set/setCoords контрактом для юнит-тестов.
  */
 export const createMockFabricObject = (props: any = {}) => {
@@ -17,6 +28,7 @@ export const createMockFabricObject = (props: any = {}) => {
     ...props,
     clone: jest.fn().mockImplementation(async() => {
       const cloned = { ...mockObject, ...JSON.parse(JSON.stringify(props)) }
+      cloned.customData = cloneCustomData(mockObject)
       cloned.set = jest.fn().mockImplementation((newProps) => {
         Object.assign(cloned, newProps)
       })
@@ -48,7 +60,10 @@ export const createMockActiveSelection = (objects: any[], props: any = {}) => {
 
   mockSelection.clone = jest.fn().mockImplementation(async() => {
     const clonedObjects = objects.map((object) => {
-      const clonedObject = { ...object }
+      const clonedObject = {
+        ...object,
+        customData: cloneCustomData(object)
+      }
 
       clonedObject.set = jest.fn().mockImplementation((newProps) => {
         Object.assign(clonedObject, newProps)

--- a/src/editor/clipboard-manager/README.md
+++ b/src/editor/clipboard-manager/README.md
@@ -1,0 +1,62 @@
+# ClipboardManager
+
+`ClipboardManager` owns copy, cut, paste, duplicate, internal clipboard state, and best-effort writes to the browser clipboard. It works together with `DeletionManager`: cut must copy only objects that can really be deleted.
+
+The manager does not know application domains. It must not inspect `customData.handle` or decide which metadata has special meaning. Applications can prepare clones through `editor.options.prepareObjectClone`.
+
+## Clone Preparation
+
+All internal object cloning goes through `_cloneObject()`:
+
+1. Clone the source Fabric object with `CLIPBOARD_CLONE_OBJECT_KEYS`.
+2. Walk the root clone and nested objects inside `ActiveSelection` or `Group`.
+3. Detach `customData` on every clone before external preparation.
+4. Call `editor.options.prepareObjectClone(object)` for each clone.
+5. Continue the normal copy, paste, duplicate, or cut flow.
+
+Detaching `customData` matters because Fabric clones may share nested metadata references with the source object. The application callback is allowed to mutate the clone, but it must not accidentally mutate the original object.
+
+## Copy, Paste, and Duplicate
+
+`copy()`, `copyPaste()`, and `paste()` all use the same clone preparation rule.
+
+- `copy()` stores a prepared clone in the internal clipboard and starts a background browser clipboard write.
+- `copyPaste()` creates a prepared clone, gives it a new identity, offsets it, materializes text/shape geometry, and inserts it.
+- `paste()` clones from the internal clipboard again, prepares that clone again, gives it a new identity, offsets it, and inserts it.
+
+This repeated preparation is intentional. A long-lived internal clipboard can contain old object data, and every inserted object must still pass through the current clone preparation contract.
+
+## Cut
+
+`cut()` must not copy an object first and discover later that deletion is blocked. It asks `DeletionManager.resolveDeleteTargets()` before filling the clipboard.
+
+Behavior:
+
+- if all selected objects can be deleted, cut copies the current active object or active selection;
+- if only some selected objects can be deleted, cut copies only those deletable objects;
+- if no selected object can be deleted, cut leaves the clipboard unchanged and asks `DeletionManager.deleteSelectedObjects()` to emit the skipped-delete notification.
+
+After a successful internal copy, deletion still goes through `DeletionManager.deleteSelectedObjects()` so history, events, groups, locks, and guards stay consistent.
+
+## Browser Clipboard
+
+System clipboard writes are best effort and run in the background. A browser permission failure should warn through `ErrorManager`, but it must not undo the internal clipboard state. The internal clipboard is the editor's reliable source for `paste()`.
+
+## When Changing This Manager
+
+- Keep clone preparation centralized in `_cloneObject()`.
+- Do not call `prepareObjectClone` on source objects.
+- Do not remove the `customData` detach step before external clone preparation.
+- Keep cut dependent on `DeletionManager.resolveDeleteTargets()`.
+- Do not make browser clipboard success a requirement for editor copy or cut.
+- When changing copy or cut, check active selection, single object, groups, and protected-object cases.
+
+## Validation
+
+For focused changes in this manager, run:
+
+```bash
+npm run typecheck
+npm run test -- specs/src/editor/clipboard-manager/index.spec.ts --runInBand --coverage=false
+npx playwright test e2e/tests/delete-guard.spec.ts --project=chromium
+```

--- a/src/editor/clipboard-manager/index.ts
+++ b/src/editor/clipboard-manager/index.ts
@@ -1,4 +1,4 @@
-import { ActiveSelection, FabricObject } from 'fabric'
+import { ActiveSelection, FabricObject, Group } from 'fabric'
 import { CLIPBOARD_DATA_PREFIX, CLIPBOARD_CLONE_OBJECT_KEYS } from '../constants'
 
 import { ImageEditor } from '../index'
@@ -34,28 +34,86 @@ export default class ClipboardManager {
     const activeObject = canvas.getActiveObject()
     if (!activeObject || activeObject.locked) return
 
-    // Асинхронно клонируем объект для внутреннего буфера (не блокирует систему)
-    this._cloneToInternalClipboard(activeObject)
-
-    this._copyToSystemClipboardInBackground({
-      activeObject,
+    this._copyObjectToClipboard({
+      object: activeObject,
       method: 'copy'
     })
   }
 
   /**
-   * Асинхронное клонирование для внутреннего буфера
+   * Клонирует объект и даёт внешнему коду подготовить клон.
    */
-  private async _cloneToInternalClipboard(activeObject: FabricObject): Promise<boolean> {
+  private async _cloneObject({ object }: { object: FabricObject }): Promise<FabricObject> {
+    const clonedObject = await object.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
+
+    this._prepareObjectClone({
+      clonedObject
+    })
+
+    return clonedObject
+  }
+
+  /**
+   * Отделяет customData клона от исходного объекта перед внешней подготовкой.
+   */
+  private _detachObjectCustomData({ object }: { object: FabricObject }): void {
+    const { customData } = object
+
+    if (!customData || typeof customData !== 'object') return
+
+    object.customData = JSON.parse(JSON.stringify(customData)) as object
+  }
+
+  /**
+   * Подготавливает корневой клон и все вложенные объекты без знания их доменной роли.
+   */
+  private _prepareObjectClone({ clonedObject }: { clonedObject: FabricObject }): void {
+    const { prepareObjectClone } = this.editor.options
+    const objectsToPrepare: FabricObject[] = [clonedObject]
+
+    for (let index = 0; index < objectsToPrepare.length; index += 1) {
+      const object = objectsToPrepare[index]
+
+      this._detachObjectCustomData({ object })
+      prepareObjectClone?.(object)
+
+      if (!(object instanceof ActiveSelection) && !(object instanceof Group)) continue
+
+      const childObjects = object.getObjects()
+
+      for (let childIndex = 0; childIndex < childObjects.length; childIndex += 1) {
+        objectsToPrepare.push(childObjects[childIndex])
+      }
+    }
+  }
+
+  /**
+   * Клонирует объект, сохраняет его во внутренний буфер и запускает системное копирование.
+   */
+  private async _copyObjectToClipboard({
+    object,
+    method
+  }: {
+    object: FabricObject
+    method: 'copy' | 'cut'
+  }): Promise<boolean> {
     const { canvas, errorManager } = this.editor
 
     try {
-      const clonedObject = await activeObject.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
+      const clonedObject = await this._cloneObject({ object })
+
       this._materializeCloneGeometry({
         clonedObject
       })
+
       this.clipboard = clonedObject
       canvas.fire('editor:object-copied', { object: clonedObject })
+
+      this._copyToSystemClipboardInBackground({
+        object: clonedObject,
+        method
+      })
+
       return true
     } catch (error) {
       errorManager.emitError({
@@ -73,13 +131,13 @@ export default class ClipboardManager {
    * Фоновое копирование объекта в системный буфер без блокировки действия пользователя.
    */
   private _copyToSystemClipboardInBackground({
-    activeObject,
+    object,
     method
   }: {
-    activeObject: FabricObject
+    object: FabricObject
     method: 'copy' | 'cut'
   }): void {
-    this._copyToSystemClipboard(activeObject).catch((error) => {
+    this._copyToSystemClipboard(object).catch((error) => {
       this.editor.errorManager.emitWarning({
         origin: 'ClipboardManager',
         method,
@@ -360,7 +418,7 @@ export default class ClipboardManager {
 
     try {
       // Используем асинхронное клонирование для корректной работы с SVG и сложными объектами
-      const clonedObject = await targetObject.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
+      const clonedObject = await this._cloneObject({ object: targetObject })
 
       materializeObjectIdentity({
         rootObject: clonedObject
@@ -407,17 +465,35 @@ export default class ClipboardManager {
     if (!activeObject || activeObject.locked) return false
 
     try {
-      const copied = await this._cloneToInternalClipboard(activeObject)
-      if (!copied) return false
-
-      this._copyToSystemClipboardInBackground({
-        activeObject,
-        method: 'cut'
-      })
-
       const objectsToDelete = activeObject instanceof ActiveSelection
         ? activeObject.getObjects()
         : [activeObject]
+      const deleteTargets = deletionManager.resolveDeleteTargets({
+        objects: objectsToDelete
+      })
+
+      if (!deleteTargets.deletableObjects.length) {
+        deletionManager.deleteSelectedObjects({
+          objects: objectsToDelete
+        })
+
+        return false
+      }
+
+      const cutSourceObject = this._createCutSourceObject({
+        activeObject,
+        objectsToCut: deleteTargets.deletableObjects
+      })
+
+      if (!cutSourceObject) return false
+
+      const copied = await this._copyObjectToClipboard({
+        object: cutSourceObject,
+        method: 'cut'
+      })
+
+      if (!copied) return false
+
       const result = deletionManager.deleteSelectedObjects({
         objects: objectsToDelete
       })
@@ -433,6 +509,26 @@ export default class ClipboardManager {
       })
       return false
     }
+  }
+
+  /**
+   * Собирает объект, который должен попасть в буфер при вырезании.
+   */
+  private _createCutSourceObject({
+    activeObject,
+    objectsToCut
+  }: {
+    activeObject: FabricObject
+    objectsToCut: FabricObject[]
+  }): FabricObject | null {
+    if (!(activeObject instanceof ActiveSelection)) return activeObject
+    if (!objectsToCut.length) return null
+    if (objectsToCut.length === activeObject.getObjects().length) return activeObject
+    if (objectsToCut.length === 1) return objectsToCut[0]
+
+    return new ActiveSelection(objectsToCut, {
+      canvas: this.editor.canvas
+    })
   }
 
   /**
@@ -517,7 +613,7 @@ export default class ClipboardManager {
 
     try {
       // Клонируем объект асинхронно (правильно для всех типов объектов)
-      const clonedObj = await this.clipboard.clone(CLIPBOARD_CLONE_OBJECT_KEYS)
+      const clonedObj = await this._cloneObject({ object: this.clipboard })
 
       canvas.discardActiveObject()
 

--- a/src/editor/deletion-manager/README.md
+++ b/src/editor/deletion-manager/README.md
@@ -1,0 +1,67 @@
+# DeletionManager
+
+`DeletionManager` owns user-level object deletion. Keyboard deletion, toolbar deletion, direct API calls, and `ClipboardManager.cut()` should all rely on the same deletion rules instead of reimplementing delete logic at the UI layer.
+
+The manager does not know application domains. It must not read `customData.handle`, image roles, product roles, or any other app-specific marker. Applications pass those rules through editor options.
+
+## Delete Flow
+
+`deleteSelectedObjects()` is the transaction boundary:
+
+1. Resolve the requested objects from `options.objects` or from the active canvas selection.
+2. Skip locked objects silently.
+3. Ask `editor.options.canDeleteObject(object)` for each unlocked object unless `ignoreDeleteGuard` is set.
+4. Delete only the objects that are actually allowed.
+5. If at least one object was protected by the guard, fire `editor:objects-delete-skipped`.
+6. Save history and fire `editor:objects-deleted` only when something was really removed.
+
+If nothing can be deleted, the manager returns `null`. In that case it must not save history, discard selection, render as a delete operation, or finish text editing just because deletion was requested.
+
+## Delete Guard
+
+`canDeleteObject` is a synchronous rule supplied by the application:
+
+```ts
+canDeleteObject: (object) => object.customData?.handle !== 'main-image'
+```
+
+The callback answers one question only: can this object be deleted by a normal editor operation. It should be cheap and free of side effects.
+
+The guard applies to public delete paths and to `cut()`. A technical operation that intentionally clears protected content should pass `ignoreDeleteGuard: true` to `deleteSelectedObjects()`.
+
+## Skipped Delete Event
+
+`editor:objects-delete-skipped` is notification only. It does not cancel deletion and must not become a second decision point. The decision has already been made by `canDeleteObject`.
+
+The event payload contains:
+
+- `skippedObjects`: objects skipped by `canDeleteObject`;
+- `requestedObjects`: objects the caller tried to delete;
+- `withoutSave`: the delete call flag.
+
+Locked objects are not reported through this event. They are an editor-level lock rule, not an application guard result.
+
+## Groups
+
+Non-SVG Fabric groups are ungrouped before deletion. Child objects go through the same guard as top-level objects.
+
+If a group contains both deletable and protected children, the manager removes the deletable children and leaves protected children on canvas. If none of the children can be deleted, the group is not ungrouped just to produce an empty delete operation.
+
+## When Changing This Manager
+
+- Keep `resolveDeleteTargets()` as the shared calculation used by deletion and cut.
+- Do not add app-specific checks here. The library contract is `canDeleteObject`.
+- Do not use events as a hidden cancellation mechanism.
+- Do not save history when no object was deleted.
+- Keep `ignoreDeleteGuard` explicit. Avoid temporary marker removal or manual bypasses in callers.
+- When changing group deletion, check mixed groups: protected child plus normal child.
+
+## Validation
+
+For focused changes in this manager, run:
+
+```bash
+npm run typecheck
+npm run test -- specs/src/editor/deletion-manager/index.spec.ts --runInBand --coverage=false
+npx playwright test e2e/tests/delete-guard.spec.ts --project=chromium
+```

--- a/src/editor/deletion-manager/README.md
+++ b/src/editor/deletion-manager/README.md
@@ -8,14 +8,19 @@ The manager does not know application domains. It must not read `customData.hand
 
 `deleteSelectedObjects()` is the transaction boundary:
 
-1. Resolve the requested objects from `options.objects` or from the active canvas selection.
+1. Resolve the requested objects from `options.objects`, from the owner of active text editing, or from the active canvas selection.
 2. Skip locked objects silently.
 3. Ask `editor.options.canDeleteObject(object)` for each unlocked object unless `ignoreDeleteGuard` is set.
-4. Delete only the objects that are actually allowed.
-5. If at least one object was protected by the guard, fire `editor:objects-delete-skipped`.
-6. Save history and fire `editor:objects-deleted` only when something was really removed.
+4. If something can be removed and the call saves history, finish active text editing before mutating canvas.
+5. Delete only the objects that are actually allowed.
+6. If at least one object was protected by the guard, fire `editor:objects-delete-skipped`.
+7. Save history and fire `editor:objects-deleted` only when something was really removed.
 
 If nothing can be deleted, the manager returns `null`. In that case it must not save history, discard selection, render as a delete operation, or finish text editing just because deletion was requested.
+
+When text inside a shape is being edited, Fabric may expose the inner textbox as the active object.
+Object-level deletion must target the shape group that owns that text, not the inner textbox itself.
+`DeletionManager` asks `TextManager` for that owner before it applies delete guards, so a protected owner still keeps the editing session open.
 
 ## Delete Guard
 

--- a/src/editor/deletion-manager/index.ts
+++ b/src/editor/deletion-manager/index.ts
@@ -192,6 +192,27 @@ export default class DeletionManager {
   }
 
   /**
+   * Возвращает объекты удаления для текущего активного контекста.
+   * Если открыт режим редактирования текста, объектные операции должны работать с владельцем текста,
+   * а не с внутренним временно активным текстовым объектом.
+   */
+  private _resolveObjectsForDelete({
+    objects,
+    withoutSave
+  }: {
+    objects?: FabricObject[]
+    withoutSave: boolean
+  }): FabricObject[] | undefined {
+    if (objects) return objects
+    if (withoutSave) return undefined
+
+    const activeTextEditingOwner = this.editor.textManager.getActiveTextEditingOwner()
+    if (!activeTextEditingOwner) return undefined
+
+    return [activeTextEditingOwner]
+  }
+
+  /**
    * Разгруппировывает группу и собирает разрешённые дочерние объекты для удаления.
    */
   private _collectGroupObjectsForDeletion({
@@ -362,7 +383,7 @@ export default class DeletionManager {
    * @param options.withoutSave - Не сохранять состояние
    * @param options.ignoreDeleteGuard - Не применять внешнюю проверку возможности удаления
    * @param options._isRecursiveCall - Устаревший внутренний параметр, оставлен для совместимости
-   * Если удаление сохраняется в историю и в этот момент открыт text editing,
+   * Если удаление сохраняется в историю и в этот момент открыт режим редактирования текста,
    * менеджер сначала завершает редактирование, чтобы текст сохранился
    * отдельным history-шагом до удаления.
    * @fires editor:objects-deleted
@@ -374,8 +395,12 @@ export default class DeletionManager {
     ignoreDeleteGuard = false
   }: DeleteSelectedObjectsParams = {}): ObjectsDeletedPayload | null {
     const { textManager } = this.editor
-    const deletePlan = this._resolveDeletePlan({
+    const objectsForDelete = this._resolveObjectsForDelete({
       objects,
+      withoutSave
+    })
+    const deletePlan = this._resolveDeletePlan({
+      objects: objectsForDelete,
       ignoreDeleteGuard
     })
 

--- a/src/editor/deletion-manager/index.ts
+++ b/src/editor/deletion-manager/index.ts
@@ -1,11 +1,62 @@
 import { FabricObject, Group } from 'fabric'
 import { ImageEditor } from '../index'
-import { ObjectsDeletedPayload } from '../types/events'
+import type {
+  ObjectsDeletedPayload,
+  ObjectsDeleteSkippedPayload
+} from '../types/events'
 
+/**
+ * Параметры удаления выбранных объектов.
+ */
 export type DeleteSelectedObjectsParams = {
   objects?: FabricObject[],
   withoutSave?: boolean,
+  ignoreDeleteGuard?: boolean,
   _isRecursiveCall?: boolean
+}
+
+/**
+ * Параметры расчёта объектов, которые можно удалить.
+ */
+export type ResolveDeleteTargetsParams = {
+  objects?: FabricObject[],
+  ignoreDeleteGuard?: boolean
+}
+
+/**
+ * Результат расчёта объектов, которые можно удалить.
+ */
+export type DeleteTargets = {
+  requestedObjects: FabricObject[]
+  deletableObjects: FabricObject[]
+  skippedObjects: FabricObject[]
+}
+
+/**
+ * Внутренний план удаления с признаком реальных изменений canvas.
+ */
+type DeletePlan = {
+  requestedObjects: FabricObject[]
+  deletableObjects: FabricObject[]
+  skippedObjects: FabricObject[]
+  hasCanvasChanges: boolean
+}
+
+/**
+ * Результат удаления объектов внутри одной операции.
+ */
+type DeleteObjectsResult = {
+  deletedObjects: FabricObject[]
+  skippedObjects: FabricObject[]
+}
+
+/**
+ * Результат разгруппировки при удалении группы.
+ */
+type GroupDeletionResult = {
+  deletedObjects: FabricObject[]
+  skippedObjects: FabricObject[]
+  objectsToDelete: FabricObject[]
 }
 
 export default class DeletionManager {
@@ -28,28 +79,280 @@ export default class DeletionManager {
   }
 
   /**
-   * Обрабатывает удаление группы: разгруппировывает и рекурсивно удаляет объекты
-   * @param group - группа для обработки
-   * @returns массив всех удаленных объектов (включая саму группу)
+   * Проверяет, можно ли удалить объект с учётом внешнего ограничения.
    */
-  private _handleGroupDeletion(group: Group): FabricObject[] {
-    const { groupingManager } = this.editor
+  private _canDeleteObject({
+    object,
+    ignoreDeleteGuard
+  }: {
+    object: FabricObject
+    ignoreDeleteGuard: boolean
+  }): boolean {
+    if (ignoreDeleteGuard) return true
 
-    // Разгруппировываем и получаем объекты
+    return this.editor.options.canDeleteObject?.(object) ?? true
+  }
+
+  /**
+   * Делит запрошенные объекты на удаляемые и пропущенные.
+   * Заблокированные объекты остаются внутренним ограничением и в skippedObjects не попадают.
+   */
+  public resolveDeleteTargets({
+    objects,
+    ignoreDeleteGuard = false
+  }: ResolveDeleteTargetsParams = {}): DeleteTargets {
+    const targetObjects = objects || this.editor.canvas.getActiveObjects()
+    const deletableObjects: FabricObject[] = []
+    const skippedObjects: FabricObject[] = []
+
+    for (let index = 0; index < targetObjects.length; index += 1) {
+      const object = targetObjects[index]
+
+      if (object.locked) continue
+
+      if (!this._canDeleteObject({ object, ignoreDeleteGuard })) {
+        skippedObjects.push(object)
+        continue
+      }
+
+      deletableObjects.push(object)
+    }
+
+    return {
+      requestedObjects: targetObjects,
+      deletableObjects,
+      skippedObjects
+    }
+  }
+
+  /**
+   * Проверяет, приведёт ли удаление к реальным изменениям canvas.
+   */
+  private _resolveDeletePlan({
+    objects,
+    ignoreDeleteGuard = false
+  }: ResolveDeleteTargetsParams = {}): DeletePlan {
+    const deleteTargets = this.resolveDeleteTargets({
+      objects,
+      ignoreDeleteGuard
+    })
+    const skippedObjects = [...deleteTargets.skippedObjects]
+    let hasCanvasChanges = false
+
+    for (let index = 0; index < deleteTargets.deletableObjects.length; index += 1) {
+      const object = deleteTargets.deletableObjects[index]
+
+      if (!DeletionManager._isUngroupableGroup(object)) {
+        hasCanvasChanges = true
+        continue
+      }
+
+      const childObjects = object.getObjects()
+
+      if (!childObjects.length) {
+        hasCanvasChanges = true
+        continue
+      }
+
+      const childTargets = this.resolveDeleteTargets({
+        objects: childObjects,
+        ignoreDeleteGuard
+      })
+
+      if (childTargets.deletableObjects.length > 0) {
+        hasCanvasChanges = true
+        continue
+      }
+
+      skippedObjects.push(...childTargets.skippedObjects)
+    }
+
+    return {
+      ...deleteTargets,
+      skippedObjects,
+      hasCanvasChanges
+    }
+  }
+
+  /**
+   * Сообщает внешнему интерфейсу, что часть объектов не была удалена.
+   */
+  private _fireDeleteSkipped({
+    skippedObjects,
+    requestedObjects,
+    withoutSave
+  }: ObjectsDeleteSkippedPayload): void {
+    if (!skippedObjects.length) return
+
+    this.editor.canvas.fire('editor:objects-delete-skipped', {
+      skippedObjects,
+      requestedObjects,
+      withoutSave
+    })
+  }
+
+  /**
+   * Разгруппировывает группу и собирает разрешённые дочерние объекты для удаления.
+   */
+  private _collectGroupObjectsForDeletion({
+    group,
+    ignoreDeleteGuard
+  }: {
+    group: Group
+    ignoreDeleteGuard: boolean
+  }): GroupDeletionResult {
+    const { groupingManager } = this.editor
+    const childObjects = group.getObjects()
+    const childTargets = this.resolveDeleteTargets({
+      objects: childObjects,
+      ignoreDeleteGuard
+    })
+
+    if (childObjects.length && !childTargets.deletableObjects.length) {
+      return {
+        deletedObjects: [],
+        skippedObjects: childTargets.skippedObjects,
+        objectsToDelete: []
+      }
+    }
+
     const { ungroupedObjects = [] } = groupingManager.ungroup({
       target: group,
       withoutSave: true
     }) ?? {}
+    const objectsToDelete: FabricObject[] = []
+    const shouldDeleteAllUngroupedObjects = !childObjects.length
 
-    // Рекурсивно удаляем разгруппированные объекты
-    this.deleteSelectedObjects({
-      objects: ungroupedObjects,
-      withoutSave: true,
-      _isRecursiveCall: true
+    for (let index = 0; index < ungroupedObjects.length; index += 1) {
+      const object = ungroupedObjects[index]
+
+      if (shouldDeleteAllUngroupedObjects || childTargets.deletableObjects.includes(object)) {
+        objectsToDelete.push(object)
+      }
+    }
+
+    return {
+      deletedObjects: [group],
+      skippedObjects: childTargets.skippedObjects,
+      objectsToDelete
+    }
+  }
+
+  /**
+   * Удаляет объекты с canvas без управления общей транзакцией истории.
+   */
+  private _deleteObjects({
+    objects,
+    ignoreDeleteGuard
+  }: {
+    objects: FabricObject[]
+    ignoreDeleteGuard: boolean
+  }): DeleteObjectsResult {
+    const { canvas } = this.editor
+    const objectsToDelete = [...objects]
+    const deletedObjects: FabricObject[] = []
+    const skippedObjects: FabricObject[] = []
+
+    for (let index = 0; index < objectsToDelete.length; index += 1) {
+      const object = objectsToDelete[index]
+
+      if (DeletionManager._isUngroupableGroup(object)) {
+        const result = this._collectGroupObjectsForDeletion({
+          group: object,
+          ignoreDeleteGuard
+        })
+
+        deletedObjects.push(...result.deletedObjects)
+        skippedObjects.push(...result.skippedObjects)
+
+        for (let childIndex = 0; childIndex < result.objectsToDelete.length; childIndex += 1) {
+          objectsToDelete.push(result.objectsToDelete[childIndex])
+        }
+
+        continue
+      }
+
+      canvas.remove(object)
+      deletedObjects.push(object)
+    }
+
+    return {
+      deletedObjects,
+      skippedObjects
+    }
+  }
+
+  /**
+   * Выполняет изменение canvas внутри приостановленной истории.
+   */
+  private _deleteObjectsInHistoryTransaction({
+    deletePlan,
+    ignoreDeleteGuard
+  }: {
+    deletePlan: DeletePlan
+    ignoreDeleteGuard: boolean
+  }): DeleteObjectsResult {
+    const {
+      canvas,
+      historyManager
+    } = this.editor
+    let deleteResult: DeleteObjectsResult = {
+      deletedObjects: [],
+      skippedObjects: []
+    }
+
+    historyManager.suspendHistory()
+
+    try {
+      deleteResult = this._deleteObjects({
+        objects: deletePlan.deletableObjects,
+        ignoreDeleteGuard
+      })
+
+      if (deleteResult.deletedObjects.length) {
+        canvas.discardActiveObject()
+        canvas.renderAll()
+      }
+    } finally {
+      historyManager.resumeHistory()
+    }
+
+    return deleteResult
+  }
+
+  /**
+   * Сохраняет успешное удаление, сообщает о пропущенных объектах и публикует событие удаления.
+   */
+  private _completeDeleteOperation({
+    deletePlan,
+    deleteResult,
+    skippedObjects,
+    withoutSave
+  }: {
+    deletePlan: DeletePlan
+    deleteResult: DeleteObjectsResult
+    skippedObjects: FabricObject[]
+    withoutSave: boolean
+  }): ObjectsDeletedPayload {
+    const { canvas, historyManager } = this.editor
+
+    if (!withoutSave) {
+      historyManager.saveState()
+    }
+
+    const result = {
+      objects: deleteResult.deletedObjects,
+      withoutSave
+    }
+
+    this._fireDeleteSkipped({
+      skippedObjects,
+      requestedObjects: deletePlan.requestedObjects,
+      withoutSave
     })
 
-    // Возвращаем саму группу и разгруппированные объекты как удаленные
-    return [group, ...ungroupedObjects]
+    canvas.fire('editor:objects-deleted', result)
+    return result
   }
 
   /**
@@ -57,72 +360,63 @@ export default class DeletionManager {
    * @param options
    * @param options.objects - массив объектов для удаления
    * @param options.withoutSave - Не сохранять состояние
-   * @param options._isRecursiveCall - Внутренний параметр для рекурсивных вызовов
+   * @param options.ignoreDeleteGuard - Не применять внешнюю проверку возможности удаления
+   * @param options._isRecursiveCall - Устаревший внутренний параметр, оставлен для совместимости
    * Если удаление сохраняется в историю и в этот момент открыт text editing,
    * менеджер сначала завершает редактирование, чтобы текст сохранился
    * отдельным history-шагом до удаления.
    * @fires editor:objects-deleted
+   * @fires editor:objects-delete-skipped
    */
   public deleteSelectedObjects({
     objects,
     withoutSave = false,
-    _isRecursiveCall = false
+    ignoreDeleteGuard = false
   }: DeleteSelectedObjectsParams = {}): ObjectsDeletedPayload | null {
-    const {
-      canvas,
-      historyManager,
-      textManager
-    } = this.editor
+    const { textManager } = this.editor
+    const deletePlan = this._resolveDeletePlan({
+      objects,
+      ignoreDeleteGuard
+    })
 
-    if (!_isRecursiveCall && !withoutSave) {
+    if (!deletePlan.hasCanvasChanges) {
+      this._fireDeleteSkipped({
+        skippedObjects: deletePlan.skippedObjects,
+        requestedObjects: deletePlan.requestedObjects,
+        withoutSave
+      })
+
+      return null
+    }
+
+    if (!withoutSave) {
       textManager.exitActiveTextEditing()
     }
 
-    // Получаем объекты для удаления
-    const targetObjects = objects || canvas.getActiveObjects()
-
-    // Отбираем только те объекты, которые не заблокированы
-    const activeObjects = targetObjects.filter((obj) => !obj.locked)
-
-    if (!activeObjects?.length) return null
-
-    // Suspend только на верхнем уровне
-    if (!_isRecursiveCall) {
-      historyManager.suspendHistory()
-    }
-
-    const deletedObjects: FabricObject[] = []
-
-    activeObjects.forEach((obj) => {
-      // Обработка групп: разгруппировываем и рекурсивно удаляем
-      if (DeletionManager._isUngroupableGroup(obj)) {
-        const deleted = this._handleGroupDeletion(obj)
-        deletedObjects.push(...deleted)
-        return
-      }
-
-      // Обычное удаление объекта
-      canvas.remove(obj)
-      deletedObjects.push(obj)
+    const deleteResult = this._deleteObjectsInHistoryTransaction({
+      deletePlan,
+      ignoreDeleteGuard
     })
+    const skippedObjects = [
+      ...deletePlan.skippedObjects,
+      ...deleteResult.skippedObjects
+    ]
 
-    // Операции только на верхнем уровне
-    if (_isRecursiveCall) return null
+    if (!deleteResult.deletedObjects.length) {
+      this._fireDeleteSkipped({
+        skippedObjects,
+        requestedObjects: deletePlan.requestedObjects,
+        withoutSave
+      })
 
-    canvas.discardActiveObject()
-    canvas.renderAll()
-    historyManager.resumeHistory()
-
-    if (!withoutSave) {
-      historyManager.saveState()
+      return null
     }
 
-    const result = {
-      objects: deletedObjects,
+    return this._completeDeleteOperation({
+      deletePlan,
+      deleteResult,
+      skippedObjects,
       withoutSave
-    }
-
-    canvas.fire('editor:objects-deleted', result)
-    return result
+    })
   }
 }

--- a/src/editor/text-manager/index.ts
+++ b/src/editor/text-manager/index.ts
@@ -371,6 +371,20 @@ export default class TextManager {
   }
 
   /**
+   * Возвращает объект, который владеет активным редактируемым текстом.
+   * Для самостоятельного текста это сам текстовый объект, для текста внутри фигуры — группа фигуры.
+   */
+  public getActiveTextEditingOwner(): FabricObject | null {
+    const activeObject = this.canvas.getActiveObject()
+
+    if (!TextManager._isTextbox(activeObject)) return null
+    if (activeObject.isEditing !== true) return null
+    if (!TextManager._isShapeOwnedTextbox(activeObject)) return activeObject
+
+    return activeObject.group ?? activeObject
+  }
+
+  /**
    * Завершает активное редактирование текста перед внешним прерывающим действием.
    * Используется там, где следующее действие должно зафиксировать введённый текст
    * отдельным history-шагом до собственной мутации.

--- a/src/editor/types/events.d.ts
+++ b/src/editor/types/events.d.ts
@@ -118,6 +118,15 @@ export type ObjectsDeletedPayload = {
 }
 
 /**
+ * Параметры события editor:objects-delete-skipped
+ */
+export type ObjectsDeleteSkippedPayload = {
+  skippedObjects: FabricObject[]
+  requestedObjects: FabricObject[]
+  withoutSave?: boolean
+}
+
+/**
  * Параметры события editor:history-state-loaded
  * @todo: Заменить object на тип который будет соответствовать объекту состояния истории, когда класс будет переписан на TS
  */
@@ -317,6 +326,11 @@ declare module 'fabric' {
      * Срабатывает при удалении выбранных объектов с канваса.
      */
     'editor:objects-deleted': ObjectsDeletedPayload
+
+    /**
+     * Срабатывает, когда часть объектов нельзя удалить через операции редактора.
+     */
+    'editor:objects-delete-skipped': ObjectsDeleteSkippedPayload
 
     /**
      * Срабатывает после загрузки состояния канваса (из JSON истории).

--- a/src/editor/types/fabric-extensions.d.ts
+++ b/src/editor/types/fabric-extensions.d.ts
@@ -1,4 +1,5 @@
 import 'fabric'
+import type { FabricObject as FabricObjectInstance } from 'fabric'
 import type { EditorFontDefinition } from './font'
 import { ImageEditor } from '..'
 
@@ -166,6 +167,16 @@ declare module 'fabric' {
      * Показывать программные viewport-скроллбары для pan при увеличенном canvas.
      */
     showViewportScrollbars: boolean
+    /**
+     * Проверяет, можно ли удалить объект через операции редактора.
+     * Если не задана, объект можно удалить, кроме заблокированных объектов.
+     */
+    canDeleteObject?: (object: FabricObjectInstance) => boolean
+    /**
+     * Подготавливает клон объекта перед сохранением в буфер или добавлением на canvas.
+     * Коллбэк получает только клон и не должен менять исходный объект.
+     */
+    prepareObjectClone?: (object: FabricObjectInstance) => void
     /**
      * Коллбэк, который будет вызван при готовности редактора.
      * Используется для выполнения действий после полной инициализации редактора.


### PR DESCRIPTION
Добавлена возможность при инициализации указать следующее:

- какие объекты могут быть удалены через передачу функции `canDeleteObject(object)`. При этом, при вызове DeletionManager можно передать параметр `ignoreDeleteGuard`, который разрешает удалить объект несмотря на запрет. Это технический параметр, который нужен чтобы удалить объект тогда, когда происходит замена, или когда есть необходимость именно удалить объект, чтобы загрузить новый (ИИ удаление фона, апскейлинг, применение темплейта). 
- передача функции `prepareObjectClone(object)`, которая вызывается при копировании/дублировании объекта, чтобы можно было удалить признак главного изображения, или какие-то другие свойства которые копия не должна наследовать
- Если удаление объекта не было выполнено по причине того что есть запрет на его удаление в `canDeleteObject`, то будет вызывано событие `editor:objects-delete-skipped`.