### PR TITLE
ImageManager. Чиним артефакты в виде серой рамки при экспорте изображения в JPEG формате

### DIFF
--- a/e2e/fixtures/data/image.data.ts
+++ b/e2e/fixtures/data/image.data.ts
@@ -12,3 +12,26 @@ export const IMAGE_TOLERANCE = {
   position: 1.5,
   geometry: 2
 }
+
+/** Размер монтажной области для проверки JPEG-экспорта. */
+export const IMAGE_EXPORT_MONTAGE_SIZE = {
+  width: 128,
+  height: 128
+}
+
+/** Заливка, у которой легко заметить осветление edge-пикселей при лишнем clipPath. */
+export const IMAGE_EXPORT_EDGE_FILL = '#4a90e2'
+
+/** Максимальное расхождение edge-пикселя и внутреннего пикселя после JPEG-кодирования. */
+export const IMAGE_EXPORT_EDGE_COLOR_TOLERANCE = 8
+
+/** Объект, который целиком находится вне монтажной области и не должен попасть в экспорт. */
+export const IMAGE_OUTSIDE_MONTAGE_OBJECT = {
+  width: 32,
+  height: 32,
+  left: -48,
+  top: 24
+}
+
+/** Нижняя граница белого пикселя после JPEG-кодирования. */
+export const IMAGE_EXPORT_WHITE_PIXEL_MIN_CHANNEL = 245

--- a/e2e/models/image.model.ts
+++ b/e2e/models/image.model.ts
@@ -15,6 +15,12 @@ type ImagePixelColor = {
   alpha: number
 }
 
+/** Размер изображения в data URL. */
+type ImageDataUrlSize = {
+  width: number
+  height: number
+}
+
 /** Источник live image-объекта в Fabric. */
 type ImageSourceInfo = {
   id: string | null
@@ -163,6 +169,49 @@ export class ImageModel {
     return dataUrl
   }
 
+  /** Экспортирует всю монтажную область через публичный API ImageManager в data URL. */
+  async exportCanvasAsBase64(params: { contentType?: string } = {}): Promise<string> {
+    const dataUrl = await this.page.evaluate(({ contentType = 'image/png' }) => {
+      const { editor } = window as any
+
+      return editor.imageManager.exportCanvasAsImageFile({
+        contentType,
+        exportAsBase64: true
+      }).then((result: { image?: unknown } | null) => (
+        typeof result?.image === 'string' ? result.image : null
+      ))
+    }, params)
+
+    expect(dataUrl, 'экспорт монтажной области должен вернуть data URL').not.toBeNull()
+    if (!dataUrl) {
+      throw new Error('Не удалось экспортировать монтажную область в data URL')
+    }
+
+    return dataUrl
+  }
+
+  /** Возвращает размер изображения из data URL. */
+  async getDataUrlSize(params: { dataUrl: string }): Promise<ImageDataUrlSize> {
+    const size = await this.page.evaluate(async({ dataUrl }) => {
+      const image = new Image()
+
+      await new Promise<void>((resolve, reject) => {
+        image.onload = () => resolve()
+        image.onerror = () => reject(new Error('Не удалось загрузить data URL изображение'))
+        image.src = dataUrl
+      })
+
+      return {
+        width: image.width,
+        height: image.height
+      }
+    }, params)
+
+    expect(size, 'размер изображения должен читаться из data URL').not.toBeNull()
+
+    return size
+  }
+
   /** Возвращает цвет пикселя из data URL изображения. */
   async getDataUrlPixelColor(params: { dataUrl: string, x: number, y: number }): Promise<ImagePixelColor> {
     const pixel = await this.page.evaluate(async({ dataUrl, x, y }) => {
@@ -268,6 +317,36 @@ export class ImageModel {
     }
 
     return info
+  }
+
+  /** Переносит левый верхний угол bounds изображения в координаты canvas-сцены. */
+  async moveBoundsTo(
+    params: { left: number, top: number } & ObjectTargetParams
+  ): Promise<SnappingObjectSnapshot> {
+    const snapshot = await this.page.evaluate(({
+      objectIndex,
+      id,
+      left,
+      top
+    }) => {
+      const {
+        editor,
+        __editorHelpers: helpers
+      } = window as any
+      const target = helpers.resolveCanvasObject(objectIndex, id)
+      if (!target) return null
+
+      target.set({ left, top })
+      target.setCoords()
+      editor.canvas.renderAll()
+
+      return helpers.serializeSnappingObjectSnapshot(target)
+    }, params)
+
+    await waitForCanvasRender({ page: this.page })
+    expect(snapshot, 'должен существовать snapshot изображения после переноса').not.toBeNull()
+
+    return snapshot as SnappingObjectSnapshot
   }
 
   /** Масштабирует изображение вправо через реальную drag-сессию с фиксированной левой верхней точкой. */

--- a/e2e/tests/image-manager/index.spec.ts
+++ b/e2e/tests/image-manager/index.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../../fixtures/editor.fixture'
 import {
   IMAGE_BASE_SIZE,
+  IMAGE_EXPORT_EDGE_COLOR_TOLERANCE,
+  IMAGE_EXPORT_EDGE_FILL,
+  IMAGE_EXPORT_MONTAGE_SIZE,
+  IMAGE_EXPORT_WHITE_PIXEL_MIN_CHANNEL,
+  IMAGE_OUTSIDE_MONTAGE_OBJECT,
   IMAGE_TOLERANCE
 } from '../../fixtures/data/image.data'
 
@@ -28,6 +33,120 @@ test.describe('Импорт изображения', () => {
 })
 
 test.describe('Экспорт изображения', () => {
+  test('JPEG-экспорт не осветляет внешний край монтажной области', async({
+    images
+  }) => {
+    await test.step('Заполнить монтажную область цветным изображением до краёв', async() => {
+      const imageObject = await images.addFilledImage({
+        ...IMAGE_EXPORT_MONTAGE_SIZE,
+        fill: IMAGE_EXPORT_EDGE_FILL,
+        scale: 'scale-montage',
+        withoutSelection: true
+      })
+
+      images.checkCreation({ imageObject })
+    })
+
+    const dataUrl = await test.step('Экспортировать монтажную область в JPEG', async() => {
+      return images.exportCanvasAsBase64({ contentType: 'image/jpeg' })
+    })
+
+    const centerPixel = await test.step('Прочитать внутренний пиксель экспортированного JPEG', async() => {
+      return images.getDataUrlPixelColor({
+        dataUrl,
+        x: IMAGE_EXPORT_MONTAGE_SIZE.width / 2,
+        y: IMAGE_EXPORT_MONTAGE_SIZE.height / 2
+      })
+    })
+
+    const edgePixels = await test.step('Прочитать edge-пиксели экспортированного JPEG', async() => {
+      return Promise.all([
+        images.getDataUrlPixelColor({
+          dataUrl,
+          x: 0,
+          y: IMAGE_EXPORT_MONTAGE_SIZE.height / 2
+        }),
+        images.getDataUrlPixelColor({
+          dataUrl,
+          x: IMAGE_EXPORT_MONTAGE_SIZE.width - 1,
+          y: IMAGE_EXPORT_MONTAGE_SIZE.height / 2
+        }),
+        images.getDataUrlPixelColor({
+          dataUrl,
+          x: IMAGE_EXPORT_MONTAGE_SIZE.width / 2,
+          y: 0
+        }),
+        images.getDataUrlPixelColor({
+          dataUrl,
+          x: IMAGE_EXPORT_MONTAGE_SIZE.width / 2,
+          y: IMAGE_EXPORT_MONTAGE_SIZE.height - 1
+        })
+      ])
+    })
+
+    await test.step('Проверить что внешний край совпадает с внутренней заливкой', () => {
+      for (const edgePixel of edgePixels) {
+        const redDelta = Math.abs(edgePixel.red - centerPixel.red)
+        const greenDelta = Math.abs(edgePixel.green - centerPixel.green)
+        const blueDelta = Math.abs(edgePixel.blue - centerPixel.blue)
+
+        expect(redDelta).toBeLessThanOrEqual(IMAGE_EXPORT_EDGE_COLOR_TOLERANCE)
+        expect(greenDelta).toBeLessThanOrEqual(IMAGE_EXPORT_EDGE_COLOR_TOLERANCE)
+        expect(blueDelta).toBeLessThanOrEqual(IMAGE_EXPORT_EDGE_COLOR_TOLERANCE)
+        expect(edgePixel.alpha).toBe(255)
+      }
+    })
+  })
+
+  test('JPEG-экспорт не включает объект, который целиком находится за монтажной областью', async({
+    canvas,
+    images
+  }) => {
+    await test.step('Задать размер монтажной области', async() => {
+      await canvas.setMontageResolution(IMAGE_EXPORT_MONTAGE_SIZE)
+    })
+
+    const outsideImage = await test.step('Добавить изображение и перенести его за левую границу', async() => {
+      const imageObject = await images.addFilledImage({
+        width: IMAGE_OUTSIDE_MONTAGE_OBJECT.width,
+        height: IMAGE_OUTSIDE_MONTAGE_OBJECT.height,
+        fill: '#ff0000',
+        withoutSelection: true
+      })
+      const image = images.checkCreation({ imageObject })
+
+      return images.moveBoundsTo({
+        id: image.id,
+        left: IMAGE_OUTSIDE_MONTAGE_OBJECT.left,
+        top: IMAGE_OUTSIDE_MONTAGE_OBJECT.top
+      })
+    })
+
+    const dataUrl = await test.step('Экспортировать монтажную область в JPEG', async() => {
+      return images.exportCanvasAsBase64({ contentType: 'image/jpeg' })
+    })
+
+    const exportedSize = await test.step('Получить размер экспортированного JPEG', async() => {
+      return images.getDataUrlSize({ dataUrl })
+    })
+
+    const edgePixel = await test.step('Прочитать пиксель рядом с объектом за границей', async() => {
+      return images.getDataUrlPixelColor({
+        dataUrl,
+        x: 0,
+        y: Math.round(outsideImage.centerY)
+      })
+    })
+
+    await test.step('Проверить что экспорт остался в границах монтажной области', () => {
+      expect(exportedSize).toEqual(IMAGE_EXPORT_MONTAGE_SIZE)
+      expect(edgePixel.red).toBeGreaterThanOrEqual(IMAGE_EXPORT_WHITE_PIXEL_MIN_CHANNEL)
+      expect(edgePixel.green).toBeGreaterThanOrEqual(IMAGE_EXPORT_WHITE_PIXEL_MIN_CHANNEL)
+      expect(edgePixel.blue).toBeGreaterThanOrEqual(IMAGE_EXPORT_WHITE_PIXEL_MIN_CHANNEL)
+      expect(edgePixel.alpha).toBe(255)
+    })
+  })
+
   test('экспортирует обрезанное изображение в base64 с учётом crop-области', async({
     crop,
     images

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.03",
+  "version": "0.10.04",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.10.03",
+      "version": "0.10.04",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.03",
+  "version": "0.10.04",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/image-manager/index.spec.ts
+++ b/specs/src/editor/image-manager/index.spec.ts
@@ -565,6 +565,23 @@ describe('ImageManager', () => {
       expect(clone.backgroundColor).toBe('#ffffff')
     })
 
+    it('убирает canvas clipPath из экспортного клона', async() => {
+      const { clone } = createMockCanvasClone({
+        objects: [{ id: mockEditor.montageArea.id, visible: true }]
+      })
+      let clipPathDuringRender: unknown = null
+
+      clone.renderAll.mockImplementation(() => {
+        clipPathDuringRender = clone.clipPath
+      })
+      mockCanvas.clone.mockResolvedValueOnce(clone)
+
+      await imageManager.exportCanvasAsImageFile({ contentType: 'image/jpeg', exportAsBlob: true })
+
+      expect(clipPathDuringRender).toBeUndefined()
+      expect(clone.clipPath).toBeUndefined()
+    })
+
     it('exports canvas as PDF base64', async() => {
       mockWorkerManager.post.mockResolvedValueOnce('data:image/png;base64,canvas')
 

--- a/specs/test-utils/managers/image.ts
+++ b/specs/test-utils/managers/image.ts
@@ -112,6 +112,7 @@ export const createMockCanvasClone = ({
   const clone = {
     enableRetinaScaling: true,
     backgroundColor: '',
+    clipPath: { id: 'area-clip' },
     viewportTransform: [1, 0, 0, 1, 0, 0] as any,
     getObjects: jest.fn().mockReturnValue(objects),
     getElement: jest.fn().mockReturnValue(element),

--- a/src/editor/image-manager/canvas-export.ts
+++ b/src/editor/image-manager/canvas-export.ts
@@ -166,6 +166,11 @@ function prepareClonedCanvasForExport({
   hideMontageArea({ editor, tmpCanvas })
   hideInteractionBlockerOverlay({ editor, tmpCanvas })
 
+  // Экспортный bitmap уже ограничен размерами монтажной области. Если оставить
+  // canvas-level clipPath в клоне, canvas сглаживает этот край, и JPG получает
+  // заметную серую рамку.
+  tmpCanvas.clipPath = undefined
+
   tmpCanvas.viewportTransform = [1, 0, 0, 1, -left, -top]
   tmpCanvas.setDimensions({ width, height }, { backstoreOnly: true })
   tmpCanvas.renderAll()


### PR DESCRIPTION
При сохранении монтажная область обрезалась дважды: физическим размером экспортного canvas и clipPath в библиотеке редактора. clipPath лежал ровно по краю экспортируемого битмапа, поэтому canvas сглаживал край маски. При экспорте в JPEG полупрозрачные пиксели по краям смешивались с белым фоном и превращались в серую 1px-рамку.