### PR TITLE
Рефакторинг. Делаем общую логику рассчёта snapping при перемещении изображений.

### DIFF
--- a/e2e/models/snapping.model.ts
+++ b/e2e/models/snapping.model.ts
@@ -11,27 +11,37 @@ import type {
 } from '../types'
 import { waitForCanvasRender } from '../helpers/canvas-render.helper'
 
-type CanvasPagePoint = {
+/** Координаты указателя в клиентской системе браузера. */
+type CanvasClientPoint = {
   x: number
   y: number
 }
 
+/** Данные Fabric-преобразования, необходимые для следующего шага drag. */
 type DragTransformInfo = {
   offsetX: number
   offsetY: number
-  pointerX: number
-  pointerY: number
   snapshot: SnappingObjectSnapshot
 }
 
+/** Идентификатор объекта и модификатор одного pointer-step. */
+type DragPointerParams = ObjectTargetParams & {
+  ctrlKey?: boolean
+}
+
+/** Управляет пользовательскими drag-сценариями и читает состояние прилипания. */
 export class SnappingModel {
   private readonly page: Page
 
-  private activePointerPagePoint: CanvasPagePoint | null
+  private activePointerClientPoint: CanvasClientPoint | null
 
+  private isControlKeyPressed: boolean
+
+  /** Создаёт модель прилипания для указанной Playwright-страницы. */
   constructor(page: Page) {
     this.page = page
-    this.activePointerPagePoint = null
+    this.activePointerClientPoint = null
+    this.isControlKeyPressed = false
   }
 
   /** Возвращает текущее состояние направляющих SnappingManager. */
@@ -63,8 +73,30 @@ export class SnappingModel {
     return snapshot as SnappingObjectSnapshot
   }
 
-  /** Начинает интерактивное перетаскивание объекта и кеширует anchor-ы для снапа. */
+  /** Начинает реальное перетаскивание выбранного объекта из его центра. */
   async startObjectDrag(params: SnappingDragStartParams = {}): Promise<SnappingObjectSnapshot> {
+    const dragStart = await this._resolveObjectDragStartClientPoint(params)
+
+    await waitForCanvasRender({ page: this.page })
+
+    const { x, y } = dragStart
+    this.activePointerClientPoint = {
+      x,
+      y
+    }
+    await this.page.mouse.move(x, y)
+    await this.page.mouse.down()
+    await waitForCanvasRender({ page: this.page })
+
+    await this._assertObjectDragStarted(params)
+
+    return this.getObjectSnapshot(params)
+  }
+
+  /** Возвращает клиентские координаты центра выбранного объекта. */
+  private async _resolveObjectDragStartClientPoint(
+    params: SnappingDragStartParams
+  ): Promise<CanvasClientPoint> {
     const dragStart = await this.page.evaluate(({ objectIndex, id }) => {
       const {
         editor,
@@ -77,16 +109,14 @@ export class SnappingModel {
       editor.canvas.setActiveObject(target)
       target.setCoords()
 
-      const originX = typeof target.originX === 'string' ? target.originX : 'left'
-      const originY = typeof target.originY === 'string' ? target.originY : 'top'
-      const originPoint = typeof target.getPointByOrigin === 'function'
-        ? target.getPointByOrigin(originX, originY)
+      const centerPoint = typeof target.getCenterPoint === 'function'
+        ? target.getCenterPoint()
         : {
           x: typeof target.left === 'number' ? target.left : 0,
           y: typeof target.top === 'number' ? target.top : 0
         }
-      const sceneX = typeof originPoint.x === 'number' ? originPoint.x : 0
-      const sceneY = typeof originPoint.y === 'number' ? originPoint.y : 0
+      const sceneX = typeof centerPoint.x === 'number' ? centerPoint.x : 0
+      const sceneY = typeof centerPoint.y === 'number' ? centerPoint.y : 0
       const [a, b, c, d, tx, ty] = editor.canvas.viewportTransform
       const rect = editor.canvas.upperCanvasEl.getBoundingClientRect()
 
@@ -99,59 +129,42 @@ export class SnappingModel {
     }, params)
 
     expect(dragStart, 'должна существовать стартовая pointer-точка для перетаскивания').not.toBeNull()
+    expect(Number.isFinite(dragStart?.x), 'стартовая X-координата drag должна быть конечной').toBe(true)
+    expect(Number.isFinite(dragStart?.y), 'стартовая Y-координата drag должна быть конечной').toBe(true)
 
-    await waitForCanvasRender({ page: this.page })
+    return dragStart as CanvasClientPoint
+  }
 
-    const { x, y } = dragStart as CanvasPagePoint
-    this.activePointerPagePoint = {
-      x,
-      y
-    }
-    await this._dispatchPointerDown({
-      point: this.activePointerPagePoint
-    })
-    await waitForCanvasRender({ page: this.page })
-
-    const transformReady = await this.page.evaluate(({ objectIndex, id }) => {
+  /** Проверяет, что pointerdown начал именно перемещение выбранного объекта. */
+  private async _assertObjectDragStarted(params: SnappingDragStartParams): Promise<void> {
+    const dragTransform = await this.page.evaluate(({ objectIndex, id }) => {
       const {
         editor,
         __editorHelpers: helpers
       } = window as any
 
       const target = helpers.resolveCanvasObject(objectIndex, id)
-      if (!target) return false
-
       const transform = editor.canvas._currentTransform
-      if (!transform) return false
+      if (!target || !transform || transform.target !== target) return null
 
-      return transform.target === target
+      return {
+        action: transform.action ?? null
+      }
     }, params)
 
-    expect(transformReady, 'после начала drag должен появиться transform для нужного объекта').toBe(true)
-
-    return this.getObjectSnapshot(params)
+    expect(dragTransform, 'после начала drag должен появиться transform для нужного объекта').not.toBeNull()
+    expect(dragTransform?.action, 'pointerdown должен начать перемещение, а не работу с control').toBe('drag')
   }
 
   /** Перемещает объект в live drag-сессии и возвращает его новый snapshot. */
   async dragObjectTo(params: SnappingDragMoveParams): Promise<SnappingObjectSnapshot> {
     const dragInfo = await this._getDragTransformInfo(params)
-    const targetSceneX = params.left === dragInfo.snapshot.left
-      ? dragInfo.pointerX
-      : params.left + dragInfo.offsetX
-    const targetSceneY = params.top === dragInfo.snapshot.top
-      ? dragInfo.pointerY
-      : params.top + dragInfo.offsetY
-    const pagePoint = await this._resolvePagePointForScenePoint({
-      x: targetSceneX,
-      y: targetSceneY
+    return this._moveDragPointerToFabricPosition({
+      params,
+      dragInfo,
+      left: params.left,
+      top: params.top
     })
-
-    await this._movePointerDuringDrag({
-      point: pagePoint,
-      ctrlKey: params.ctrlKey
-    })
-
-    return this.getObjectSnapshot(params)
   }
 
   /** Перемещает объект в live drag-сессии так, чтобы его bounding box пришёл в нужную позицию. */
@@ -159,23 +172,13 @@ export class SnappingModel {
     const dragInfo = await this._getDragTransformInfo(params)
     const nextLeft = dragInfo.snapshot.left + (params.left - dragInfo.snapshot.boundsLeft)
     const nextTop = dragInfo.snapshot.top + (params.top - dragInfo.snapshot.boundsTop)
-    const targetSceneX = params.left === dragInfo.snapshot.boundsLeft
-      ? dragInfo.pointerX
-      : nextLeft + dragInfo.offsetX
-    const targetSceneY = params.top === dragInfo.snapshot.boundsTop
-      ? dragInfo.pointerY
-      : nextTop + dragInfo.offsetY
-    const pagePoint = await this._resolvePagePointForScenePoint({
-      x: targetSceneX,
-      y: targetSceneY
-    })
 
-    await this._movePointerDuringDrag({
-      point: pagePoint,
-      ctrlKey: params.ctrlKey
+    return this._moveDragPointerToFabricPosition({
+      params,
+      dragInfo,
+      left: nextLeft,
+      top: nextTop
     })
-
-    return this.getObjectSnapshot(params)
   }
 
   /** Выполняет полный drag объекта до нужной позиции bounding box и завершает его через mouseup. */
@@ -192,19 +195,34 @@ export class SnappingModel {
     const dragInfo = await this._getDragTransformInfo(params)
     const nextLeft = dragInfo.snapshot.left + (params.centerX - dragInfo.snapshot.centerX)
     const nextTop = dragInfo.snapshot.top + (params.centerY - dragInfo.snapshot.centerY)
-    const targetSceneX = params.centerX === dragInfo.snapshot.centerX
-      ? dragInfo.pointerX
-      : nextLeft + dragInfo.offsetX
-    const targetSceneY = params.centerY === dragInfo.snapshot.centerY
-      ? dragInfo.pointerY
-      : nextTop + dragInfo.offsetY
-    const pagePoint = await this._resolvePagePointForScenePoint({
-      x: targetSceneX,
-      y: targetSceneY
+
+    return this._moveDragPointerToFabricPosition({
+      params,
+      dragInfo,
+      left: nextLeft,
+      top: nextTop
+    })
+  }
+
+  /** Перемещает реальный указатель в позицию, соответствующую Fabric left/top. */
+  private async _moveDragPointerToFabricPosition({
+    params,
+    dragInfo,
+    left,
+    top
+  }: {
+    params: DragPointerParams
+    dragInfo: DragTransformInfo
+    left: number
+    top: number
+  }): Promise<SnappingObjectSnapshot> {
+    const clientPoint = await this._resolveClientPointForScenePoint({
+      x: left + dragInfo.offsetX,
+      y: top + dragInfo.offsetY
     })
 
     await this._movePointerDuringDrag({
-      point: pagePoint,
+      point: clientPoint,
       ctrlKey: params.ctrlKey
     })
 
@@ -214,19 +232,19 @@ export class SnappingModel {
   /** Завершает pointer-взаимодействие и очищает направляющие как после mouseup. */
   async finishPointerInteraction(): Promise<SnappingGuideState> {
     expect(
-      this.activePointerPagePoint,
+      this.activePointerClientPoint,
       'pointer interaction должна завершаться только после начала drag'
     ).not.toBeNull()
 
-    await this._dispatchPointerUp({
-      point: this.activePointerPagePoint as CanvasPagePoint
-    })
+    await this.page.mouse.up()
     await waitForCanvasRender({ page: this.page })
-    this.activePointerPagePoint = null
+    await this._setControlKeyPressed({ pressed: false })
+    this.activePointerClientPoint = null
 
     return this.getGuideState()
   }
 
+  /** Возвращает текущее Fabric-преобразование и геометрию выбранного объекта. */
   private async _getDragTransformInfo(params: ObjectTargetParams): Promise<DragTransformInfo> {
     const dragInfo = await this.page.evaluate(({ objectIndex, id }) => {
       const {
@@ -243,8 +261,6 @@ export class SnappingModel {
       return {
         offsetX: typeof transform.offsetX === 'number' ? transform.offsetX : 0,
         offsetY: typeof transform.offsetY === 'number' ? transform.offsetY : 0,
-        pointerX: typeof transform.lastX === 'number' ? transform.lastX : 0,
-        pointerY: typeof transform.lastY === 'number' ? transform.lastY : 0,
         snapshot: helpers.serializeSnappingObjectSnapshot(target)
       }
     }, params)
@@ -254,7 +270,10 @@ export class SnappingModel {
     return dragInfo as DragTransformInfo
   }
 
-  private async _resolvePagePointForScenePoint(point: { x: number, y: number }): Promise<CanvasPagePoint> {
+  /** Переводит координаты сцены в клиентские координаты браузера. */
+  private async _resolveClientPointForScenePoint(
+    point: { x: number, y: number }
+  ): Promise<CanvasClientPoint> {
     return this.page.evaluate(({ x, y }) => {
       const {
         editor
@@ -270,100 +289,35 @@ export class SnappingModel {
     }, point)
   }
 
+  /** Выполняет одно реальное перемещение указателя с явно заданным состоянием Ctrl. */
   private async _movePointerDuringDrag({
     point,
     ctrlKey = false
   }: {
-    point: CanvasPagePoint
+    point: CanvasClientPoint
     ctrlKey?: boolean
   }): Promise<void> {
-    await this._dispatchPointerMove({
-      point,
-      ctrlKey
-    })
+    await this._setControlKeyPressed({ pressed: ctrlKey })
+    await this.page.mouse.move(point.x, point.y)
     await waitForCanvasRender({ page: this.page })
-    this.activePointerPagePoint = point
+    this.activePointerClientPoint = point
   }
 
-  private async _dispatchPointerDown({
-    point
+  /** Синхронизирует Ctrl с состоянием модификатора следующего события мыши. */
+  private async _setControlKeyPressed({
+    pressed
   }: {
-    point: CanvasPagePoint
+    pressed: boolean
   }): Promise<void> {
-    await this.page.evaluate(({ x, y }) => {
-      const {
-        editor
-      } = window as any
+    if (pressed === this.isControlKeyPressed) return
 
-      const event = new PointerEvent('pointerdown', {
-        clientX: x,
-        clientY: y,
-        button: 0,
-        buttons: 1,
-        bubbles: true,
-        cancelable: true,
-        pointerId: 1,
-        isPrimary: true
-      })
+    if (pressed) {
+      await this.page.keyboard.down('Control')
+      this.isControlKeyPressed = true
+      return
+    }
 
-      editor.canvas._onMouseDown(event)
-    }, point)
-  }
-
-  private async _dispatchPointerMove({
-    point,
-    ctrlKey
-  }: {
-    point: CanvasPagePoint
-    ctrlKey: boolean
-  }): Promise<void> {
-    await this.page.evaluate(({ x, y, ctrlKey: isCtrlPressed }) => {
-      const {
-        editor
-      } = window as any
-
-      const event = new PointerEvent('pointermove', {
-        clientX: x,
-        clientY: y,
-        button: 0,
-        buttons: 1,
-        bubbles: true,
-        cancelable: true,
-        pointerId: 1,
-        isPrimary: true,
-        ctrlKey: isCtrlPressed
-      })
-
-      editor.canvas._onMouseMove(event)
-    }, {
-      x: point.x,
-      y: point.y,
-      ctrlKey
-    })
-  }
-
-  private async _dispatchPointerUp({
-    point
-  }: {
-    point: CanvasPagePoint
-  }): Promise<void> {
-    await this.page.evaluate(({ x, y }) => {
-      const {
-        editor
-      } = window as any
-
-      const event = new PointerEvent('pointerup', {
-        clientX: x,
-        clientY: y,
-        button: 0,
-        buttons: 0,
-        bubbles: true,
-        cancelable: true,
-        pointerId: 1,
-        isPrimary: true
-      })
-
-      editor.canvas._onMouseUp(event)
-    }, point)
+    await this.page.keyboard.up('Control')
+    this.isControlKeyPressed = false
   }
 }

--- a/e2e/tests/snapping-manager/snapping-image-moving.spec.ts
+++ b/e2e/tests/snapping-manager/snapping-image-moving.spec.ts
@@ -1,0 +1,225 @@
+import { test, expect } from '../../fixtures/editor.fixture'
+import { SNAPPING_TOLERANCE } from '../../fixtures/data/snapping.data'
+import type { SnappingObjectSnapshot } from '../../types'
+
+/** Данные для сценариев перемещения изображения. */
+type ImageMovementSetup = {
+  imageId: string
+  reference: SnappingObjectSnapshot
+}
+
+let setup: ImageMovementSetup
+
+test.beforeEach(async({
+  editorModel,
+  images,
+  shapes,
+  snapping
+}) => {
+  const montageBounds = await editorModel.getMontageAreaBounds()
+  const importedImage = await images.addFilledImage({
+    width: 30,
+    height: 30
+  })
+  const image = images.checkCreation({ imageObject: importedImage })
+  const referenceShape = await shapes.addAtBounds({
+    presetKey: 'square',
+    options: {
+      id: 'reference-shape',
+      left: montageBounds.left + 100,
+      top: montageBounds.top + 120,
+      width: 12,
+      height: 40,
+      text: ''
+    }
+  })
+
+  shapes.checkCreation({
+    shape: referenceShape,
+    presetKey: 'square'
+  })
+
+  setup = {
+    imageId: image.id,
+    reference: await snapping.getObjectSnapshot({ id: 'reference-shape' })
+  }
+})
+
+test('при движении внутри зоны прилипания не переключает изображение на более близкую направляющую', async({
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.imageId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+
+  expect(snapped.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(snapped.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+
+  const held = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: snapped.boundsLeft + 4,
+    top: snapped.boundsTop + 4
+  })
+  const guideState = await snapping.getGuideState()
+
+  expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 1)
+  expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 1)
+  expect(guideState.guides).toEqual(expect.arrayContaining([
+    {
+      type: 'vertical',
+      position: setup.reference.boundsLeft
+    },
+    {
+      type: 'horizontal',
+      position: setup.reference.boundsTop
+    }
+  ]))
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.imageId })
+
+  expect(committed.boundsLeft).toBeCloseTo(held.boundsLeft, 1)
+  expect(committed.boundsTop).toBeCloseTo(held.boundsTop, 1)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('при выходе по горизонтали отпускает только вертикальную направляющую и не меняет положение после mouseup', async({
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.imageId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+
+  expect(snapped.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(snapped.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+
+  const releasedX = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: snapped.boundsLeft + 40,
+    top: snapped.boundsTop + 4
+  })
+  const guideState = await snapping.getGuideState()
+  const verticalGuides = guideState.guides.filter((guide) => guide.type === 'vertical')
+  const horizontalGuides = guideState.guides.filter((guide) => guide.type === 'horizontal')
+
+  expect(Math.abs(releasedX.boundsLeft - snapped.boundsLeft))
+    .toBeGreaterThan(SNAPPING_TOLERANCE.position)
+  expect(releasedX.boundsTop).toBeCloseTo(snapped.boundsTop, 1)
+  expect(verticalGuides).toHaveLength(0)
+  expect(horizontalGuides).toEqual([{
+    type: 'horizontal',
+    position: setup.reference.boundsTop
+  }])
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.imageId })
+
+  expect(committed.boundsLeft).toBeCloseTo(releasedX.boundsLeft, 1)
+  expect(committed.boundsTop).toBeCloseTo(releasedX.boundsTop, 1)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('при нажатии Ctrl снимает удержание и после отпускания выбирает направляющую заново', async({
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.imageId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const withoutSnap = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: snapped.boundsLeft + 4,
+    top: snapped.boundsTop + 4,
+    ctrlKey: true
+  })
+  const disabledGuides = await snapping.getGuideState()
+
+  expect(Math.abs(withoutSnap.boundsLeft - (snapped.boundsLeft + 4)))
+    .toBeLessThanOrEqual(SNAPPING_TOLERANCE.position)
+  expect(Math.abs(withoutSnap.boundsTop - (snapped.boundsTop + 4)))
+    .toBeLessThanOrEqual(SNAPPING_TOLERANCE.position)
+  expect(disabledGuides.guides).toHaveLength(0)
+  expect(disabledGuides.spacingGuides).toHaveLength(0)
+
+  const reacquired = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: setup.reference.centerX + 1,
+    top: withoutSnap.boundsTop
+  })
+  const enabledGuides = await snapping.getGuideState()
+
+  expect(reacquired.boundsLeft).toBeCloseTo(setup.reference.centerX, 1)
+  expect(reacquired.boundsLeft).not.toBeCloseTo(snapped.boundsLeft, 1)
+  expect(enabledGuides.guides).toEqual(expect.arrayContaining([{
+    type: 'vertical',
+    position: setup.reference.centerX
+  }]))
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.imageId })
+
+  expect(committed.boundsLeft).toBeCloseTo(reacquired.boundsLeft, 1)
+  expect(committed.boundsTop).toBeCloseTo(reacquired.boundsTop, 1)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('при небольшом продолжении движения удерживает равноудалённость изображения', async({
+  shapes,
+  snapping
+}) => {
+  const rightShape = await shapes.addAtBounds({
+    presetKey: 'square',
+    options: {
+      id: 'right-reference-shape',
+      left: setup.reference.boundsRight + 130,
+      top: setup.reference.boundsTop,
+      width: 12,
+      height: 40,
+      text: ''
+    }
+  })
+  shapes.checkCreation({ shape: rightShape, presetKey: 'square' })
+  const rightReference = await snapping.getObjectSnapshot({ id: 'right-reference-shape' })
+  const image = await snapping.getObjectSnapshot({ id: setup.imageId })
+  const expectedLeft = setup.reference.boundsRight
+    + ((rightReference.boundsLeft - setup.reference.boundsRight - image.boundsWidth) / 2)
+
+  await snapping.startObjectDrag({ id: setup.imageId })
+  const spaced = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: expectedLeft + 3,
+    top: setup.reference.boundsTop + 5
+  })
+  const firstGuides = await snapping.getGuideState()
+  const held = await snapping.dragObjectBoundsTo({
+    id: setup.imageId,
+    left: spaced.boundsLeft + 4,
+    top: spaced.boundsTop
+  })
+  const heldGuides = await snapping.getGuideState()
+
+  expect(spaced.boundsLeft).toBeCloseTo(expectedLeft, 0)
+  expect(firstGuides.spacingGuides.length).toBeGreaterThan(0)
+  expect(held.boundsLeft).toBeCloseTo(spaced.boundsLeft, 0)
+  expect(held.boundsTop).toBeCloseTo(spaced.boundsTop, 1)
+  expect(heldGuides.spacingGuides.length).toBeGreaterThan(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.imageId })
+
+  expect(committed.boundsLeft).toBeCloseTo(held.boundsLeft, 1)
+  expect(committed.boundsTop).toBeCloseTo(held.boundsTop, 1)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.10.10",
+      "version": "0.10.11",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/snapping-manager/movement-snap-candidates.spec.ts
+++ b/specs/src/editor/snapping-manager/movement-snap-candidates.spec.ts
@@ -1,0 +1,82 @@
+import { createMovementSnapEnvironment } from '../../../../src/editor/snapping-manager/movement-snap-candidates'
+import { createMovementBounds } from '../../../test-utils/shared/movement-snapping-core'
+
+it('фиксирует стабильный порядок линий и отделяет montage от spacing-целей', () => {
+  const referenceBounds = createMovementBounds({
+    left: 100,
+    top: 120,
+    width: 40,
+    height: 20
+  })
+  const montageBounds = createMovementBounds({
+    left: 0,
+    top: 0,
+    width: 500,
+    height: 400
+  })
+  const environment = createMovementSnapEnvironment({
+    sources: [
+      {
+        id: 'reference',
+        bounds: referenceBounds,
+        useForSpacing: true
+      },
+      {
+        id: 'montage',
+        bounds: montageBounds,
+        edgeCategory: 'domain-boundary'
+      }
+    ],
+    zoom: 2
+  })
+
+  expect(environment.candidates).toHaveLength(12)
+  expect(environment.candidates[0]).toEqual(expect.objectContaining({
+    id: 'reference:left',
+    position: referenceBounds.left,
+    snapshotIndex: 0
+  }))
+  expect(environment.candidates[6]).toEqual(expect.objectContaining({
+    id: 'montage:left',
+    category: 'domain-boundary',
+    snapshotIndex: 6
+  }))
+  expect(environment.spacingBounds).toEqual([referenceBounds])
+  expect(environment.zoom).toBe(2)
+  expect(Object.isFrozen(environment.candidates)).toBe(true)
+})
+
+it('отклоняет неуникальные id, некорректные центры и zoom', () => {
+  const bounds = createMovementBounds({
+    left: 0,
+    top: 0
+  })
+
+  expect(() => {
+    createMovementSnapEnvironment({
+      sources: [
+        { id: 'same', bounds },
+        { id: 'same', bounds }
+      ],
+      zoom: 1
+    })
+  }).toThrow('must be non-empty and unique')
+  expect(() => {
+    createMovementSnapEnvironment({
+      sources: [{
+        id: 'invalid-center',
+        bounds: {
+          ...bounds,
+          centerX: bounds.centerX + 1
+        }
+      }],
+      zoom: 1
+    })
+  }).toThrow('centers must be derived')
+  expect(() => {
+    createMovementSnapEnvironment({
+      sources: [],
+      zoom: 0
+    })
+  }).toThrow('zoom must be a finite positive number')
+})

--- a/specs/src/editor/snapping-manager/movement-snapping-lifecycle.spec.ts
+++ b/specs/src/editor/snapping-manager/movement-snapping-lifecycle.spec.ts
@@ -1,0 +1,207 @@
+import { emitCanvasEvent } from '../../../test-utils/canvas/events'
+import {
+  createMovementSnappingLifecycleSetup,
+  seedVisibleSnappingState
+} from '../../../test-utils/managers/snapping-lifecycle'
+
+/** Canvas-события, которые завершают текущий snapping interaction. */
+const CANVAS_TERMINAL_EVENTS = [
+  'mouse:up',
+  'selection:created',
+  'selection:updated',
+  'selection:cleared'
+] as const
+
+/** Window-события, которые прерывают текущий snapping interaction. */
+const WINDOW_TERMINAL_EVENTS = [
+  'pointercancel',
+  'touchcancel',
+  'blur'
+] as const
+
+it('новый mousedown очищает направляющие и кеш предыдущего interaction', () => {
+  const {
+    manager,
+    canvas,
+    state,
+    activeTarget,
+    startGestureMock
+  } = createMovementSnappingLifecycleSetup()
+  emitCanvasEvent({
+    canvas,
+    event: 'mouse:down',
+    payload: { target: activeTarget }
+  })
+  seedVisibleSnappingState({ state })
+
+  emitCanvasEvent({
+    canvas,
+    event: 'mouse:down',
+    payload: { target: activeTarget }
+  })
+
+  expect(startGestureMock).toHaveBeenCalledTimes(2)
+  expect(state.activeMovementSnappingTarget).toBe(activeTarget)
+  expect(state.activeGuides).toEqual([])
+  expect(state.activeSpacingGuides).toEqual([])
+  expect(state.anchors.vertical).not.toContain(100)
+  expect(state.anchors.horizontal).not.toContain(80)
+
+  manager.destroy()
+})
+
+it.each(CANVAS_TERMINAL_EVENTS)('%s очищает movement-сессию и видимые направляющие', (event) => {
+  const {
+    manager,
+    canvas,
+    state,
+    activeTarget,
+    finishGestureMock
+  } = createMovementSnappingLifecycleSetup()
+  emitCanvasEvent({
+    canvas,
+    event: 'mouse:down',
+    payload: { target: activeTarget }
+  })
+  seedVisibleSnappingState({ state })
+
+  emitCanvasEvent({ canvas, event })
+
+  expect(finishGestureMock).toHaveBeenCalledTimes(1)
+  expect(state.activeMovementSnappingTarget).toBeNull()
+  expect(state.activeGuides).toEqual([])
+  expect(state.activeSpacingGuides).toEqual([])
+  expect(state.anchors).toEqual({ vertical: [], horizontal: [] })
+
+  manager.destroy()
+})
+
+it.each(WINDOW_TERMINAL_EVENTS)('%s прерывает movement-сессию и очищает направляющие', (event) => {
+  const {
+    manager,
+    canvas,
+    state,
+    activeTarget,
+    finishGestureMock
+  } = createMovementSnappingLifecycleSetup()
+  emitCanvasEvent({
+    canvas,
+    event: 'mouse:down',
+    payload: { target: activeTarget }
+  })
+  seedVisibleSnappingState({ state })
+
+  window.dispatchEvent(new Event(event))
+
+  expect(finishGestureMock).toHaveBeenCalledTimes(1)
+  expect(state.activeMovementSnappingTarget).toBeNull()
+  expect(state.activeGuides).toEqual([])
+  expect(state.activeSpacingGuides).toEqual([])
+  expect(state.anchors).toEqual({ vertical: [], horizontal: [] })
+
+  manager.destroy()
+})
+
+it('удаление активного изображения завершает его movement-сессию', () => {
+  const {
+    manager,
+    canvas,
+    state,
+    activeTarget,
+    finishGestureMock
+  } = createMovementSnappingLifecycleSetup()
+  emitCanvasEvent({
+    canvas,
+    event: 'mouse:down',
+    payload: { target: activeTarget }
+  })
+  seedVisibleSnappingState({ state })
+
+  emitCanvasEvent({
+    canvas,
+    event: 'object:removed',
+    payload: { target: activeTarget }
+  })
+
+  expect(finishGestureMock).toHaveBeenCalledTimes(1)
+  expect(state.activeMovementSnappingTarget).toBeNull()
+  expect(state.activeGuides).toEqual([])
+  expect(state.activeSpacingGuides).toEqual([])
+  expect(state.anchors).toEqual({ vertical: [], horizontal: [] })
+
+  manager.destroy()
+})
+
+it('удаление другого объекта не прерывает movement активного изображения', () => {
+  const {
+    manager,
+    canvas,
+    state,
+    activeTarget,
+    finishGestureMock
+  } = createMovementSnappingLifecycleSetup()
+  emitCanvasEvent({
+    canvas,
+    event: 'mouse:down',
+    payload: { target: activeTarget }
+  })
+  seedVisibleSnappingState({ state })
+
+  emitCanvasEvent({
+    canvas,
+    event: 'object:removed',
+    payload: { target: {} }
+  })
+
+  expect(finishGestureMock).not.toHaveBeenCalled()
+  expect(state.activeMovementSnappingTarget).toBe(activeTarget)
+  expect(state.activeGuides).toHaveLength(1)
+  expect(state.activeSpacingGuides).toHaveLength(1)
+  expect(state.anchors).toEqual({ vertical: [100], horizontal: [80] })
+
+  manager.destroy()
+})
+
+describe('уничтожение SnappingManager во время перемещения изображения', () => {
+  it('destroy очищает interaction и симметрично снимает canvas и window listeners', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener')
+
+    try {
+      const {
+        manager,
+        canvas,
+        state,
+        activeTarget,
+        finishGestureMock
+      } = createMovementSnappingLifecycleSetup()
+      emitCanvasEvent({
+        canvas,
+        event: 'mouse:down',
+        payload: { target: activeTarget }
+      })
+      seedVisibleSnappingState({ state })
+
+      manager.destroy()
+
+      expect(finishGestureMock).toHaveBeenCalledTimes(1)
+      expect(state.activeMovementSnappingTarget).toBeNull()
+      expect(state.activeGuides).toEqual([])
+      expect(canvas.off).toHaveBeenCalledWith('object:removed', expect.any(Function))
+      expect(canvas.off).toHaveBeenCalledWith('selection:created', expect.any(Function))
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('pointercancel', expect.any(Function))
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('touchcancel', expect.any(Function))
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('blur', expect.any(Function))
+
+      finishGestureMock.mockClear()
+      emitCanvasEvent({ canvas, event: 'selection:created' })
+      window.dispatchEvent(new Event('pointercancel'))
+
+      expect(finishGestureMock).not.toHaveBeenCalled()
+      expect(addEventListenerSpy).toHaveBeenCalledWith('pointercancel', expect.any(Function))
+    } finally {
+      addEventListenerSpy.mockRestore()
+      removeEventListenerSpy.mockRestore()
+    }
+  })
+})

--- a/specs/src/editor/snapping-manager/movement-snapping-resolver.spec.ts
+++ b/specs/src/editor/snapping-manager/movement-snapping-resolver.spec.ts
@@ -1,0 +1,785 @@
+import type { MovementSnapCandidateSource } from '../../../../src/editor/snapping-manager/movement-snap-candidates'
+import {
+  FREE_MOVEMENT_HOLD_STATE,
+  resolveMovementSnapPlan,
+  verifyMovementSnapPlan
+} from '../../../../src/editor/snapping-manager/movement-snapping-resolver'
+import {
+  createFinalMovementGeometry,
+  createMovementBaseline,
+  createMovementBounds,
+  createMovementRawIntent
+} from '../../../test-utils/shared/movement-snapping-core'
+
+/** Узкая цель с двумя близкими вертикальными направляющими. */
+const REFERENCE_SOURCE = {
+  id: 'reference',
+  bounds: createMovementBounds({
+    left: 100,
+    top: 100,
+    width: 12,
+    height: 40
+  }),
+  useForSpacing: true
+} satisfies MovementSnapCandidateSource
+
+/** Два широких объекта с позицией равноудалённости `left = 35` для target шириной 20. */
+const HORIZONTAL_SPACING_SOURCES = [
+  {
+    id: 'left-spacing-source',
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 300 }),
+    useForSpacing: true
+  },
+  {
+    id: 'right-spacing-source',
+    bounds: createMovementBounds({ left: 70, top: 0, width: 20, height: 300 }),
+    useForSpacing: true
+  }
+] satisfies readonly MovementSnapCandidateSource[]
+
+/** Spacing-цели, у которых после сдвига по Y появляется новый ближайший сосед. */
+const CHANGING_NEIGHBOR_SOURCES = [
+  {
+    id: 'left-spacing-source',
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 10 }),
+    useForSpacing: true
+  },
+  {
+    id: 'closer-spacing-source',
+    bounds: createMovementBounds({ left: 25, top: 7, width: 2, height: 4 }),
+    useForSpacing: true
+  },
+  {
+    id: 'right-spacing-source',
+    bounds: createMovementBounds({ left: 70, top: 0, width: 20, height: 10 }),
+    useForSpacing: true
+  }
+] satisfies readonly MovementSnapCandidateSource[]
+
+/** Источники для возврата к X-направляющей при удерживаемой Y-направляющей. */
+const CHANGING_NEIGHBOR_WITH_FALLBACK_SOURCES = [
+  ...CHANGING_NEIGHBOR_SOURCES,
+  {
+    id: 'fallback-x-line',
+    bounds: createMovementBounds({
+      left: 37,
+      top: -100,
+      width: 0,
+      height: 300
+    })
+  },
+  {
+    id: 'held-y-line',
+    bounds: createMovementBounds({
+      left: -100,
+      top: 4,
+      width: 500,
+      height: 0
+    })
+  }
+] satisfies readonly MovementSnapCandidateSource[]
+
+/** Две совместимые reference-направляющие с разным пересечением по Y. */
+const RELATED_REFERENCE_SPACING_SOURCES = [
+  {
+    id: 'before-reference-start',
+    bounds: createMovementBounds({ left: -40, top: -2, width: 20, height: 12 }),
+    useForSpacing: true
+  },
+  {
+    id: 'before-neighbor',
+    bounds: createMovementBounds({ left: 0, top: -2, width: 20, height: 12 }),
+    useForSpacing: true
+  },
+  {
+    id: 'after-neighbor',
+    bounds: createMovementBounds({ left: 80, top: 0, width: 20, height: 4 }),
+    useForSpacing: true
+  },
+  {
+    id: 'after-reference-end',
+    bounds: createMovementBounds({ left: 120, top: 0, width: 20, height: 4 }),
+    useForSpacing: true
+  }
+] satisfies readonly MovementSnapCandidateSource[]
+
+/** Одинаковые spacing-границы в двух непересекающихся рядах. */
+const SAME_SPACING_EDGES_IN_DIFFERENT_ROWS = [
+  {
+    id: 'first-row-left',
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 8 }),
+    useForSpacing: true
+  },
+  {
+    id: 'first-row-right',
+    bounds: createMovementBounds({ left: 70, top: 0, width: 20, height: 8 }),
+    useForSpacing: true
+  },
+  {
+    id: 'second-row-left',
+    bounds: createMovementBounds({ left: 0, top: 12, width: 20, height: 8 }),
+    useForSpacing: true
+  },
+  {
+    id: 'second-row-right',
+    bounds: createMovementBounds({ left: 70, top: 12, width: 20, height: 8 }),
+    useForSpacing: true
+  }
+] satisfies readonly MovementSnapCandidateSource[]
+
+/** Spacing-цели для независимой проверки X hold и Y acquisition. */
+const PER_AXIS_SPACING_SOURCES = [
+  ...HORIZONTAL_SPACING_SOURCES,
+  {
+    id: 'top-spacing-source',
+    bounds: createMovementBounds({
+      left: -200,
+      top: 0,
+      width: 300,
+      height: 20
+    }),
+    useForSpacing: true
+  },
+  {
+    id: 'bottom-spacing-source',
+    bounds: createMovementBounds({
+      left: -200,
+      top: 70,
+      width: 300,
+      height: 20
+    }),
+    useForSpacing: true
+  }
+] satisfies readonly MovementSnapCandidateSource[]
+
+it('удерживает выбранные направляющие, даже когда соседняя линия становится ближе', () => {
+  const baseline = createMovementBaseline({
+    sources: [REFERENCE_SOURCE]
+  })
+  const acquiredPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 101, top: 101 }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const acquired = verifyMovementSnapPlan({
+    baseline,
+    plan: acquiredPlan,
+    finalGeometry: createFinalMovementGeometry({ left: 100, top: 100 })
+  })
+  const heldPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 104, top: 104 }),
+    holdState: acquired.holdState
+  })
+  const held = verifyMovementSnapPlan({
+    baseline,
+    plan: heldPlan,
+    finalGeometry: createFinalMovementGeometry({ left: 100, top: 100 })
+  })
+  const acquiredX = acquiredPlan.constraints.x
+  const acquiredY = acquiredPlan.constraints.y
+  const heldX = heldPlan.constraints.x
+
+  expect(acquiredX?.kind).toBe('line')
+  expect(acquiredY?.kind).toBe('line')
+  expect(heldX?.kind).toBe('line')
+  if (
+    acquiredX?.kind !== 'line'
+    || acquiredY?.kind !== 'line'
+    || heldX?.kind !== 'line'
+  ) {
+    throw new Error(
+      'В этом сценарии должны быть выбраны обычные line constraints'
+    )
+  }
+
+  expect(acquiredX.candidate.id).toBe('reference:left')
+  expect(acquiredY.candidate.id).toBe('reference:top')
+  expect(heldX.transition).toBe('held')
+  expect(heldX.candidate.id).toBe('reference:left')
+  expect(heldPlan.nextPosition).toEqual({ left: 100, top: 100 })
+  expect(held.guides).toHaveLength(2)
+})
+
+it('отпускает X независимо от продолжающего удерживаться Y', () => {
+  const baseline = createMovementBaseline({
+    sources: [REFERENCE_SOURCE]
+  })
+  const acquiredPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 101, top: 101 }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const acquired = verifyMovementSnapPlan({
+    baseline,
+    plan: acquiredPlan,
+    finalGeometry: createFinalMovementGeometry({ left: 100, top: 100 })
+  })
+  const releasedPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 140, top: 104 }),
+    holdState: acquired.holdState
+  })
+  const released = verifyMovementSnapPlan({
+    baseline,
+    plan: releasedPlan,
+    finalGeometry: createFinalMovementGeometry({ left: 140, top: 100 })
+  })
+
+  expect(releasedPlan.constraints.x).toBeNull()
+  expect(releasedPlan.constraints.y?.transition).toBe('held')
+  expect(releasedPlan.nextPosition).toEqual({ left: 140, top: 100 })
+  expect(released.holdState.x.kind).toBe('free')
+  expect(released.holdState.y.kind).toBe('line')
+  expect(released.guides.map((guide) => guide.axis)).toEqual(['y'])
+})
+
+it('Ctrl возвращает raw position и очищает transient hold', () => {
+  const baseline = createMovementBaseline({
+    sources: [REFERENCE_SOURCE]
+  })
+  const acquiredPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 101, top: 101 }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const acquired = verifyMovementSnapPlan({
+    baseline,
+    plan: acquiredPlan,
+    finalGeometry: createFinalMovementGeometry({ left: 100, top: 100 })
+  })
+  const disabledPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 104.25,
+      top: 104.25,
+      ctrlKey: true
+    }),
+    holdState: acquired.holdState
+  })
+  const disabled = verifyMovementSnapPlan({
+    baseline,
+    plan: disabledPlan,
+    finalGeometry: createFinalMovementGeometry({ left: 104.25, top: 104.25 })
+  })
+
+  expect(disabledPlan.nextPosition).toEqual({ left: 104.25, top: 104.25 })
+  expect(disabledPlan.constraints).toEqual({ x: null, y: null })
+  expect(disabled.guides).toHaveLength(0)
+  expect(disabled.spacingGuides).toHaveLength(0)
+  expect(disabled.holdState).toEqual(FREE_MOVEMENT_HOLD_STATE)
+})
+
+it('не публикует и не удерживает линию, которой final geometry не достигла', () => {
+  const baseline = createMovementBaseline({
+    sources: [REFERENCE_SOURCE]
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 101, top: 101 }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const verification = verifyMovementSnapPlan({
+    baseline,
+    plan,
+    finalGeometry: createFinalMovementGeometry({ left: 105, top: 100 })
+  })
+
+  expect(verification.blockedAxes).toEqual(['x'])
+  expect(verification.guides.map((guide) => guide.axis)).toEqual(['y'])
+  expect(verification.holdState.x.kind).toBe('free')
+  expect(verification.holdState.y.kind).toBe('line')
+})
+
+it('переводит acquire-порог из экранных пикселей через zoom', () => {
+  const zoomedBaseline = createMovementBaseline({
+    sources: [REFERENCE_SOURCE],
+    zoom: 2
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline: zoomedBaseline,
+    intent: createMovementRawIntent({ left: 103, top: 103, canSnapY: false }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+
+  expect(zoomedBaseline.thresholds.acquire).toBe(2.5)
+  expect(plan.constraints.x).toBeNull()
+  expect(plan.constraints.y).toBeNull()
+  expect(plan.nextPosition).toEqual({ left: 103, top: 103 })
+})
+
+it('включает pixel rounding и равноудалённость в одну итоговую translation', () => {
+  const spacingBaseline = createMovementBaseline({
+    bounds: createMovementBounds({
+      left: 0,
+      top: 0,
+      width: 20,
+      height: 30
+    }),
+    sources: HORIZONTAL_SPACING_SOURCES
+  })
+  const spaced = resolveMovementSnapPlan({
+    baseline: spacingBaseline,
+    intent: createMovementRawIntent({
+      left: 33,
+      top: 100.6,
+      width: 20
+    }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const verifiedSpacing = verifyMovementSnapPlan({
+    baseline: spacingBaseline,
+    plan: spaced,
+    finalGeometry: createFinalMovementGeometry({
+      left: 35,
+      top: 101,
+      width: 20
+    })
+  })
+  const heldSpacing = resolveMovementSnapPlan({
+    baseline: spacingBaseline,
+    intent: createMovementRawIntent({
+      left: 39,
+      top: 100.6,
+      width: 20
+    }),
+    holdState: verifiedSpacing.holdState
+  })
+
+  expect(spaced.nextPosition).toEqual({ left: 35, top: 101 })
+  expect(spaced.constraints.x?.kind).toBe('spacing')
+  expect(spaced.constraints.y).toBeNull()
+  expect(heldSpacing.nextPosition).toEqual({ left: 35, top: 101 })
+  expect(verifiedSpacing.spacingGuides.length).toBeGreaterThan(0)
+  expect(verifiedSpacing.holdState.x.kind).toBe('spacing')
+})
+
+it('заново выбирает равноудалённость после перехода к другим соседям с такими же X-границами', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 4 }),
+    sources: SAME_SPACING_EDGES_IN_DIFFERENT_ROWS
+  })
+  const acquiredPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 33,
+      top: 2,
+      width: 20,
+      height: 4,
+      canSnapY: false
+    }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const acquired = verifyMovementSnapPlan({
+    baseline,
+    plan: acquiredPlan,
+    finalGeometry: createFinalMovementGeometry({ left: 35, top: 2, width: 20, height: 4 })
+  })
+  const nextPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 39,
+      top: 14,
+      width: 20,
+      height: 4,
+      canSnapY: false
+    }),
+    holdState: acquired.holdState
+  })
+  const acquiredX = acquiredPlan.constraints.x
+  const nextX = nextPlan.constraints.x
+
+  expect(acquiredX?.kind).toBe('spacing')
+  expect(nextX?.kind).toBe('spacing')
+  if (acquiredX?.kind !== 'spacing' || nextX?.kind !== 'spacing') {
+    throw new Error('В обоих рядах должна быть выбрана равноудалённость')
+  }
+
+  expect(nextX.transition).toBe('acquired')
+  expect(nextX.candidateId).not.toBe(acquiredX.candidateId)
+  expect(acquiredX.selections[0].identity.before?.top).toBe(0)
+  expect(nextX.selections[0].identity.before?.top).toBe(12)
+})
+
+it('при коррекции по Y прилипает к обычной направляющей по X, если у равноудалённости меняется ближайший сосед', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 4 }),
+    sources: CHANGING_NEIGHBOR_WITH_FALLBACK_SOURCES
+  })
+  const heldYCandidate = baseline.candidates.find(({ id }) => id === 'held-y-line:top')
+  expect(heldYCandidate).toBeDefined()
+  if (!heldYCandidate) {
+    throw new Error('Y-направляющая должна входить в baseline')
+  }
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 33,
+      top: 3,
+      width: 20,
+      height: 4
+    }),
+    holdState: {
+      x: FREE_MOVEMENT_HOLD_STATE.x,
+      y: {
+        kind: 'line',
+        candidate: heldYCandidate,
+        activeAnchor: 'top'
+      }
+    }
+  })
+  const verification = verifyMovementSnapPlan({
+    baseline,
+    plan,
+    finalGeometry: createFinalMovementGeometry({
+      left: plan.nextPosition.left,
+      top: plan.nextPosition.top,
+      width: 20,
+      height: 4
+    })
+  })
+  const xConstraint = plan.constraints.x
+
+  expect(xConstraint?.kind).toBe('line')
+  if (xConstraint?.kind !== 'line') {
+    throw new Error('После потери равноудалённости должна быть выбрана X-направляющая')
+  }
+
+  expect(xConstraint.candidate.id).toBe('fallback-x-line:left')
+  expect(xConstraint.transition).toBe('acquired')
+  expect(plan.constraints.y?.transition).toBe('held')
+  expect(plan.nextPosition).toEqual({ left: 37, top: 4 })
+  expect(verification.spacingGuides).toHaveLength(0)
+  expect(verification.blockedAxes).toEqual([])
+  expect(verification.holdState.x.kind).toBe('line')
+  expect(verification.guides.map(({ axis }) => axis)).toEqual(['x', 'y'])
+})
+
+it('сохраняет основную равноудалённость, если дополнительный интервал перестаёт быть применим', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 4 }),
+    sources: RELATED_REFERENCE_SPACING_SOURCES
+  })
+  const rawIntent = createMovementRawIntent({
+    left: 40,
+    top: 3,
+    width: 20,
+    height: 4
+  })
+  const beforeCorrection = resolveMovementSnapPlan({
+    baseline,
+    intent: {
+      ...rawIntent,
+      axes: { x: true, y: false }
+    },
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: rawIntent,
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const initialX = beforeCorrection.constraints.x
+  const finalX = plan.constraints.x
+
+  expect(initialX?.kind).toBe('spacing')
+  expect(finalX?.kind).toBe('spacing')
+  if (initialX?.kind !== 'spacing' || finalX?.kind !== 'spacing') {
+    throw new Error('В этом сценарии по X должна быть выбрана равноудалённость')
+  }
+
+  expect(initialX.selections.map(({ identity }) => identity.side)).toEqual(['before', 'after'])
+  expect(initialX.selections.map(({ isPrimary }) => isPrimary)).toEqual([true, false])
+  expect(finalX.selections).toHaveLength(1)
+  expect(finalX.selections[0].identity.side).toBe('before')
+  expect(finalX.selections[0].isPrimary).toBe(true)
+  expect(plan.nextPosition).toEqual({ left: 40, top: 4 })
+  expect(plan.constraints.y?.kind).toBe('line')
+})
+
+it('показывает только основной интервал, если дополнительный пропал после фактического перемещения', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 4 }),
+    sources: RELATED_REFERENCE_SPACING_SOURCES
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 40,
+      top: 3,
+      width: 20,
+      height: 4,
+      canSnapY: false
+    }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const verification = verifyMovementSnapPlan({
+    baseline,
+    plan,
+    finalGeometry: createFinalMovementGeometry({
+      left: 40,
+      top: 4,
+      width: 20,
+      height: 4
+    })
+  })
+  const xConstraint = plan.constraints.x
+
+  expect(xConstraint?.kind).toBe('spacing')
+  if (xConstraint?.kind !== 'spacing') {
+    throw new Error('До применения движения по X должны быть выбраны два интервала равноудалённости')
+  }
+
+  expect(xConstraint.selections).toHaveLength(2)
+  expect(verification.spacingGuides).toHaveLength(1)
+  expect(verification.blockedAxes).toEqual([])
+  expect(verification.holdState.x.kind).toBe('spacing')
+})
+
+it('не показывает равноудалённость, если после перемещения появился более близкий сосед', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 4 }),
+    sources: CHANGING_NEIGHBOR_SOURCES
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 33,
+      top: 3,
+      width: 20,
+      height: 4,
+      canSnapY: false
+    }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const verification = verifyMovementSnapPlan({
+    baseline,
+    plan,
+    finalGeometry: createFinalMovementGeometry({
+      left: 35,
+      top: 4,
+      width: 20,
+      height: 4
+    })
+  })
+
+  expect(plan.nextPosition).toEqual({ left: 35, top: 3 })
+  expect(plan.constraints.x?.kind).toBe('spacing')
+  expect(verification.spacingGuides).toHaveLength(0)
+  expect(verification.guides).toHaveLength(0)
+  expect(verification.blockedAxes).toEqual(['x'])
+  expect(verification.holdState.x.kind).toBe('free')
+})
+
+it('удерживает line и не применяет более близкий spacing по той же оси', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 30 }),
+    sources: [
+      ...HORIZONTAL_SPACING_SOURCES,
+      {
+        id: 'line-source',
+        bounds: createMovementBounds({
+          left: 34,
+          top: 0,
+          width: 0,
+          height: 300
+        })
+      }
+    ]
+  })
+  const acquiredPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 33, top: 100.6, width: 20 }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const acquired = verifyMovementSnapPlan({
+    baseline,
+    plan: acquiredPlan,
+    finalGeometry: createFinalMovementGeometry({
+      left: 34,
+      top: 101,
+      width: 20
+    })
+  })
+  const heldPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 38, top: 100.6, width: 20 }),
+    holdState: acquired.holdState
+  })
+
+  expect(acquiredPlan.constraints.x?.kind).toBe('line')
+  expect(acquired.spacingGuides).toHaveLength(0)
+  expect(acquired.holdState.x.kind).toBe('line')
+  expect(heldPlan.constraints.x?.kind).toBe('line')
+  expect(heldPlan.constraints.x?.transition).toBe('held')
+  expect(heldPlan.nextPosition).toEqual({ left: 34, top: 101 })
+})
+
+it('выбирает spacing, если его новая correction меньше line correction', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 30 }),
+    sources: [
+      ...HORIZONTAL_SPACING_SOURCES,
+      {
+        id: 'line-source',
+        bounds: createMovementBounds({
+          left: 37,
+          top: 0,
+          width: 0,
+          height: 300
+        })
+      }
+    ]
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 33, top: 100.6, width: 20 }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const verified = verifyMovementSnapPlan({
+    baseline,
+    plan,
+    finalGeometry: createFinalMovementGeometry({
+      left: 35,
+      top: 101,
+      width: 20
+    })
+  })
+
+  expect(plan.constraints.x?.kind).toBe('spacing')
+  expect(plan.nextPosition).toEqual({ left: 35, top: 101 })
+  expect(verified.guides).toHaveLength(0)
+  expect(verified.spacingGuides.length).toBeGreaterThan(0)
+  expect(verified.holdState.x.kind).toBe('spacing')
+})
+
+it('при практически равном расстоянии выбирает границу рабочей области', () => {
+  const baseline = createMovementBaseline({
+    sources: [
+      {
+        id: 'object-edge',
+        bounds: createMovementBounds({ left: 100, top: 0, width: 0, height: 300 })
+      },
+      {
+        id: 'work-area',
+        bounds: createMovementBounds({
+          left: 100.0000000005,
+          top: 0,
+          width: 0,
+          height: 300
+        }),
+        edgeCategory: 'domain-boundary'
+      }
+    ]
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 100, top: 400, canSnapY: false }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const constraint = plan.constraints.x
+
+  expect(constraint?.kind).toBe('line')
+  if (constraint?.kind !== 'line') {
+    throw new Error('В этом сценарии должна быть выбрана обычная направляющая')
+  }
+
+  expect(constraint.candidate.id).toBe('work-area:left')
+  expect(constraint.candidate.category).toBe('domain-boundary')
+})
+
+it('не расширяет acquisition-порог свободной Y из-за spacing hold по X', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 20 }),
+    sources: PER_AXIS_SPACING_SOURCES
+  })
+  const acquiredPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 33,
+      top: 200,
+      width: 20,
+      height: 20
+    }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const acquired = verifyMovementSnapPlan({
+    baseline,
+    plan: acquiredPlan,
+    finalGeometry: createFinalMovementGeometry({
+      left: 35,
+      top: 200,
+      width: 20,
+      height: 20
+    })
+  })
+  const heldPlan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({
+      left: 39,
+      top: 28,
+      width: 20,
+      height: 20
+    }),
+    holdState: acquired.holdState
+  })
+
+  expect(acquired.holdState.x.kind).toBe('spacing')
+  expect(acquired.holdState.y.kind).toBe('free')
+  expect(heldPlan.constraints.x?.kind).toBe('spacing')
+  expect(heldPlan.constraints.x?.transition).toBe('held')
+  expect(heldPlan.constraints.y).toBeNull()
+  expect(heldPlan.nextPosition).toEqual({ left: 35, top: 28 })
+})
+
+it('не подтверждает spacing после изменения размеров target', () => {
+  const baseline = createMovementBaseline({
+    bounds: createMovementBounds({ left: 0, top: 0, width: 20, height: 30 }),
+    sources: HORIZONTAL_SPACING_SOURCES
+  })
+  const plan = resolveMovementSnapPlan({
+    baseline,
+    intent: createMovementRawIntent({ left: 33, top: 100.6, width: 20 }),
+    holdState: FREE_MOVEMENT_HOLD_STATE
+  })
+  const verification = verifyMovementSnapPlan({
+    baseline,
+    plan,
+    finalGeometry: createFinalMovementGeometry({
+      left: 35,
+      top: 101,
+      width: 21
+    })
+  })
+
+  expect(plan.constraints.x?.kind).toBe('spacing')
+  expect(verification.spacingGuides).toHaveLength(0)
+  expect(verification.blockedAxes).toEqual(['x'])
+  expect(verification.holdState.x.kind).toBe('free')
+})
+
+it('отклоняет raw intent, который не является translation начального состояния', () => {
+  const baseline = createMovementBaseline()
+  const translated = createMovementRawIntent({ left: 10, top: 10 })
+
+  expect(() => {
+    resolveMovementSnapPlan({
+      baseline,
+      intent: createMovementRawIntent({ left: 10, top: 10, width: 31 }),
+      holdState: FREE_MOVEMENT_HOLD_STATE
+    })
+  }).toThrow('must be a translation of the gesture baseline')
+  expect(() => {
+    resolveMovementSnapPlan({
+      baseline,
+      intent: {
+        ...translated,
+        position: {
+          left: translated.position.left + 1,
+          top: translated.position.top
+        }
+      },
+      holdState: FREE_MOVEMENT_HOLD_STATE
+    })
+  }).toThrow('must be a translation of the gesture baseline')
+})

--- a/specs/src/editor/snapping-manager/movement-snapping-runtime.spec.ts
+++ b/specs/src/editor/snapping-manager/movement-snapping-runtime.spec.ts
@@ -1,0 +1,149 @@
+import type { MovementSnapCandidateSource } from '../../../../src/editor/snapping-manager/movement-snap-candidates'
+import { MovementSnappingRuntime } from '../../../../src/editor/snapping-manager/movement-snapping-runtime'
+import {
+  createFinalMovementGeometry,
+  createMovementBaseline,
+  createMovementBounds,
+  createMovementRawIntent
+} from '../../../test-utils/shared/movement-snapping-core'
+
+/** Цель с близкими edge и center guide для проверки runtime hold-state. */
+const REFERENCE_SOURCE = {
+  id: 'reference',
+  bounds: createMovementBounds({
+    left: 100,
+    top: 100,
+    width: 12,
+    height: 40
+  })
+} satisfies MovementSnapCandidateSource
+
+it('выдаёт один план на marker и возвращает подтверждённый duplicate без новой мутации', () => {
+  const runtime = new MovementSnappingRuntime()
+  const marker = {}
+  runtime.startSession({
+    baseline: createMovementBaseline({
+      sources: [REFERENCE_SOURCE]
+    })
+  })
+
+  const intent = createMovementRawIntent({ left: 101, top: 101 })
+  const step = runtime.resolveMovementPlan({
+    marker,
+    intent
+  })
+  expect(step.kind).toBe('planned')
+  if (step.kind !== 'planned') {
+    throw new Error('Первый movement-step должен выдать новый план')
+  }
+
+  const verification = runtime.verifyMovementPlan({
+    token: step.token,
+    finalGeometry: createFinalMovementGeometry({ left: 100, top: 100 })
+  })
+  const duplicate = runtime.resolveMovementPlan({ marker, intent })
+
+  expect(verification.guides).toHaveLength(2)
+  expect(duplicate.kind).toBe('duplicate')
+  if (duplicate.kind !== 'duplicate') {
+    throw new Error(
+      'Повторный marker должен вернуть сохранённый movement-step'
+    )
+  }
+
+  expect(duplicate.phase).toBe('verified')
+  expect(duplicate.token).toBe(step.token)
+  expect(duplicate.verification).toBe(verification)
+})
+
+it('не позволяет проверить один movement token повторно', () => {
+  const runtime = new MovementSnappingRuntime()
+  runtime.startSession({
+    baseline: createMovementBaseline({
+      sources: [REFERENCE_SOURCE]
+    })
+  })
+  const step = runtime.resolveMovementPlan({
+    marker: {},
+    intent: createMovementRawIntent({ left: 101, top: 101 })
+  })
+  expect(step.kind).toBe('planned')
+  if (step.kind !== 'planned') {
+    throw new Error('Movement runtime должен выдать план для нового marker')
+  }
+
+  const finalGeometry = createFinalMovementGeometry({ left: 100, top: 100 })
+  const firstVerification = runtime.verifyMovementPlan({
+    token: step.token,
+    finalGeometry
+  })
+
+  expect(firstVerification.guides).toHaveLength(2)
+  expect(() => {
+    runtime.verifyMovementPlan({
+      token: step.token,
+      finalGeometry
+    })
+  }).toThrow('Movement plan token has already been used')
+})
+
+it('не переносит заблокированную направляющую в следующий hold-state', () => {
+  const runtime = new MovementSnappingRuntime()
+  runtime.startSession({
+    baseline: createMovementBaseline({
+      sources: [REFERENCE_SOURCE]
+    })
+  })
+  const firstStep = runtime.resolveMovementPlan({
+    marker: {},
+    intent: createMovementRawIntent({ left: 101, top: 101 })
+  })
+  expect(firstStep.kind).toBe('planned')
+  if (firstStep.kind !== 'planned') {
+    throw new Error('Первый movement marker должен выдать план')
+  }
+
+  const blocked = runtime.verifyMovementPlan({
+    token: firstStep.token,
+    finalGeometry: createFinalMovementGeometry({ left: 105, top: 100 })
+  })
+  const nextStep = runtime.resolveMovementPlan({
+    marker: {},
+    intent: createMovementRawIntent({ left: 104, top: 104 })
+  })
+
+  expect(blocked.holdState.x.kind).toBe('free')
+  expect(blocked.holdState.y.kind).toBe('line')
+  expect(nextStep.kind).toBe('planned')
+  expect(nextStep.plan.constraints.x?.kind).toBe('line')
+  expect(nextStep.plan.constraints.y?.kind).toBe('line')
+  if (
+    nextStep.plan.constraints.x?.kind !== 'line'
+    || nextStep.plan.constraints.y?.kind !== 'line'
+  ) {
+    throw new Error('Следующий movement-step должен выбрать line constraints')
+  }
+
+  expect(nextStep.plan.constraints.x?.transition).toBe('acquired')
+  expect(nextStep.plan.constraints.x?.candidate.id).toBe('reference:center-x')
+  expect(nextStep.plan.constraints.y?.transition).toBe('held')
+})
+
+it('очищает активную сессию идемпотентно', () => {
+  const runtime = new MovementSnappingRuntime()
+  runtime.startSession({
+    baseline: createMovementBaseline()
+  })
+
+  const firstCleanup = runtime.finishSession()
+  const repeatedCleanup = runtime.finishSession()
+
+  expect(firstCleanup.didCleanup).toBe(true)
+  expect(repeatedCleanup.didCleanup).toBe(false)
+  expect(() => {
+    runtime.resolveMovementPlan({
+      marker: {},
+      intent: createMovementRawIntent({ left: 10, top: 10 })
+    })
+  }).toThrow('Movement snapping runtime has no active session')
+})

--- a/specs/test-utils/managers/snapping-lifecycle.ts
+++ b/specs/test-utils/managers/snapping-lifecycle.ts
@@ -1,0 +1,73 @@
+import SnappingManager from '../../../src/editor/snapping-manager'
+import type {
+  AnchorBuckets,
+  GuideLine,
+  SpacingGuide
+} from '../../../src/editor/snapping-manager/types'
+import { createBoundsObject, createSnappingTestContext } from '../canvas/geometry-objects'
+
+/** Доступная тестам часть transient-состояния SnappingManager. */
+type SnappingManagerLifecycleState = {
+  activeGuides: GuideLine[]
+  activeSpacingGuides: SpacingGuide[]
+  anchors: AnchorBuckets
+  activeMovementSnappingTarget: object | null
+  movementSnappingController: {
+    startGesture: ({ target }: { target?: object | null }) => boolean
+    finishGesture: () => void
+  }
+}
+
+/**
+ * Создаёт SnappingManager и явные spy для проверки terminal lifecycle movement-сессии.
+ */
+export const createMovementSnappingLifecycleSetup = () => {
+  const { editor, canvas } = createSnappingTestContext()
+  const manager = new SnappingManager({ editor })
+  const state: SnappingManagerLifecycleState = manager as any
+  const startGestureMock = jest
+    .spyOn(state.movementSnappingController, 'startGesture')
+    .mockReturnValue(true)
+  const finishGestureMock = jest.spyOn(state.movementSnappingController, 'finishGesture')
+  const activeTarget = createBoundsObject({
+    left: 100,
+    top: 80,
+    width: 40,
+    height: 30,
+    id: 'active-image'
+  })
+
+  return {
+    manager,
+    canvas,
+    state,
+    activeTarget,
+    startGestureMock,
+    finishGestureMock
+  }
+}
+
+/** Добавляет видимые guide и anchors, которые обязан очистить terminal event. */
+export const seedVisibleSnappingState = ({
+  state
+}: {
+  state: SnappingManagerLifecycleState
+}): void => {
+  state.activeGuides = [{
+    type: 'vertical',
+    position: 100
+  }]
+  state.activeSpacingGuides = [{
+    type: 'horizontal',
+    axis: 100,
+    refStart: 10,
+    refEnd: 20,
+    activeStart: 30,
+    activeEnd: 40,
+    distance: 10
+  }]
+  state.anchors = {
+    vertical: [100],
+    horizontal: [80]
+  }
+}

--- a/specs/test-utils/shared/movement-snapping-core.ts
+++ b/specs/test-utils/shared/movement-snapping-core.ts
@@ -1,0 +1,111 @@
+import {
+  createMovementSnapEnvironment,
+  type MovementSnapCandidateSource
+} from '../../../src/editor/snapping-manager/movement-snap-candidates'
+import {
+  createMovementGestureBaseline,
+  type FinalMovementGeometry,
+  type MovementGestureBaseline,
+  type MovementRawIntent
+} from '../../../src/editor/snapping-manager/movement-snapping-resolver'
+import type { ObjectBounds } from '../../../src/editor/utils/geometry'
+
+/** Создаёт точные границы translation-объекта с центрами из тех же граней. */
+export function createMovementBounds({
+  left,
+  top,
+  width = 30,
+  height = 30
+}: {
+  left: number
+  top: number
+  width?: number
+  height?: number
+}): ObjectBounds {
+  return {
+    left,
+    right: left + width,
+    top,
+    bottom: top + height,
+    centerX: left + (width / 2),
+    centerY: top + (height / 2)
+  }
+}
+
+/** Создаёт baseline movement-жеста с неизменяемым снимком целей. */
+export function createMovementBaseline({
+  bounds = createMovementBounds({ left: 0, top: 0 }),
+  sources = [],
+  zoom = 1
+}: {
+  bounds?: ObjectBounds
+  sources?: readonly MovementSnapCandidateSource[]
+  zoom?: number
+} = {}): MovementGestureBaseline {
+  return createMovementGestureBaseline({
+    bounds,
+    position: {
+      left: bounds.left,
+      top: bounds.top
+    },
+    environment: createMovementSnapEnvironment({
+      sources,
+      zoom
+    })
+  })
+}
+
+/** Создаёт raw movement intent для объекта с left/top origin. */
+export function createMovementRawIntent({
+  left,
+  top,
+  width = 30,
+  height = 30,
+  canSnapX = true,
+  canSnapY = true,
+  ctrlKey = false
+}: {
+  left: number
+  top: number
+  width?: number
+  height?: number
+  canSnapX?: boolean
+  canSnapY?: boolean
+  ctrlKey?: boolean
+}): MovementRawIntent {
+  return {
+    bounds: createMovementBounds({ left, top, width, height }),
+    position: {
+      left,
+      top
+    },
+    axes: {
+      x: canSnapX,
+      y: canSnapY
+    },
+    modifiers: {
+      ctrlKey
+    }
+  }
+}
+
+/** Создаёт фактическую movement-геометрию после применения рассчитанной позиции. */
+export function createFinalMovementGeometry({
+  left,
+  top,
+  width = 30,
+  height = 30
+}: {
+  left: number
+  top: number
+  width?: number
+  height?: number
+}): FinalMovementGeometry {
+  return {
+    bounds: createMovementBounds({ left, top, width, height }),
+    position: {
+      left,
+      top
+    }
+  }
+}

--- a/src/editor/snapping-manager/README.md
+++ b/src/editor/snapping-manager/README.md
@@ -1,8 +1,8 @@
 # SnappingManager
 
-`SnappingManager` finds guides, resolves snapping, and renders only the guides that the object actually reaches. It does not change the canonical dimensions of composite objects; those remain the responsibility of the manager that owns the corresponding object type.
+`SnappingManager` finds guides and coordinates both verified and legacy snapping paths. Migrated interactions publish guides only after the object reaches them, while legacy interactions keep their existing calculated-guide contract. Canonical dimensions of composite objects remain the responsibility of the manager that owns the corresponding object type.
 
-The new two-phase contract is currently used when scaling a regular top-level shape. Images, standalone text, `ActiveSelection`, and `CropFrame` still use the legacy path. The exact migration boundary and the recommended order for continuing the work are documented in [`technical-specifications/unified-scale-snapping-current-state.md`](../../../technical-specifications/unified-scale-snapping-current-state.md).
+The two-phase contract is currently used when scaling a regular top-level shape and when moving a standalone top-level `FabricImage`. Movement of shapes, standalone text, `ActiveSelection`, `Group`, and `CropFrame` still uses the legacy path, as does all image scaling. The exact migration boundary and the recommended order for continuing the work are documented in [`technical-specifications/unified-scale-snapping-current-state.md`](../../../technical-specifications/unified-scale-snapping-current-state.md).
 
 ## Responsibilities
 
@@ -10,19 +10,24 @@ The new two-phase contract is currently used when scaling a regular top-level sh
 - [`scale-snapping-resolver.ts`](./scale-snapping-resolver.ts) selects guides and maintains independent hold states for the X and Y axes. It does not mutate the canvas.
 - [`scale-projection.ts`](./scale-projection.ts) describes the linear relationship between scale factors and object edges.
 - [`scale-snapping-runtime.ts`](./scale-snapping-runtime.ts) connects raw pointer intent, mutation-free resolution, and verification of the geometry that was actually applied.
-- [`calculations.ts`](./calculations.ts) resolves ordinary line snapping while an object is moving.
-- [`spacing.ts`](./spacing.ts) resolves equal spacing and returns the actual segments to render.
+- [`movement-snap-candidates.ts`](./movement-snap-candidates.ts) creates line targets with stable identities for the lifetime of a gesture and separates ordinary objects from montage bounds used only for line snapping.
+- [`movement-snapping-resolver.ts`](./movement-snapping-resolver.ts) selects one line or equal-spacing constraint per axis, preserves the selected constraint through its release zone, revalidates the exact selected spacing intervals against the combined predicted and final bounds, falls back to a line from the same raw intent when the primary interval is lost, handles Ctrl and pixel rounding, and verifies the applied result without mutating Fabric objects.
+- [`movement-snapping-runtime.ts`](./movement-snapping-runtime.ts) gives one movement plan to each native pointer marker and updates line and spacing hold state only after verification.
+- [`movement-snapping-controller.ts`](./movement-snapping-controller.ts) captures an immutable movement session and applies one final translation for standalone top-level images. Other object types are deliberately routed to the legacy owner.
+- [`calculations.ts`](./calculations.ts) resolves ordinary line snapping for movement targets that have not yet been migrated.
+- [`spacing.ts`](./spacing.ts) resolves equal spacing and returns every selected interval with its exact nearest-neighbour or reference-pattern identity, whether it is primary or related, and the segment to render.
 - [`scaling.ts`](./scaling.ts) and [`pixel-grid.ts`](./pixel-grid.ts) support resize scenarios that have not yet been migrated, including `CropFrame`.
-- [`index.ts`](./index.ts) owns the target snapshot, publishes verified guides, and preserves the legacy handling for object types that do not yet have an owner for the new contract.
+- [`renderer.ts`](./renderer.ts) owns drawing line and spacing guides and calculating fallback viewport bounds.
+- [`index.ts`](./index.ts) routes gestures to migrated or legacy owners, publishes verified guides, owns terminal cleanup, and preserves the old handling for object types that have not moved to the new contract.
 - [`../utils/geometry.ts`](../utils/geometry.ts) returns exact object bounds in scene coordinates and separately provides the rounded representation required by legacy code.
 
-## Contract for a single scaling step
+## Contract for a single migrated interaction step
 
 ```text
 gesture-start state
   → pointer intent
   → mutation-free snap resolution
-  → one application by the object manager
+  → one application by the current domain or Fabric owner
   → verification of the actual bounds
   → guide publication
 ```
@@ -30,20 +35,30 @@ gesture-start state
 The following rules are mandatory:
 
 - every new `mousemove` is resolved from the state captured on `mousedown`, not from the result of the previous snapped step;
-- `object:scaling` and the following `mouse:move` with the same `event.e` represent one step;
+- in migrated scaling paths, `object:scaling` and the following `mouse:move` with the same `event.e` represent one step;
 - a guide remains held until the raw pointer intent crosses the release threshold;
 - when both axes are available, acquiring or releasing one guide must not reset the other;
 - rounding must not move an edge that is already constrained by a guide;
 - a guide is published only after the exact bounds of the applied result have been verified;
 - `mouseup` must not change the last visible state.
 
+Each spacing plan keeps the exact before and after neighbours and the reference pattern selected from the immutable gesture snapshot. Applicability is checked after X and Y corrections are combined and again against the final bounds. Losing only a related interval hides only that guide; losing the primary interval rejects the spacing constraint and lets the same raw intent acquire a line instead.
+
 ## ShapeManager integration
 
 For a regular shape, the geometry snapshot is captured on `mousedown`. `ShapeManager` resolves the active control mode and remains the sole owner of minimum size, layout, text wrapping, and canonical dimension commits. `SnappingManager` provides the resolved constraints and verifies the resulting bounds after they have been applied.
 
-The new path supports side and corner controls, rotation, centred scaling, free corner scaling with Shift, and disabling snapping with Ctrl. Skewed, flipped, nested, or axis-locked shapes, `ActiveSelection`, and gestures that cross the fixed point are explicitly routed to the legacy path before the new owner performs its first mutation.
+The new path supports side and corner controls, rotation, centred scaling, free corner scaling with Shift, and disabling snapping with Ctrl. Skewed, flipped, nested, or axis-locked shapes and `ActiveSelection` use the legacy path. A supported gesture that later crosses the fixed point may hand the remaining live interaction back to the legacy path after earlier unified steps have already been applied.
 
 Gesture state is cleared on `mouseup`, selection changes, object removal, `pointercancel`, `touchcancel`, window blur, and manager destruction.
+
+## Image movement integration
+
+For a standalone top-level image, `mousedown` captures exact initial bounds, Fabric `left/top`, zoom, named line candidates, and spacing candidates. Every `object:moving` step reads the raw Fabric result, resolves line and equal-spacing hold state independently by axis, includes pixel rounding in the same final position, applies at most one post-Fabric translation, and verifies the resulting exact bounds before publishing guides.
+
+Ctrl returns the unrounded raw Fabric position and clears both line and spacing hold state. A repeated native marker reuses its verified result without reading or changing the target again. A new `mousedown` first ends the previous movement session and clears visible guides and legacy anchor caches before the new snapshot and anchors are captured. The movement session and visible guides are also cleared on `mouseup`, selection changes, removal of the active target, `pointercancel`, `touchcancel`, window blur, and manager destruction.
+
+This phase intentionally supports only a top-level `FabricImage`. Image movement without an active browser gesture and movement of shapes, standalone text, `ActiveSelection`, `Group`, and `CropFrame` continue through the legacy path. Image scaling is also still legacy. The next representative slice starts with the `mr` control of a standalone image; the remaining movement targets are migrated one at a time after that slice.
 
 ## Geometry, distances, and MeasurementManager
 

--- a/src/editor/snapping-manager/index.ts
+++ b/src/editor/snapping-manager/index.ts
@@ -10,8 +10,6 @@ import {
 
 import { ImageEditor } from '..'
 import {
-  GUIDE_COLOR,
-  GUIDE_WIDTH,
   SNAP_THRESHOLD,
   SPACING_CONTEXT_SWITCH_DISTANCE,
   SPACING_SNAP_HOLD_MARGIN
@@ -30,7 +28,11 @@ import {
 } from './scale-snap-candidates'
 import type { VerifiedScaleGuide } from './scale-snapping-resolver'
 import type { ScaleSceneEdge } from './scale-projection'
-import { drawSpacingGuide } from './renderer'
+import { MovementSnappingController } from './movement-snapping-controller'
+import {
+  calculateSnappingViewportBounds,
+  renderSnappingGuides
+} from './renderer'
 import {
   applyMovementStep,
   applyScalingStep,
@@ -67,7 +69,6 @@ import {
   collectExcludedObjects,
   shouldIgnoreObject
 } from '../utils/object-filter'
-import { resolveDisplayDistance } from '../utils/distance'
 
 type TransformEvent = BasicTransformEvent<TPointerEvent> & {
   target?: FabricObject | null
@@ -75,6 +76,11 @@ type TransformEvent = BasicTransformEvent<TPointerEvent> & {
 }
 
 type MouseEventInfo = TPointerEventInfo<TPointerEvent> & {
+  target?: FabricObject | null
+}
+
+/** Canvas-событие с объектом, который мог быть target активной сессии. */
+type ObjectTargetEvent = {
   target?: FabricObject | null
 }
 
@@ -219,6 +225,12 @@ export default class SnappingManager {
   /** События указателя, уже обработанные менеджером конкретного типа объекта. */
   private readonly handledScaleStepEvents = new WeakSet<object>()
 
+  /** Владелец unified movement-сессии для уже перенесённых типов объектов. */
+  private readonly movementSnappingController: MovementSnappingController
+
+  /** Активный target unified movement-сессии для точной обработки object:removed. */
+  private activeMovementSnappingTarget: FabricObject | null = null
+
   /**
    * Обработчик начала перетаскивания объекта.
    */
@@ -235,9 +247,12 @@ export default class SnappingManager {
   private _onObjectScaling: (event: TransformEvent) => void
 
   /**
-   * Обработчик завершения перетаскивания.
+   * Обработчик завершения или прерывания interaction.
    */
-  private _onMouseUp: () => void
+  private _onInteractionFinished: () => void
+
+  /** Обработчик удаления возможного target активной movement-сессии. */
+  private _onObjectRemoved: (event: ObjectTargetEvent) => void
 
   /**
    * Обработчик очистки перед рендером.
@@ -256,11 +271,13 @@ export default class SnappingManager {
     this.editor = editor
     const { canvas } = editor
     this.canvas = canvas
+    this.movementSnappingController = new MovementSnappingController({ editor })
 
     this._onMouseDown = this._handleMouseDown.bind(this)
     this._onObjectMoving = this._handleObjectMoving.bind(this)
     this._onObjectScaling = this._handleObjectScaling.bind(this)
-    this._onMouseUp = this._handleMouseUp.bind(this)
+    this._onInteractionFinished = this._handleInteractionFinished.bind(this)
+    this._onObjectRemoved = this._handleObjectRemoved.bind(this)
     this._onBeforeRender = this._handleBeforeRender.bind(this)
     this._onAfterRender = this._handleAfterRender.bind(this)
 
@@ -272,8 +289,7 @@ export default class SnappingManager {
    */
   public destroy(): void {
     this._unbindEvents()
-    this._clearGuides()
-    this._clearAnchors()
+    this._finishSnappingInteraction()
   }
 
   /**
@@ -343,9 +359,17 @@ export default class SnappingManager {
     canvas.on('mouse:down', this._onMouseDown)
     canvas.on('object:moving', this._onObjectMoving)
     canvas.on('object:scaling', this._onObjectScaling)
-    canvas.on('mouse:up', this._onMouseUp)
+    canvas.on('mouse:up', this._onInteractionFinished)
+    canvas.on('object:removed', this._onObjectRemoved)
+    canvas.on('selection:created', this._onInteractionFinished)
+    canvas.on('selection:updated', this._onInteractionFinished)
+    canvas.on('selection:cleared', this._onInteractionFinished)
     canvas.on('before:render', this._onBeforeRender)
     canvas.on('after:render', this._onAfterRender)
+
+    window.addEventListener('pointercancel', this._onInteractionFinished)
+    window.addEventListener('touchcancel', this._onInteractionFinished)
+    window.addEventListener('blur', this._onInteractionFinished)
   }
 
   /**
@@ -356,22 +380,31 @@ export default class SnappingManager {
     canvas.off('mouse:down', this._onMouseDown)
     canvas.off('object:moving', this._onObjectMoving)
     canvas.off('object:scaling', this._onObjectScaling)
-    canvas.off('mouse:up', this._onMouseUp)
+    canvas.off('mouse:up', this._onInteractionFinished)
+    canvas.off('object:removed', this._onObjectRemoved)
+    canvas.off('selection:created', this._onInteractionFinished)
+    canvas.off('selection:updated', this._onInteractionFinished)
+    canvas.off('selection:cleared', this._onInteractionFinished)
     canvas.off('before:render', this._onBeforeRender)
     canvas.off('after:render', this._onAfterRender)
+
+    window.removeEventListener('pointercancel', this._onInteractionFinished)
+    window.removeEventListener('touchcancel', this._onInteractionFinished)
+    window.removeEventListener('blur', this._onInteractionFinished)
   }
 
   /**
-   * Кеширует набор опорных линий в момент начала перетаскивания.
+   * Очищает прошлый interaction и фиксирует цели нового gesture.
    */
   private _handleMouseDown(event: MouseEventInfo): void {
     const { target } = event
-    this._clearSpacingContexts()
+    this._clearGuides()
+    this._clearAnchors()
 
-    if (!target) {
-      this._clearAnchors()
-      return
-    }
+    const usesUnifiedMovement = this.movementSnappingController.startGesture({ target })
+    this.activeMovementSnappingTarget = usesUnifiedMovement ? target ?? null : null
+
+    if (!target) return
 
     this._cacheAnchors({ activeObject: target, mode: 'rounded' })
   }
@@ -380,6 +413,15 @@ export default class SnappingManager {
    * Выполняет привязку объекта к ближайшим линиям при его перемещении.
    */
   private _handleObjectMoving(event: TransformEvent): void {
+    const unifiedStep = this.movementSnappingController.handleObjectMoving({ event })
+    if (unifiedStep.handled) {
+      this._applyGuides({
+        guides: [...unifiedStep.guides],
+        spacingGuides: [...unifiedStep.spacingGuides]
+      })
+      return
+    }
+
     const context = this._resolveObjectMovementContext({ event })
     if (!context) return
 
@@ -1155,9 +1197,24 @@ export default class SnappingManager {
   }
 
   /**
-   * Очищает направляющие и кеш после окончания перетаскивания.
+   * Очищает movement-сессию, направляющие и кеш после завершающего события.
    */
-  private _handleMouseUp(): void {
+  private _handleInteractionFinished(): void {
+    this._finishSnappingInteraction()
+  }
+
+  /** Завершает interaction, только если с canvas удалили его активный target. */
+  private _handleObjectRemoved(event: ObjectTargetEvent): void {
+    const { target } = event
+    if (!target || target !== this.activeMovementSnappingTarget) return
+
+    this._finishSnappingInteraction()
+  }
+
+  /** Идемпотентно очищает всё transient-состояние текущего interaction с прилипанием. */
+  private _finishSnappingInteraction(): void {
+    this.movementSnappingController.finishGesture()
+    this.activeMovementSnappingTarget = null
     this._clearGuides()
     this._clearAnchors()
   }
@@ -1178,80 +1235,12 @@ export default class SnappingManager {
    * Отрисовывает активные направляющие после рендера канваса.
    */
   private _handleAfterRender(): void {
-    if (!this.activeGuides.length && !this.activeSpacingGuides.length) return
-
-    const { canvas, guideBounds: cachedGuideBounds } = this
-    const context = canvas.getSelectionContext()
-
-    if (!context) return
-
-    const bounds = cachedGuideBounds ?? this._calculateViewportBounds()
-    const { left, right, top, bottom } = bounds
-    const { viewportTransform } = canvas
-    const zoom = canvas.getZoom() || 1
-    const spacingGuideLabels = this.activeSpacingGuides.map(({ distance }) => {
-      return resolveDisplayDistance({ distance }).toString()
+    renderSnappingGuides({
+      canvas: this.canvas,
+      guideBounds: this.guideBounds,
+      guides: this.activeGuides,
+      spacingGuides: this.activeSpacingGuides
     })
-
-    context.save()
-    try {
-      if (Array.isArray(viewportTransform)) {
-        context.transform(...viewportTransform)
-      }
-      context.lineWidth = GUIDE_WIDTH / zoom
-      context.strokeStyle = GUIDE_COLOR
-      context.setLineDash([4, 4])
-      this._drawActiveLineGuides({ context, left, right, top, bottom })
-      this._drawActiveSpacingGuides({ context, zoom, labels: spacingGuideLabels })
-    } finally {
-      context.restore()
-    }
-  }
-
-  /** Рисует активные линейные направляющие в пределах монтажной области или canvas. */
-  private _drawActiveLineGuides({
-    context,
-    left,
-    right,
-    top,
-    bottom
-  }: {
-    context: CanvasRenderingContext2D
-    left: number
-    right: number
-    top: number
-    bottom: number
-  }): void {
-    for (const guide of this.activeGuides) {
-      context.beginPath()
-      if (guide.type === 'vertical') {
-        context.moveTo(guide.position, top)
-        context.lineTo(guide.position, bottom)
-      } else {
-        context.moveTo(left, guide.position)
-        context.lineTo(right, guide.position)
-      }
-      context.stroke()
-    }
-  }
-
-  /** Рисует направляющие равноудалённости с уже проверенными подписями. */
-  private _drawActiveSpacingGuides({
-    context,
-    zoom,
-    labels
-  }: {
-    context: CanvasRenderingContext2D
-    zoom: number
-    labels: string[]
-  }): void {
-    for (let index = 0; index < this.activeSpacingGuides.length; index += 1) {
-      const guide = this.activeSpacingGuides[index]
-      const distanceLabel = labels[index]
-      if (!guide || distanceLabel === undefined) continue
-
-      drawSpacingGuide({ context, guide, zoom, distanceLabel })
-    }
   }
 
   /**
@@ -1362,7 +1351,7 @@ export default class SnappingManager {
         bottom
       }
     } else {
-      this.guideBounds = this._calculateViewportBounds()
+      this.guideBounds = calculateSnappingViewportBounds({ canvas: this.canvas })
     }
 
     this.anchors = nextAnchors
@@ -1450,35 +1439,5 @@ export default class SnappingManager {
     const cropTarget = activeObject as CropFrameSnapTarget | null | undefined
 
     return cropTarget?.cropSource === object
-  }
-
-  /**
-   * Возвращает границы для рисования направляющих.
-   */
-  private _calculateViewportBounds(): GuideBounds {
-    const { canvas } = this
-    const { viewportTransform } = canvas
-    const width = canvas.getWidth()
-    const height = canvas.getHeight()
-
-    const [
-      scaleX = 1,
-      ,,
-      scaleY = 1,
-      translateX = 0,
-      translateY = 0
-    ] = viewportTransform ?? []
-
-    const left = (0 - translateX) / scaleX
-    const top = (0 - translateY) / scaleY
-    const right = (width - translateX) / scaleX
-    const bottom = (height - translateY) / scaleY
-
-    return {
-      left,
-      right,
-      top,
-      bottom
-    }
   }
 }

--- a/src/editor/snapping-manager/movement-snap-candidates.ts
+++ b/src/editor/snapping-manager/movement-snap-candidates.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-use-before-define -- Публичная функция расположена перед внутренними проверками. */
+import type { ObjectBounds } from '../utils/geometry'
+
+/** Ось перемещения в координатах сцены. */
+export type MovementSceneAxis = 'x' | 'y'
+
+/** Именованная опорная точка перемещаемого bounding box. */
+export type MovementBoundsAnchor = 'left' | 'centerX' | 'right' | 'top' | 'centerY' | 'bottom'
+
+/** Категория направляющей для разрешения равных кандидатов. */
+export type MovementSnapCandidateCategory = 'domain-boundary' | 'edge' | 'center'
+
+/** Объект с точными границами, зафиксированными в начале перемещения. */
+export type MovementSnapCandidateSource = Readonly<{
+  id: string
+  bounds: ObjectBounds
+  edgeCategory?: Extract<MovementSnapCandidateCategory, 'domain-boundary' | 'edge'>
+  useForSpacing?: boolean
+}>
+
+/** Именованная направляющая из неизменяемого снимка целей. */
+export type MovementSnapCandidate = Readonly<{
+  id: string
+  axis: MovementSceneAxis
+  position: number
+  category: MovementSnapCandidateCategory
+  snapshotIndex: number
+}>
+
+/** Цели прилипания и zoom, зафиксированные на один жест перемещения. */
+export type MovementSnapEnvironment = Readonly<{
+  candidates: readonly MovementSnapCandidate[]
+  spacingBounds: readonly ObjectBounds[]
+  zoom: number
+}>
+
+/** Именованная линия одного исходного объекта. */
+type MovementSnapSourceLine = Readonly<{
+  key: 'left' | 'center-x' | 'right' | 'top' | 'center-y' | 'bottom'
+  axis: MovementSceneAxis
+  position: number
+  category: MovementSnapCandidateCategory
+}>
+
+/** Допуск проверки центров, рассчитанных из точных граней. */
+const EXACT_BOUNDS_CENTER_EPSILON = 0.000000001
+
+/**
+ * Создаёт неизменяемый снимок линейных и spacing-целей одного movement-жеста.
+ */
+export function createMovementSnapEnvironment({
+  sources,
+  zoom
+}: {
+  sources: readonly MovementSnapCandidateSource[]
+  zoom: number
+}): MovementSnapEnvironment {
+  assertEnvironmentInputs({ sources, zoom })
+
+  const candidates: MovementSnapCandidate[] = []
+  const spacingBounds: ObjectBounds[] = []
+
+  for (const source of sources) {
+    for (const line of createSourceLines({ source })) {
+      candidates.push(Object.freeze({
+        id: `${source.id}:${line.key}`,
+        axis: line.axis,
+        position: line.position,
+        category: line.category,
+        snapshotIndex: candidates.length
+      }))
+    }
+
+    if (source.useForSpacing) {
+      spacingBounds.push(createBoundsSnapshot({ bounds: source.bounds }))
+    }
+  }
+
+  return Object.freeze({
+    candidates: Object.freeze(candidates),
+    spacingBounds: Object.freeze(spacingBounds),
+    zoom
+  })
+}
+
+/** Проверяет zoom, уникальность идентификаторов и точную геометрию источников. */
+function assertEnvironmentInputs({
+  sources,
+  zoom
+}: {
+  sources: readonly MovementSnapCandidateSource[]
+  zoom: number
+}): void {
+  if (!Number.isFinite(zoom) || zoom <= 0) {
+    throw new Error('Movement snapping zoom must be a finite positive number')
+  }
+
+  const sourceIds = new Set<string>()
+  for (const source of sources) {
+    if (!source.id.trim() || sourceIds.has(source.id)) {
+      throw new Error(`Movement snap source id "${source.id}" must be non-empty and unique`)
+    }
+
+    sourceIds.add(source.id)
+    createBoundsSnapshot({ bounds: source.bounds })
+  }
+}
+
+/** Копирует и проверяет точные границы одного источника. */
+function createBoundsSnapshot({ bounds }: { bounds: ObjectBounds }): ObjectBounds {
+  const { left, right, top, bottom, centerX, centerY } = bounds
+  const values = [left, right, top, bottom, centerX, centerY]
+  if (!values.every(Number.isFinite) || right < left || bottom < top) {
+    throw new Error('Movement snap source bounds must contain finite ordered values')
+  }
+
+  const expectedCenterX = left + ((right - left) / 2)
+  const expectedCenterY = top + ((bottom - top) / 2)
+  if (Math.abs(centerX - expectedCenterX) > EXACT_BOUNDS_CENTER_EPSILON
+    || Math.abs(centerY - expectedCenterY) > EXACT_BOUNDS_CENTER_EPSILON) {
+    throw new Error('Movement snap source centers must be derived from its edges')
+  }
+
+  return Object.freeze({ left, right, top, bottom, centerX, centerY })
+}
+
+/** Возвращает грани и центры источника в стабильном порядке. */
+function createSourceLines({
+  source
+}: {
+  source: MovementSnapCandidateSource
+}): readonly MovementSnapSourceLine[] {
+  const { bounds, edgeCategory = 'edge' } = source
+
+  return Object.freeze([
+    { key: 'left', axis: 'x', position: bounds.left, category: edgeCategory },
+    { key: 'center-x', axis: 'x', position: bounds.centerX, category: 'center' },
+    { key: 'right', axis: 'x', position: bounds.right, category: edgeCategory },
+    { key: 'top', axis: 'y', position: bounds.top, category: edgeCategory },
+    { key: 'center-y', axis: 'y', position: bounds.centerY, category: 'center' },
+    { key: 'bottom', axis: 'y', position: bounds.bottom, category: edgeCategory }
+  ])
+}

--- a/src/editor/snapping-manager/movement-snapping-controller.ts
+++ b/src/editor/snapping-manager/movement-snapping-controller.ts
@@ -1,0 +1,311 @@
+/* eslint-disable no-use-before-define -- Публичный controller расположен перед внутренними преобразованиями результата. */
+import {
+  FabricImage,
+  type BasicTransformEvent,
+  type FabricObject,
+  type TPointerEvent
+} from 'fabric'
+
+import type { ImageEditor } from '..'
+import {
+  createMovementSnapEnvironment,
+  type MovementSnapCandidateSource
+} from './movement-snap-candidates'
+import {
+  createMovementGestureBaseline,
+  createMovementGuideLines,
+  type FinalMovementGeometry,
+  type MovementRawIntent,
+  type MovementSnapPlan,
+  type MovementSnapVerification,
+  type MovementTargetPosition
+} from './movement-snapping-resolver'
+import {
+  MovementSnappingRuntime,
+  type DuplicateMovementRuntimeStep
+} from './movement-snapping-runtime'
+import type {
+  GuideLine,
+  SpacingGuide
+} from './types'
+import { getObjectExactBounds } from '../utils/geometry'
+import {
+  collectExcludedObjects,
+  shouldIgnoreObject
+} from '../utils/object-filter'
+
+/** Canvas-событие одного live movement-step. */
+export type MovementTransformEvent = BasicTransformEvent<TPointerEvent> & {
+  target?: FabricObject | null
+  e?: TPointerEvent | null
+}
+
+/** Событие обработает legacy movement owner. */
+export type UnhandledMovementStep = Readonly<{
+  handled: false
+}>
+
+/** Событие обработано новым movement owner, включая отсутствие guide. */
+export type HandledMovementStep = Readonly<{
+  handled: true
+  guides: readonly GuideLine[]
+  spacingGuides: readonly SpacingGuide[]
+}>
+
+/** Результат маршрутизации одного movement-step. */
+export type MovementStepResult = UnhandledMovementStep | HandledMovementStep
+
+/** Неизменяемый результат для target-ов, которые ещё не мигрированы. */
+const UNHANDLED_MOVEMENT_STEP: UnhandledMovementStep = Object.freeze({
+  handled: false
+})
+
+/**
+ * Владеет unified movement-сессией одиночного изображения.
+ * Остальные target-ы до следующих этапов продолжают использовать legacy owner.
+ */
+export class MovementSnappingController {
+  private readonly _editor: ImageEditor
+
+  private readonly _runtime = new MovementSnappingRuntime()
+
+  private _activeTarget: FabricImage | null = null
+
+  /** Создаёт movement owner для canvas текущего редактора. */
+  constructor({
+    editor
+  }: {
+    editor: ImageEditor
+  }) {
+    this._editor = editor
+  }
+
+  /** Начинает unified-сессию только для поддержанного одиночного изображения. */
+  startGesture({
+    target
+  }: {
+    target?: FabricObject | null
+  }): boolean {
+    this.finishGesture()
+    if (!this._isSupportedTarget(target)) return false
+
+    const bounds = getObjectExactBounds({ object: target })
+    if (!bounds) {
+      throw new Error('Image movement snapping requires exact target bounds')
+    }
+
+    const position = this._readTargetPosition({ target })
+    const environment = this._captureEnvironment({ activeObject: target })
+    const baseline = createMovementGestureBaseline({
+      bounds,
+      position,
+      environment
+    })
+
+    this._runtime.startSession({ baseline })
+    this._activeTarget = target
+
+    return true
+  }
+
+  /** Рассчитывает, применяет один раз и проверяет текущий Image movement-step. */
+  handleObjectMoving({
+    event
+  }: {
+    event: MovementTransformEvent
+  }): MovementStepResult {
+    const { target } = event
+    const activeTarget = this._activeTarget
+    if (!target || !activeTarget || target !== activeTarget) return UNHANDLED_MOVEMENT_STEP
+
+    const marker = resolveMovementMarker({ event })
+    const duplicate = this._runtime.getDuplicateStep({ marker })
+    if (duplicate) return createDuplicateStepResult({ duplicate })
+
+    const intent = this._createRawIntent({ target: activeTarget, event })
+    const step = this._runtime.resolveMovementPlan({ marker, intent })
+    if (step.kind === 'duplicate') return createDuplicateStepResult({ duplicate: step })
+
+    this._applyMovementPlan({ target: activeTarget, plan: step.plan })
+    const verification = this._runtime.verifyMovementPlan({
+      token: step.token,
+      finalGeometry: this._readFinalGeometry({ target: activeTarget })
+    })
+
+    return createHandledStepResult({ verification })
+  }
+
+  /** Идемпотентно очищает transient movement-состояние. */
+  finishGesture(): void {
+    this._runtime.finishSession()
+    this._activeTarget = null
+  }
+
+  /** Возвращает true только для top-level FabricImage текущей фазы. */
+  private _isSupportedTarget(
+    target?: FabricObject | null
+  ): target is FabricImage {
+    return target instanceof FabricImage && !target.group
+  }
+
+  /** Создаёт raw intent до любой post-Fabric мутации текущего шага. */
+  private _createRawIntent({
+    target,
+    event
+  }: {
+    target: FabricImage
+    event: MovementTransformEvent
+  }): MovementRawIntent {
+    const bounds = getObjectExactBounds({ object: target })
+    if (!bounds) {
+      throw new Error('Image movement snapping requires exact raw bounds')
+    }
+
+    return {
+      bounds,
+      position: this._readTargetPosition({ target }),
+      axes: {
+        x: !target.lockMovementX,
+        y: !target.lockMovementY
+      },
+      modifiers: {
+        ctrlKey: Boolean(event.e?.ctrlKey)
+      }
+    }
+  }
+
+  /** Применяет одну итоговую target translation, если plan изменил raw position. */
+  private _applyMovementPlan({
+    target,
+    plan
+  }: {
+    target: FabricImage
+    plan: MovementSnapPlan
+  }): void {
+    const { left, top } = plan.nextPosition
+    if (target.left === left && target.top === top) return
+
+    target.set({ left, top })
+    target.setCoords()
+  }
+
+  /** Читает фактическую геометрию после единственного применения плана. */
+  private _readFinalGeometry({
+    target
+  }: {
+    target: FabricImage
+  }): FinalMovementGeometry {
+    const bounds = getObjectExactBounds({ object: target })
+    if (!bounds) {
+      throw new Error('Image movement snapping requires exact final bounds')
+    }
+
+    return {
+      bounds,
+      position: this._readTargetPosition({ target })
+    }
+  }
+
+  /** Читает конечные Fabric left/top без fallback-нормализации. */
+  private _readTargetPosition({
+    target
+  }: {
+    target: FabricImage
+  }): MovementTargetPosition {
+    if (!Number.isFinite(target.left) || !Number.isFinite(target.top)) {
+      throw new Error('Image movement snapping requires finite target position')
+    }
+
+    return {
+      left: target.left,
+      top: target.top
+    }
+  }
+
+  /** Фиксирует exact bounds неподвижных целей и montage один раз на gesture. */
+  private _captureEnvironment({
+    activeObject
+  }: {
+    activeObject: FabricImage
+  }) {
+    const sources = this._collectCandidateSources({ activeObject })
+    const montageBounds = getObjectExactBounds({ object: this._editor.montageArea })
+    if (montageBounds) {
+      sources.push({
+        id: 'montage-area',
+        bounds: montageBounds,
+        edgeCategory: 'domain-boundary'
+      })
+    }
+
+    return createMovementSnapEnvironment({
+      sources,
+      zoom: this._editor.canvas.getZoom() || 1
+    })
+  }
+
+  /** Собирает стабильные цели обычного и равноудалённого прилипания. */
+  private _collectCandidateSources({
+    activeObject
+  }: {
+    activeObject: FabricImage
+  }): MovementSnapCandidateSource[] {
+    const excluded = collectExcludedObjects({ activeObject })
+    const sources: MovementSnapCandidateSource[] = []
+
+    this._editor.canvas.forEachObject((object) => {
+      if (shouldIgnoreObject({ object, excluded })) return
+
+      const bounds = getObjectExactBounds({ object })
+      if (!bounds) return
+
+      sources.push({
+        id: `object:${sources.length}:${object.id ?? object.type}`,
+        bounds,
+        useForSpacing: true
+      })
+    })
+
+    return sources
+  }
+}
+
+/** Выбирает native event как marker или использует canvas event для тестового пути. */
+function resolveMovementMarker({
+  event
+}: {
+  event: MovementTransformEvent
+}): object {
+  const { e } = event
+  if ((typeof e === 'object' && e !== null) || typeof e === 'function') return e
+
+  return event
+}
+
+/** Возвращает уже подтверждённый результат, не читая повторно изменённый target. */
+function createDuplicateStepResult({
+  duplicate
+}: {
+  duplicate: DuplicateMovementRuntimeStep
+}): HandledMovementStep {
+  if (!duplicate.verification) {
+    throw new Error('Duplicate movement step cannot be handled before verification')
+  }
+
+  return createHandledStepResult({
+    verification: duplicate.verification
+  })
+}
+
+/** Преобразует verification в renderer-контракт SnappingManager. */
+function createHandledStepResult({
+  verification
+}: {
+  verification: MovementSnapVerification
+}): HandledMovementStep {
+  return Object.freeze({
+    handled: true,
+    guides: Object.freeze(createMovementGuideLines({ guides: verification.guides })),
+    spacingGuides: Object.freeze([...verification.spacingGuides])
+  })
+}

--- a/src/editor/snapping-manager/movement-snapping-resolver.ts
+++ b/src/editor/snapping-manager/movement-snapping-resolver.ts
@@ -1,0 +1,1359 @@
+/* eslint-disable no-use-before-define -- Публичные контракты расположены перед внутренними расчётами. */
+import {
+  MOVE_SNAP_STEP,
+  SNAP_THRESHOLD,
+  SPACING_SNAP_HOLD_MARGIN
+} from './constants'
+import {
+  calculateHorizontalSpacing,
+  calculateVerticalSpacing,
+  createSpacingGuideGeometryKey,
+  isSpacingSelectionApplicable,
+  type ResolvedSpacingSelection,
+  type SpacingSelectionContext,
+  type SpacingSelectionIdentity
+} from './spacing'
+import {
+  type MovementBoundsAnchor,
+  type MovementSceneAxis,
+  type MovementSnapCandidate,
+  type MovementSnapCandidateCategory,
+  type MovementSnapEnvironment
+} from './movement-snap-candidates'
+import type {
+  Bounds,
+  GuideLine,
+  SpacingGuide,
+  SpacingPattern
+} from './types'
+import { buildSpacingPatterns } from './utils'
+
+/** Положение Fabric origin перемещаемого объекта. */
+export type MovementTargetPosition = Readonly<{
+  left: number
+  top: number
+}>
+
+/** Состояние одной оси без удерживаемой направляющей. */
+export type FreeMovementAxisHold = Readonly<{
+  kind: 'free'
+}>
+
+/** Удержание конкретной линии и опорной точки перемещаемого объекта. */
+export type HeldMovementLineAxisHold = Readonly<{
+  kind: 'line'
+  candidate: MovementSnapCandidate
+  activeAnchor: MovementBoundsAnchor
+}>
+
+/** Удержание конкретного интервала равноудалённости. */
+export type HeldMovementSpacingAxisHold = Readonly<{
+  kind: 'spacing'
+  candidateId: string
+  context: Readonly<SpacingSelectionContext>
+}>
+
+/** Свободное или удерживаемое состояние одной оси. */
+export type MovementAxisHold = FreeMovementAxisHold
+  | HeldMovementLineAxisHold
+  | HeldMovementSpacingAxisHold
+
+/** Независимое временное состояние line или spacing-ограничений по двум осям. */
+export type MovementHoldState = Readonly<{
+  x: MovementAxisHold
+  y: MovementAxisHold
+}>
+
+/** Пороговые значения одного movement-жеста в координатах сцены. */
+export type MovementSnapThresholds = Readonly<{
+  acquire: number
+  release: number
+  spacingRelease: number
+  verification: number
+}>
+
+/** Неизменяемый снимок начальной геометрии и целей перемещения. */
+export type MovementGestureBaseline = Readonly<{
+  bounds: Bounds
+  position: MovementTargetPosition
+  candidates: readonly MovementSnapCandidate[]
+  spacingBounds: readonly Bounds[]
+  spacingPatterns: Readonly<{
+    vertical: readonly SpacingPattern[]
+    horizontal: readonly SpacingPattern[]
+  }>
+  thresholds: MovementSnapThresholds
+}>
+
+/** Доступные оси прилипания текущего movement-step. */
+export type MovementSnapAxes = Readonly<{
+  x: boolean
+  y: boolean
+}>
+
+/** Raw-состояние объекта после Fabric drag и до применения прилипания. */
+export type MovementRawIntent = Readonly<{
+  bounds: Bounds
+  position: MovementTargetPosition
+  axes: MovementSnapAxes
+  modifiers: Readonly<{
+    ctrlKey: boolean
+  }>
+}>
+
+/** Способ выбора ограничения на текущем шаге. */
+export type MovementSnapTransition = 'acquired' | 'held'
+
+/** Выбранная линия и опорная точка по одной оси. */
+export type PlannedMovementLineConstraint = Readonly<{
+  kind: 'line'
+  axis: MovementSceneAxis
+  activeAnchor: MovementBoundsAnchor
+  candidate: MovementSnapCandidate
+  transition: MovementSnapTransition
+}>
+
+/** Выбранный интервал равноудалённости по одной оси. */
+export type PlannedMovementSpacingConstraint = Readonly<{
+  kind: 'spacing'
+  axis: MovementSceneAxis
+  candidateId: string
+  context: Readonly<SpacingSelectionContext>
+  delta: number
+  selections: readonly ResolvedSpacingSelection[]
+  transition: MovementSnapTransition
+}>
+
+/** Единственное линейное или spacing-ограничение одной оси. */
+export type PlannedMovementConstraint = PlannedMovementLineConstraint
+  | PlannedMovementSpacingConstraint
+
+/** Результат расчёта одной итоговой translation для текущего raw-состояния. */
+export type MovementSnapPlan = Readonly<{
+  rawIntent: MovementRawIntent
+  nextPosition: MovementTargetPosition
+  predictedBounds: Bounds
+  constraints: Readonly<{
+    x: PlannedMovementConstraint | null
+    y: PlannedMovementConstraint | null
+  }>
+  verificationEpsilon: number
+}>
+
+/** Фактическое состояние после единственного применения movement-плана. */
+export type FinalMovementGeometry = Readonly<{
+  bounds: Bounds
+  position: MovementTargetPosition
+}>
+
+/** Линейная направляющая, подтверждённая по фактической геометрии. */
+export type VerifiedMovementGuide = Readonly<{
+  axis: MovementSceneAxis
+  activeAnchor: MovementBoundsAnchor
+  position: number
+  candidateId: string
+  category: MovementSnapCandidateCategory
+  snapshotIndex: number
+}>
+
+/** Подтверждённые направляющие и новое transient-состояние movement-жеста. */
+export type MovementSnapVerification = Readonly<{
+  guides: readonly VerifiedMovementGuide[]
+  spacingGuides: readonly SpacingGuide[]
+  blockedAxes: readonly MovementSceneAxis[]
+  holdState: MovementHoldState
+}>
+
+/** Результат выбора ограничения по одной оси до materialization guide. */
+type MovementAxisProposal = Readonly<
+  | PlannedMovementLineConstraint
+  | PlannedMovementSpacingConstraint
+>
+
+/** Ограничения обеих осей до materialization итогового movement-плана. */
+type MovementAxisProposals = Readonly<{
+  x: MovementAxisProposal | null
+  y: MovementAxisProposal | null
+}>
+
+/** Результат существующего spacing-calculator по одной оси. */
+type MovementSpacingCalculation = {
+  delta: number
+  guides: SpacingGuide[]
+  context: SpacingSelectionContext | null
+  selections: ResolvedSpacingSelection[]
+}
+
+/** Общий допуск проверки фактически применённого movement-плана. */
+export const MOVEMENT_SNAP_VERIFICATION_EPSILON = 0.1
+
+/** Допуск проверки центров в точных границах. */
+const EXACT_BOUNDS_CENTER_EPSILON = 0.000000001
+
+/** Допуск сравнения двух correction при выборе одного ограничения. */
+const MOVEMENT_CORRECTION_COMPARISON_EPSILON = 0.000000001
+
+/** Число проходов для стабилизации cross-axis spacing после замены constraints. */
+const MOVEMENT_SPACING_COMPATIBILITY_PASSES = 3
+
+/** Порядок категорий при одинаковом расстоянии до нескольких линий. */
+const MOVEMENT_CANDIDATE_CATEGORY_PRIORITY: Readonly<Record<MovementSnapCandidateCategory, number>> = Object.freeze({
+  'domain-boundary': 0,
+  edge: 1,
+  center: 2
+})
+
+/** Опорные точки по X в стабильном порядке. */
+const X_ANCHORS: readonly MovementBoundsAnchor[] = Object.freeze(['left', 'centerX', 'right'])
+
+/** Опорные точки по Y в стабильном порядке. */
+const Y_ANCHORS: readonly MovementBoundsAnchor[] = Object.freeze(['top', 'centerY', 'bottom'])
+
+/** Общее неизменяемое состояние свободной оси. */
+const FREE_MOVEMENT_AXIS_HOLD: FreeMovementAxisHold = Object.freeze({ kind: 'free' })
+
+/** Начальное состояние без удерживаемых линейных направляющих. */
+export const FREE_MOVEMENT_HOLD_STATE: MovementHoldState = Object.freeze({
+  x: FREE_MOVEMENT_AXIS_HOLD,
+  y: FREE_MOVEMENT_AXIS_HOLD
+})
+
+/**
+ * Проверяет и сохраняет начальную геометрию, цели и пороги movement-жеста.
+ */
+export function createMovementGestureBaseline({
+  bounds,
+  position,
+  environment
+}: {
+  bounds: Bounds
+  position: MovementTargetPosition
+  environment: MovementSnapEnvironment
+}): MovementGestureBaseline {
+  const exactBounds = createExactBoundsSnapshot({ bounds })
+  const exactPosition = createPositionSnapshot({ position })
+  const spacingBounds = environment.spacingBounds.map((candidateBounds) => {
+    return createExactBoundsSnapshot({ bounds: candidateBounds })
+  })
+  const spacingPatterns = buildSpacingPatterns({ bounds: [...spacingBounds] })
+
+  return Object.freeze({
+    bounds: exactBounds,
+    position: exactPosition,
+    candidates: environment.candidates,
+    spacingBounds: Object.freeze(spacingBounds),
+    spacingPatterns: freezeSpacingPatterns({ patterns: spacingPatterns }),
+    thresholds: createMovementSnapThresholds({ zoom: environment.zoom })
+  })
+}
+
+/**
+ * Рассчитывает одну итоговую translation от raw intent и текущего hold-state.
+ */
+export function resolveMovementSnapPlan({
+  baseline,
+  intent,
+  holdState
+}: {
+  baseline: MovementGestureBaseline
+  intent: MovementRawIntent
+  holdState: MovementHoldState
+}): MovementSnapPlan {
+  const rawIntent = createRawIntentSnapshot({ intent })
+  assertMovementHoldState({ baseline, holdState })
+  assertRawIntentMatchesBaseline({ baseline, intent: rawIntent })
+
+  if (rawIntent.modifiers.ctrlKey) {
+    return createDisabledMovementPlan({ rawIntent })
+  }
+
+  const proposals = resolveCompatibleMovementProposals({
+    baseline,
+    intent: rawIntent,
+    proposals: {
+      x: resolveAxisProposal({ axis: 'x', baseline, intent: rawIntent, hold: holdState.x }),
+      y: resolveAxisProposal({ axis: 'y', baseline, intent: rawIntent, hold: holdState.y })
+    }
+  })
+  const nextPosition = resolveNextMovementPosition({
+    intent: rawIntent,
+    proposals
+  })
+  const predictedBounds = translateBounds({
+    bounds: rawIntent.bounds,
+    deltaX: nextPosition.left - rawIntent.position.left,
+    deltaY: nextPosition.top - rawIntent.position.top
+  })
+  const constraints = createPlannedMovementConstraints({
+    proposals,
+    deltaX: nextPosition.left - rawIntent.position.left,
+    deltaY: nextPosition.top - rawIntent.position.top
+  })
+
+  return Object.freeze({
+    rawIntent,
+    nextPosition,
+    predictedBounds,
+    constraints,
+    verificationEpsilon: baseline.thresholds.verification
+  })
+}
+
+/**
+ * Проверяет фактическую геометрию и только после этого обновляет hold-state и guide.
+ */
+export function verifyMovementSnapPlan({
+  baseline,
+  plan,
+  finalGeometry
+}: {
+  baseline: MovementGestureBaseline
+  plan: MovementSnapPlan
+  finalGeometry: FinalMovementGeometry
+}): MovementSnapVerification {
+  const bounds = createExactBoundsSnapshot({ bounds: finalGeometry.bounds })
+  const position = createPositionSnapshot({ position: finalGeometry.position })
+  const dimensionsPreserved = areBoundsDimensionsEqual({
+    first: baseline.bounds,
+    second: bounds,
+    epsilon: plan.verificationEpsilon
+  })
+  const xVerified = verifyMovementAxisConstraint({
+    baseline,
+    constraint: plan.constraints.x,
+    plan,
+    bounds,
+    position,
+    dimensionsPreserved
+  })
+  const yVerified = verifyMovementAxisConstraint({
+    baseline,
+    constraint: plan.constraints.y,
+    plan,
+    bounds,
+    position,
+    dimensionsPreserved
+  })
+
+  return createMovementVerification({
+    baseline,
+    plan,
+    xVerified,
+    yVerified,
+    bounds
+  })
+}
+
+/** Создаёт план без прилипания и pixel rounding при нажатом Ctrl. */
+function createDisabledMovementPlan({
+  rawIntent
+}: {
+  rawIntent: MovementRawIntent
+}): MovementSnapPlan {
+  return Object.freeze({
+    rawIntent,
+    nextPosition: rawIntent.position,
+    predictedBounds: rawIntent.bounds,
+    constraints: Object.freeze({ x: null, y: null }),
+    verificationEpsilon: MOVEMENT_SNAP_VERIFICATION_EPSILON
+  })
+}
+
+/** Выбирает ровно одно удерживаемое или новое ограничение по одной оси. */
+function resolveAxisProposal({
+  axis,
+  baseline,
+  intent,
+  hold
+}: {
+  axis: MovementSceneAxis
+  baseline: MovementGestureBaseline
+  intent: MovementRawIntent
+  hold: MovementAxisHold
+}): MovementAxisProposal | null {
+  if (!intent.axes[axis]) return null
+
+  const heldProposal = resolveHeldAxisProposal({
+    axis,
+    baseline,
+    intent,
+    hold
+  })
+  if (heldProposal) return heldProposal
+
+  const line = resolveAcquiredLineConstraint({
+    axis,
+    bounds: intent.bounds,
+    candidates: baseline.candidates,
+    threshold: baseline.thresholds.acquire
+  })
+  const spacing = resolveSpacingConstraint({
+    axis,
+    baseline,
+    bounds: intent.bounds,
+    threshold: baseline.thresholds.acquire,
+    transition: 'acquired'
+  })
+
+  return selectAcquiredAxisProposal({
+    bounds: intent.bounds,
+    line,
+    spacing
+  })
+}
+
+/** Сохраняет прежнее line или spacing-ограничение внутри его release-zone. */
+function resolveHeldAxisProposal({
+  axis,
+  baseline,
+  intent,
+  hold
+}: {
+  axis: MovementSceneAxis
+  baseline: MovementGestureBaseline
+  intent: MovementRawIntent
+  hold: MovementAxisHold
+}): MovementAxisProposal | null {
+  if (hold.kind === 'line') {
+    return resolveHeldLineConstraint({
+      axis,
+      bounds: intent.bounds,
+      hold,
+      releaseThreshold: baseline.thresholds.release
+    })
+  }
+  if (hold.kind === 'spacing') {
+    return resolveHeldSpacingConstraint({
+      axis,
+      baseline,
+      bounds: intent.bounds,
+      hold
+    })
+  }
+
+  return null
+}
+
+/** Сохраняет выбранную line, пока её raw anchor остаётся в release-zone. */
+function resolveHeldLineConstraint({
+  axis,
+  bounds,
+  hold,
+  releaseThreshold
+}: {
+  axis: MovementSceneAxis
+  bounds: Bounds
+  hold: HeldMovementLineAxisHold
+  releaseThreshold: number
+}): PlannedMovementLineConstraint | null {
+  const rawPosition = bounds[hold.activeAnchor]
+  const distance = Math.abs(rawPosition - hold.candidate.position)
+  if (distance > releaseThreshold) return null
+
+  return Object.freeze({
+    kind: 'line',
+    axis,
+    activeAnchor: hold.activeAnchor,
+    candidate: hold.candidate,
+    transition: 'held'
+  })
+}
+
+/** Сохраняет конкретный spacing-кандидат, не переключаясь внутри release-zone. */
+function resolveHeldSpacingConstraint({
+  axis,
+  baseline,
+  bounds,
+  hold
+}: {
+  axis: MovementSceneAxis
+  baseline: MovementGestureBaseline
+  bounds: Bounds
+  hold: HeldMovementSpacingAxisHold
+}): PlannedMovementSpacingConstraint | null {
+  const constraint = resolveSpacingConstraint({
+    axis,
+    baseline,
+    bounds,
+    threshold: baseline.thresholds.spacingRelease,
+    previousContext: hold.context,
+    transition: 'held'
+  })
+  if (!constraint || constraint.candidateId !== hold.candidateId) return null
+
+  return constraint
+}
+
+/** Выбирает меньшую новую correction; при равенстве line имеет приоритет над spacing. */
+function selectAcquiredAxisProposal({
+  bounds,
+  line,
+  spacing
+}: {
+  bounds: Bounds
+  line: PlannedMovementLineConstraint | null
+  spacing: PlannedMovementSpacingConstraint | null
+}): MovementAxisProposal | null {
+  if (!line) return spacing
+  if (!spacing) return line
+
+  const lineDelta = Math.abs(resolveLineConstraintDelta({
+    constraint: line,
+    bounds
+  }))
+
+  return lineDelta <= Math.abs(spacing.delta) + MOVEMENT_CORRECTION_COMPARISON_EPSILON
+    ? line
+    : spacing
+}
+
+/** Стабилизирует spacing-ограничения после совместной коррекции обеих осей. */
+function resolveCompatibleMovementProposals({
+  baseline,
+  intent,
+  proposals
+}: {
+  baseline: MovementGestureBaseline
+  intent: MovementRawIntent
+  proposals: MovementAxisProposals
+}): MovementAxisProposals {
+  let compatible = proposals
+
+  for (let pass = 0; pass < MOVEMENT_SPACING_COMPATIBILITY_PASSES; pass += 1) {
+    const nextPosition = resolveNextMovementPosition({
+      intent,
+      proposals: compatible
+    })
+    const predictedBounds = translateBounds({
+      bounds: intent.bounds,
+      deltaX: nextPosition.left - intent.position.left,
+      deltaY: nextPosition.top - intent.position.top
+    })
+    const x = resolveCompatibleSpacingProposal({
+      proposal: compatible.x,
+      baseline,
+      intent,
+      bounds: predictedBounds
+    })
+    const y = resolveCompatibleSpacingProposal({
+      proposal: compatible.y,
+      baseline,
+      intent,
+      bounds: predictedBounds
+    })
+    if (x === compatible.x && y === compatible.y) return compatible
+
+    compatible = Object.freeze({ x, y })
+  }
+
+  return compatible
+}
+
+/** Фильтрует secondary spacing guides или возвращает line при потере primary interval. */
+function resolveCompatibleSpacingProposal({
+  proposal,
+  baseline,
+  intent,
+  bounds
+}: {
+  proposal: MovementAxisProposal | null
+  baseline: MovementGestureBaseline
+  intent: MovementRawIntent
+  bounds: Bounds
+}): MovementAxisProposal | null {
+  if (!proposal || proposal.kind === 'line') return proposal
+
+  const selections = resolveApplicableSpacingSelections({
+    constraint: proposal,
+    baseline,
+    bounds
+  })
+  if (!selections.some(({ isPrimary }) => isPrimary)) {
+    return resolveAcquiredLineConstraint({
+      axis: proposal.axis,
+      bounds: intent.bounds,
+      candidates: baseline.candidates,
+      threshold: baseline.thresholds.acquire
+    })
+  }
+  if (selections.length === proposal.selections.length) return proposal
+
+  return Object.freeze({
+    ...proposal,
+    selections: Object.freeze(selections)
+  })
+}
+
+/** Возвращает cross-axis tolerance выбранного acquire или held spacing. */
+function resolveSpacingSelectionTolerance({
+  constraint,
+  baseline
+}: {
+  constraint: PlannedMovementSpacingConstraint
+  baseline: MovementGestureBaseline
+}): number {
+  return constraint.transition === 'held'
+    ? baseline.thresholds.spacingRelease
+    : baseline.thresholds.acquire
+}
+
+/** Оставляет только spacing selections, применимые к заданным общим bounds. */
+function resolveApplicableSpacingSelections({
+  constraint,
+  baseline,
+  bounds
+}: {
+  constraint: PlannedMovementSpacingConstraint
+  baseline: MovementGestureBaseline
+  bounds: Bounds
+}): readonly ResolvedSpacingSelection[] {
+  const tolerance = resolveSpacingSelectionTolerance({
+    constraint,
+    baseline
+  })
+
+  return constraint.selections.filter((selection) => {
+    return isSpacingSelectionApplicable({
+      selection,
+      activeBounds: bounds,
+      candidates: baseline.spacingBounds,
+      tolerance
+    })
+  })
+}
+
+/** Ищет ближайшую новую пару active anchor → candidate. */
+function resolveAcquiredLineConstraint({
+  axis,
+  bounds,
+  candidates,
+  threshold
+}: {
+  axis: MovementSceneAxis
+  bounds: Bounds
+  candidates: readonly MovementSnapCandidate[]
+  threshold: number
+}): PlannedMovementLineConstraint | null {
+  let best: PlannedMovementLineConstraint | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+  const anchors = axis === 'x' ? X_ANCHORS : Y_ANCHORS
+
+  for (let anchorIndex = 0; anchorIndex < anchors.length; anchorIndex += 1) {
+    const activeAnchor = anchors[anchorIndex]
+    for (const candidate of candidates) {
+      if (candidate.axis !== axis) continue
+
+      const distance = Math.abs(bounds[activeAnchor] - candidate.position)
+      if (distance > threshold) continue
+      if (!isBetterMovementCandidate({ candidate, distance, current: best, currentDistance: bestDistance })) continue
+
+      best = Object.freeze({
+        kind: 'line',
+        axis,
+        activeAnchor,
+        candidate,
+        transition: 'acquired'
+      })
+      bestDistance = distance
+    }
+  }
+
+  return best
+}
+
+/** Сравнивает кандидатов по расстоянию, категории и стабильному snapshot index. */
+function isBetterMovementCandidate({
+  candidate,
+  distance,
+  current,
+  currentDistance
+}: {
+  candidate: MovementSnapCandidate
+  distance: number
+  current: PlannedMovementLineConstraint | null
+  currentDistance: number
+}): boolean {
+  if (!current) return true
+
+  const distanceDifference = distance - currentDistance
+  if (distanceDifference < -MOVEMENT_CORRECTION_COMPARISON_EPSILON) return true
+  if (distanceDifference > MOVEMENT_CORRECTION_COMPARISON_EPSILON) return false
+
+  const candidatePriority = MOVEMENT_CANDIDATE_CATEGORY_PRIORITY[candidate.category]
+  const currentPriority = MOVEMENT_CANDIDATE_CATEGORY_PRIORITY[current.candidate.category]
+  if (candidatePriority !== currentPriority) return candidatePriority < currentPriority
+
+  return candidate.snapshotIndex < current.candidate.snapshotIndex
+}
+
+/** Возвращает сдвиг, необходимый для выбранной line. */
+function resolveLineConstraintDelta({
+  constraint,
+  bounds
+}: {
+  constraint: PlannedMovementLineConstraint
+  bounds: Bounds
+}): number {
+  return constraint.candidate.position - bounds[constraint.activeAnchor]
+}
+
+/** Возвращает correction выбранного line или spacing-ограничения. */
+function resolveProposalDelta({
+  proposal,
+  bounds
+}: {
+  proposal: MovementAxisProposal | null
+  bounds: Bounds
+}): number {
+  if (!proposal) return 0
+  if (proposal.kind === 'spacing') return proposal.delta
+
+  return resolveLineConstraintDelta({ constraint: proposal, bounds })
+}
+
+/** Адаптирует существующий spacing-calculator к одному именованному constraint. */
+function resolveSpacingConstraint({
+  axis,
+  baseline,
+  bounds,
+  threshold,
+  transition,
+  previousContext = null
+}: {
+  axis: MovementSceneAxis
+  baseline: MovementGestureBaseline
+  bounds: Bounds
+  threshold: number
+  transition: MovementSnapTransition
+  previousContext?: Readonly<SpacingSelectionContext> | null
+}): PlannedMovementSpacingConstraint | null {
+  const calculation = calculateMovementAxisSpacing({
+    axis,
+    baseline,
+    bounds,
+    threshold,
+    previousContext
+  })
+  if (!calculation.context || !calculation.guides.length) return null
+  if (!calculation.selections.length) {
+    throw new Error('Movement spacing result must describe its selected intervals')
+  }
+
+  const context = freezeSpacingContext({ context: calculation.context })
+  if (!context) {
+    throw new Error('Movement spacing result must contain a context')
+  }
+  const selections = freezeSpacingSelections({
+    selections: calculation.selections
+  })
+  const primarySelections = selections.filter(({ isPrimary }) => isPrimary)
+  if (primarySelections.length !== 1) {
+    throw new Error('Movement spacing result must identify exactly one primary interval')
+  }
+  const [primarySelection] = primarySelections
+
+  return Object.freeze({
+    kind: 'spacing',
+    axis,
+    candidateId: createSpacingCandidateId({
+      axis,
+      identity: primarySelection.identity,
+      context
+    }),
+    context,
+    delta: calculation.delta,
+    selections,
+    transition
+  })
+}
+
+/** Вызывает horizontal или vertical spacing-calculator с порогом конкретной оси. */
+function calculateMovementAxisSpacing({
+  axis,
+  baseline,
+  bounds,
+  threshold,
+  previousContext
+}: {
+  axis: MovementSceneAxis
+  baseline: MovementGestureBaseline
+  bounds: Bounds
+  threshold: number
+  previousContext?: Readonly<SpacingSelectionContext> | null
+}): MovementSpacingCalculation {
+  const params = {
+    activeBounds: bounds,
+    candidates: baseline.spacingBounds.map((candidate) => ({ ...candidate })),
+    threshold,
+    patterns: axis === 'x'
+      ? baseline.spacingPatterns.horizontal.map((pattern) => ({ ...pattern }))
+      : baseline.spacingPatterns.vertical.map((pattern) => ({ ...pattern })),
+    previousContext: previousContext ? { ...previousContext } : null,
+    switchDistance: previousContext ? Number.POSITIVE_INFINITY : 0
+  }
+
+  return axis === 'x'
+    ? calculateHorizontalSpacing(params)
+    : calculateVerticalSpacing(params)
+}
+
+/** Создаёт стабильный идентификатор из полной identity основного spacing-интервала. */
+function createSpacingCandidateId({
+  axis,
+  identity,
+  context
+}: {
+  axis: MovementSceneAxis
+  identity: SpacingSelectionIdentity
+  context: SpacingSelectionContext
+}): string {
+  return JSON.stringify({
+    axis,
+    context,
+    identity
+  })
+}
+
+/** Сравнивает координаты identity без display rounding. */
+function areNumbersNear(first: number, second: number): boolean {
+  return Math.abs(first - second) <= EXACT_BOUNDS_CENTER_EPSILON
+}
+
+/** Рассчитывает единственную позицию target из одного constraint на каждой оси. */
+function resolveNextMovementPosition({
+  intent,
+  proposals
+}: {
+  intent: MovementRawIntent
+  proposals: MovementAxisProposals
+}): MovementTargetPosition {
+  return Object.freeze({
+    left: resolveMovementAxisPosition({
+      value: intent.position.left,
+      delta: resolveProposalDelta({ proposal: proposals.x, bounds: intent.bounds }),
+      canSnap: intent.axes.x,
+      hasConstraint: Boolean(proposals.x)
+    }),
+    top: resolveMovementAxisPosition({
+      value: intent.position.top,
+      delta: resolveProposalDelta({ proposal: proposals.y, bounds: intent.bounds }),
+      canSnap: intent.axes.y,
+      hasConstraint: Boolean(proposals.y)
+    })
+  })
+}
+
+/** Округляет свободную ось к pixel grid, не меняя защищённую направляющую. */
+function resolveMovementAxisPosition({
+  value,
+  delta,
+  canSnap,
+  hasConstraint
+}: {
+  value: number
+  delta: number
+  canSnap: boolean
+  hasConstraint: boolean
+}): number {
+  if (!canSnap) return value
+  if (hasConstraint) return value + delta
+
+  return Math.round(value / MOVE_SNAP_STEP) * MOVE_SNAP_STEP
+}
+
+/** Материализует plan constraints и переносит spacing guide по поперечной оси. */
+function createPlannedMovementConstraints({
+  proposals,
+  deltaX,
+  deltaY
+}: {
+  proposals: MovementAxisProposals
+  deltaX: number
+  deltaY: number
+}): MovementSnapPlan['constraints'] {
+  return Object.freeze({
+    x: materializeMovementConstraint({ proposal: proposals.x, deltaX, deltaY }),
+    y: materializeMovementConstraint({ proposal: proposals.y, deltaX, deltaY })
+  })
+}
+
+/** Копирует line или фиксирует spacing guide в ожидаемой финальной позиции. */
+function materializeMovementConstraint({
+  proposal,
+  deltaX,
+  deltaY
+}: {
+  proposal: MovementAxisProposal | null
+  deltaX: number
+  deltaY: number
+}): PlannedMovementConstraint | null {
+  if (!proposal || proposal.kind === 'line') return proposal
+
+  return Object.freeze({
+    ...proposal,
+    selections: Object.freeze(proposal.selections.map((selection) => {
+      const { guide } = selection
+      const crossAxisDelta = guide.type === 'horizontal' ? deltaY : deltaX
+
+      return Object.freeze({
+        ...selection,
+        guide: Object.freeze({
+          ...guide,
+          axis: guide.axis + crossAxisDelta
+        })
+      })
+    }))
+  })
+}
+
+/** Проверяет выбранное ограничение по общим final bounds, не подменяя его candidate. */
+function verifyMovementAxisConstraint({
+  baseline,
+  constraint,
+  plan,
+  bounds,
+  position,
+  dimensionsPreserved
+}: {
+  baseline: MovementGestureBaseline
+  constraint: PlannedMovementConstraint | null
+  plan: MovementSnapPlan
+  bounds: Bounds
+  position: MovementTargetPosition
+  dimensionsPreserved: boolean
+}): boolean {
+  if (!constraint || !dimensionsPreserved) return false
+
+  const targetPosition = constraint.axis === 'x' ? position.left : position.top
+  const plannedPosition = constraint.axis === 'x' ? plan.nextPosition.left : plan.nextPosition.top
+  if (Math.abs(targetPosition - plannedPosition) > plan.verificationEpsilon) return false
+  if (!doesMovementAxisMatchPlan({ axis: constraint.axis, bounds, plan })) return false
+  if (constraint.kind === 'spacing') {
+    const selections = resolveApplicableSpacingSelections({
+      constraint,
+      baseline,
+      bounds
+    })
+
+    return selections.some(({ isPrimary }) => isPrimary)
+  }
+
+  return Math.abs(
+    bounds[constraint.activeAnchor] - constraint.candidate.position
+  ) <= plan.verificationEpsilon
+}
+
+/** Сравнивает фактические и рассчитанные границы только по проверяемой оси. */
+function doesMovementAxisMatchPlan({
+  axis,
+  bounds,
+  plan
+}: {
+  axis: MovementSceneAxis
+  bounds: Bounds
+  plan: MovementSnapPlan
+}): boolean {
+  const edges: readonly (keyof Bounds)[] = axis === 'x'
+    ? ['left', 'centerX', 'right']
+    : ['top', 'centerY', 'bottom']
+
+  return edges.every((edge) => {
+    return Math.abs(bounds[edge] - plan.predictedBounds[edge]) <= plan.verificationEpsilon
+  })
+}
+
+/** Формирует окончательный результат verification. */
+function createMovementVerification({
+  baseline,
+  plan,
+  xVerified,
+  yVerified,
+  bounds
+}: {
+  baseline: MovementGestureBaseline
+  plan: MovementSnapPlan
+  xVerified: boolean
+  yVerified: boolean
+  bounds: Bounds
+}): MovementSnapVerification {
+  const guides: VerifiedMovementGuide[] = []
+  const spacingGuides: SpacingGuide[] = []
+  const blockedAxes: MovementSceneAxis[] = []
+  const x = resolveVerifiedAxisHold({
+    baseline,
+    bounds,
+    guides,
+    spacingGuides,
+    blockedAxes,
+    constraint: plan.constraints.x,
+    plan,
+    verified: xVerified
+  })
+  const y = resolveVerifiedAxisHold({
+    baseline,
+    bounds,
+    guides,
+    spacingGuides,
+    blockedAxes,
+    constraint: plan.constraints.y,
+    plan,
+    verified: yVerified
+  })
+
+  return Object.freeze({
+    guides: Object.freeze(guides),
+    spacingGuides: Object.freeze(spacingGuides),
+    blockedAxes: Object.freeze(blockedAxes),
+    holdState: Object.freeze({ x, y })
+  })
+}
+
+/** Сохраняет подтверждённый hold и guide либо отмечает заблокированную ось. */
+function resolveVerifiedAxisHold({
+  baseline,
+  bounds,
+  guides,
+  spacingGuides,
+  blockedAxes,
+  constraint,
+  plan,
+  verified
+}: {
+  baseline: MovementGestureBaseline
+  bounds: Bounds
+  guides: VerifiedMovementGuide[]
+  spacingGuides: SpacingGuide[]
+  blockedAxes: MovementSceneAxis[]
+  constraint: PlannedMovementConstraint | null
+  plan: MovementSnapPlan
+  verified: boolean
+}): MovementAxisHold {
+  if (!constraint) return FREE_MOVEMENT_AXIS_HOLD
+  if (!verified) {
+    blockedAxes.push(constraint.axis)
+    return FREE_MOVEMENT_AXIS_HOLD
+  }
+  if (constraint.kind === 'spacing') {
+    appendVerifiedSpacingGuides({
+      baseline,
+      bounds,
+      guides: spacingGuides,
+      constraint,
+      plan
+    })
+
+    return Object.freeze({
+      kind: 'spacing',
+      candidateId: constraint.candidateId,
+      context: constraint.context
+    })
+  }
+
+  guides.push(Object.freeze({
+    axis: constraint.axis,
+    activeAnchor: constraint.activeAnchor,
+    position: constraint.candidate.position,
+    candidateId: constraint.candidate.id,
+    category: constraint.candidate.category,
+    snapshotIndex: constraint.candidate.snapshotIndex
+  }))
+
+  return Object.freeze({
+    kind: 'line',
+    candidate: constraint.candidate,
+    activeAnchor: constraint.activeAnchor
+  })
+}
+
+/** Переносит сохранённые spacing guide к фактической поперечной позиции target. */
+function appendVerifiedSpacingGuides({
+  baseline,
+  bounds,
+  guides,
+  constraint,
+  plan
+}: {
+  baseline: MovementGestureBaseline
+  bounds: Bounds
+  guides: SpacingGuide[]
+  constraint: PlannedMovementSpacingConstraint
+  plan: MovementSnapPlan
+}): void {
+  const crossAxisDelta = constraint.axis === 'x'
+    ? bounds.centerY - plan.predictedBounds.centerY
+    : bounds.centerX - plan.predictedBounds.centerX
+  const selections = resolveApplicableSpacingSelections({
+    constraint,
+    baseline,
+    bounds
+  })
+  const seenGuideKeys = new Set(guides.map((guide) => {
+    return createSpacingGuideGeometryKey({ guide })
+  }))
+
+  for (const { guide } of selections) {
+    const adjustedGuide = Object.freeze({
+      ...guide,
+      axis: guide.axis + crossAxisDelta
+    })
+    const guideKey = createSpacingGuideGeometryKey({ guide: adjustedGuide })
+    if (seenGuideKeys.has(guideKey)) continue
+
+    seenGuideKeys.add(guideKey)
+    guides.push(adjustedGuide)
+  }
+}
+
+/** Переводит точные границы на рассчитанную дельту без округления. */
+function translateBounds({
+  bounds,
+  deltaX,
+  deltaY
+}: {
+  bounds: Bounds
+  deltaX: number
+  deltaY: number
+}): Bounds {
+  return Object.freeze({
+    left: bounds.left + deltaX,
+    right: bounds.right + deltaX,
+    top: bounds.top + deltaY,
+    bottom: bounds.bottom + deltaY,
+    centerX: bounds.centerX + deltaX,
+    centerY: bounds.centerY + deltaY
+  })
+}
+
+/** Проверяет и копирует raw intent до любых изменений target. */
+function createRawIntentSnapshot({
+  intent
+}: {
+  intent: MovementRawIntent
+}): MovementRawIntent {
+  return Object.freeze({
+    bounds: createExactBoundsSnapshot({ bounds: intent.bounds }),
+    position: createPositionSnapshot({ position: intent.position }),
+    axes: Object.freeze({
+      x: intent.axes.x,
+      y: intent.axes.y
+    }),
+    modifiers: Object.freeze({
+      ctrlKey: intent.modifiers.ctrlKey
+    })
+  })
+}
+
+/** Проверяет, что Fabric movement сохранил начальную геометрию и дал чистую translation. */
+function assertRawIntentMatchesBaseline({
+  baseline,
+  intent
+}: {
+  baseline: MovementGestureBaseline
+  intent: MovementRawIntent
+}): void {
+  const expectedBounds = translateBounds({
+    bounds: baseline.bounds,
+    deltaX: intent.position.left - baseline.position.left,
+    deltaY: intent.position.top - baseline.position.top
+  })
+  const edges: readonly (keyof Bounds)[] = [
+    'left',
+    'centerX',
+    'right',
+    'top',
+    'centerY',
+    'bottom'
+  ]
+  const matchesBaseline = edges.every((edge) => {
+    return areNumbersNear(expectedBounds[edge], intent.bounds[edge])
+  })
+  if (!matchesBaseline) {
+    throw new Error('Movement raw intent must be a translation of the gesture baseline')
+  }
+}
+
+/** Проверяет и копирует точные границы movement-объекта. */
+function createExactBoundsSnapshot({ bounds }: { bounds: Bounds }): Bounds {
+  const { left, right, top, bottom, centerX, centerY } = bounds
+  const values = [left, right, top, bottom, centerX, centerY]
+  if (!values.every(Number.isFinite) || right < left || bottom < top) {
+    throw new Error('Movement snapping bounds must contain finite ordered values')
+  }
+
+  const expectedCenterX = left + ((right - left) / 2)
+  const expectedCenterY = top + ((bottom - top) / 2)
+  if (Math.abs(centerX - expectedCenterX) > EXACT_BOUNDS_CENTER_EPSILON
+    || Math.abs(centerY - expectedCenterY) > EXACT_BOUNDS_CENTER_EPSILON) {
+    throw new Error('Movement snapping bounds centers must be derived from its edges')
+  }
+
+  return Object.freeze({ left, right, top, bottom, centerX, centerY })
+}
+
+/** Проверяет и копирует положение Fabric target. */
+function createPositionSnapshot({
+  position
+}: {
+  position: MovementTargetPosition
+}): MovementTargetPosition {
+  if (!Number.isFinite(position.left) || !Number.isFinite(position.top)) {
+    throw new Error('Movement snapping target position must contain finite coordinates')
+  }
+
+  return Object.freeze({
+    left: position.left,
+    top: position.top
+  })
+}
+
+/** Возвращает пороги в координатах сцены с учётом zoom. */
+function createMovementSnapThresholds({
+  zoom
+}: {
+  zoom: number
+}): MovementSnapThresholds {
+  return Object.freeze({
+    acquire: SNAP_THRESHOLD / zoom,
+    release: SNAP_THRESHOLD / zoom,
+    spacingRelease: (SNAP_THRESHOLD + SPACING_SNAP_HOLD_MARGIN) / zoom,
+    verification: MOVEMENT_SNAP_VERIFICATION_EPSILON
+  })
+}
+
+/** Проверяет что переданный hold-state принадлежит текущему baseline. */
+function assertMovementHoldState({
+  baseline,
+  holdState
+}: {
+  baseline: MovementGestureBaseline
+  holdState: MovementHoldState
+}): void {
+  assertAxisHold({ axis: 'x', baseline, hold: holdState.x })
+  assertAxisHold({ axis: 'y', baseline, hold: holdState.y })
+}
+
+/** Проверяет candidate и active anchor одной удерживаемой оси. */
+function assertAxisHold({
+  axis,
+  baseline,
+  hold
+}: {
+  axis: MovementSceneAxis
+  baseline: MovementGestureBaseline
+  hold: MovementAxisHold
+}): void {
+  if (hold.kind === 'free') return
+  if (hold.kind === 'spacing') {
+    if (!hold.candidateId.trim()
+      || !Number.isFinite(hold.context.distance)
+      || hold.context.distance < 0) {
+      throw new Error(`Movement hold state contains an invalid ${axis} spacing constraint`)
+    }
+
+    return
+  }
+  if (hold.candidate.axis !== axis || resolveAnchorAxis({ anchor: hold.activeAnchor }) !== axis) {
+    throw new Error(`Movement hold state contains an invalid ${axis} constraint`)
+  }
+
+  const candidate = baseline.candidates[hold.candidate.snapshotIndex]
+  if (!candidate || candidate.id !== hold.candidate.id || candidate.position !== hold.candidate.position) {
+    throw new Error('Movement hold state candidate does not belong to the active baseline')
+  }
+}
+
+/** Возвращает ось именованной опорной точки bounds. */
+function resolveAnchorAxis({
+  anchor
+}: {
+  anchor: MovementBoundsAnchor
+}): MovementSceneAxis {
+  return anchor === 'left' || anchor === 'centerX' || anchor === 'right' ? 'x' : 'y'
+}
+
+/** Проверяет неизменность ширины и высоты во время translation. */
+function areBoundsDimensionsEqual({
+  first,
+  second,
+  epsilon
+}: {
+  first: Bounds
+  second: Bounds
+  epsilon: number
+}): boolean {
+  const firstWidth = first.right - first.left
+  const firstHeight = first.bottom - first.top
+  const secondWidth = second.right - second.left
+  const secondHeight = second.bottom - second.top
+
+  return Math.abs(firstWidth - secondWidth) <= epsilon
+    && Math.abs(firstHeight - secondHeight) <= epsilon
+}
+
+/** Копирует и замораживает spacing patterns начального снимка. */
+function freezeSpacingPatterns({
+  patterns
+}: {
+  patterns: { vertical: SpacingPattern[]; horizontal: SpacingPattern[] }
+}): MovementGestureBaseline['spacingPatterns'] {
+  return Object.freeze({
+    vertical: Object.freeze(patterns.vertical.map((pattern) => Object.freeze({ ...pattern }))),
+    horizontal: Object.freeze(patterns.horizontal.map((pattern) => Object.freeze({ ...pattern })))
+  })
+}
+
+/** Копирует и замораживает выбранные spacing-варианты вместе с их identity. */
+function freezeSpacingSelections({
+  selections
+}: {
+  selections: readonly ResolvedSpacingSelection[]
+}): readonly ResolvedSpacingSelection[] {
+  return Object.freeze(selections.map((selection) => {
+    const { identity } = selection
+
+    return Object.freeze({
+      guide: Object.freeze({ ...selection.guide }),
+      identity: Object.freeze({
+        kind: identity.kind,
+        side: identity.side,
+        before: identity.before
+          ? createExactBoundsSnapshot({ bounds: identity.before })
+          : null,
+        after: identity.after
+          ? createExactBoundsSnapshot({ bounds: identity.after })
+          : null,
+        pattern: identity.pattern
+          ? Object.freeze({ ...identity.pattern })
+          : null
+      }),
+      isPrimary: selection.isPrimary
+    })
+  }))
+}
+
+/** Копирует один выбранный spacing-контекст. */
+function freezeSpacingContext({
+  context
+}: {
+  context: SpacingSelectionContext | null
+}): SpacingSelectionContext | null {
+  if (!context) return null
+
+  return Object.freeze({
+    side: context.side,
+    kind: context.kind,
+    distance: context.distance
+  })
+}
+
+/** Преобразует подтверждённые movement-guide в формат renderer-а. */
+export function createMovementGuideLines({
+  guides
+}: {
+  guides: readonly VerifiedMovementGuide[]
+}): GuideLine[] {
+  return guides.map(({ axis, position }) => ({
+    type: axis === 'x' ? 'vertical' : 'horizontal',
+    position
+  }))
+}

--- a/src/editor/snapping-manager/movement-snapping-runtime.ts
+++ b/src/editor/snapping-manager/movement-snapping-runtime.ts
@@ -1,0 +1,293 @@
+/* eslint-disable no-use-before-define -- Публичный runtime расположен перед внутренними проверками. */
+import {
+  FREE_MOVEMENT_HOLD_STATE,
+  resolveMovementSnapPlan,
+  verifyMovementSnapPlan,
+  type FinalMovementGeometry,
+  type MovementGestureBaseline,
+  type MovementHoldState,
+  type MovementRawIntent,
+  type MovementSnapPlan,
+  type MovementSnapVerification
+} from './movement-snapping-resolver'
+
+/** Одноразовый идентификатор movement-плана. */
+export type MovementPlanToken = Readonly<{
+  sessionId: number
+  step: number
+}>
+
+/** Новый pointer-step, который можно применить ровно один раз. */
+export type PlannedMovementRuntimeStep = Readonly<{
+  kind: 'planned'
+  token: MovementPlanToken
+  plan: MovementSnapPlan
+}>
+
+/** Повтор уже рассчитанного native pointer-step. */
+export type DuplicateMovementRuntimeStep = Readonly<{
+  kind: 'duplicate'
+  phase: 'pending' | 'verified'
+  token: MovementPlanToken
+  plan: MovementSnapPlan
+  verification: MovementSnapVerification | null
+}>
+
+/** Новый или повторный результат movement runtime. */
+export type MovementRuntimeStep = PlannedMovementRuntimeStep | DuplicateMovementRuntimeStep
+
+/** Результат идемпотентного завершения movement-сессии. */
+export type MovementRuntimeCleanup = Readonly<{
+  didCleanup: boolean
+}>
+
+/** Состояние одного native pointer marker. */
+type MovementRuntimeStepRecord = {
+  token: MovementPlanToken
+  plan: MovementSnapPlan
+  verification: MovementSnapVerification | null
+}
+
+/** Изменяемое состояние одного активного movement-жеста. */
+type ActiveMovementRuntimeSession = {
+  id: number
+  baseline: MovementGestureBaseline
+  holdState: MovementHoldState
+  markerRecords: WeakMap<object, MovementRuntimeStepRecord>
+  pendingStep: MovementRuntimeStepRecord | null
+  nextStep: number
+}
+
+/** Следующий локальный идентификатор movement-сессии. */
+let nextMovementRuntimeSessionId = 1
+
+/** Неизменяемый результат повторной очистки. */
+const EMPTY_MOVEMENT_RUNTIME_CLEANUP: MovementRuntimeCleanup = Object.freeze({
+  didCleanup: false
+})
+
+/**
+ * Связывает native pointer marker с одним movement-планом и обновляет hold после verification.
+ * Runtime не изменяет Fabric-объекты.
+ */
+export class MovementSnappingRuntime {
+  private _session: ActiveMovementRuntimeSession | null = null
+
+  private readonly _issuedTokens = new WeakSet<MovementPlanToken>()
+
+  private readonly _consumedTokens = new WeakSet<MovementPlanToken>()
+
+  /** Начинает новую movement-сессию с неизменяемым baseline. */
+  startSession({
+    baseline
+  }: {
+    baseline: MovementGestureBaseline
+  }): void {
+    if (this._session) {
+      throw new Error('Movement snapping runtime already has an active session')
+    }
+
+    this._session = {
+      id: nextMovementRuntimeSessionId,
+      baseline,
+      holdState: FREE_MOVEMENT_HOLD_STATE,
+      markerRecords: new WeakMap<object, MovementRuntimeStepRecord>(),
+      pendingStep: null,
+      nextStep: 1
+    }
+    nextMovementRuntimeSessionId += 1
+  }
+
+  /** Возвращает сохранённый результат до повторного чтения изменённого target. */
+  getDuplicateStep({
+    marker
+  }: {
+    marker: object
+  }): DuplicateMovementRuntimeStep | null {
+    const session = this._getActiveSession()
+    const record = session.markerRecords.get(marker)
+    if (!record) return null
+
+    return createDuplicateMovementStep({ record })
+  }
+
+  /** Выдаёт не более одного плана для одного native pointer marker. */
+  resolveMovementPlan({
+    marker,
+    intent
+  }: {
+    marker: object
+    intent: MovementRawIntent
+  }): MovementRuntimeStep {
+    const session = this._getActiveSession()
+    const duplicate = session.markerRecords.get(marker)
+    if (duplicate) {
+      assertSameMovementIntent({ first: duplicate.plan.rawIntent, second: intent })
+      return createDuplicateMovementStep({ record: duplicate })
+    }
+    if (session.pendingStep) {
+      throw new Error('Previous movement plan token must be verified before the next pointer marker')
+    }
+
+    const plan = resolveMovementSnapPlan({
+      baseline: session.baseline,
+      intent,
+      holdState: session.holdState
+    })
+    const token = this._createPlanToken({ session })
+    const record = {
+      token,
+      plan,
+      verification: null
+    }
+    session.markerRecords.set(marker, record)
+    session.pendingStep = record
+
+    return Object.freeze({
+      kind: 'planned',
+      token,
+      plan
+    })
+  }
+
+  /** Проверяет применённый план и обновляет transient hold-state. */
+  verifyMovementPlan({
+    token,
+    finalGeometry
+  }: {
+    token: MovementPlanToken
+    finalGeometry: FinalMovementGeometry
+  }): MovementSnapVerification {
+    const session = this._getActiveSession()
+    this._assertUsableToken({ session, token })
+
+    const { pendingStep } = session
+    if (!pendingStep) {
+      throw new Error('Movement snapping runtime has no pointer step to verify')
+    }
+
+    const verification = verifyMovementSnapPlan({
+      baseline: session.baseline,
+      plan: pendingStep.plan,
+      finalGeometry
+    })
+    this._consumedTokens.add(token)
+    pendingStep.verification = verification
+    session.pendingStep = null
+    session.holdState = verification.holdState
+
+    return verification
+  }
+
+  /** Завершает active session ровно один раз. */
+  finishSession(): MovementRuntimeCleanup {
+    const session = this._session
+    if (!session) return EMPTY_MOVEMENT_RUNTIME_CLEANUP
+
+    const pendingToken = session.pendingStep?.token
+    if (pendingToken) this._consumedTokens.add(pendingToken)
+
+    this._session = null
+
+    return Object.freeze({
+      didCleanup: true
+    })
+  }
+
+  /** Возвращает активную сессию или явно сообщает о нарушении lifecycle. */
+  private _getActiveSession(): ActiveMovementRuntimeSession {
+    if (!this._session) {
+      throw new Error('Movement snapping runtime has no active session')
+    }
+
+    return this._session
+  }
+
+  /** Создаёт одноразовый token текущего pointer-step. */
+  private _createPlanToken({
+    session
+  }: {
+    session: ActiveMovementRuntimeSession
+  }): MovementPlanToken {
+    const token = Object.freeze({
+      sessionId: session.id,
+      step: session.nextStep
+    })
+    session.nextStep += 1
+    this._issuedTokens.add(token)
+
+    return token
+  }
+
+  /** Отклоняет чужой, устаревший или уже использованный token. */
+  private _assertUsableToken({
+    session,
+    token
+  }: {
+    session: ActiveMovementRuntimeSession
+    token: MovementPlanToken
+  }): void {
+    if (!this._issuedTokens.has(token)) {
+      throw new Error('Foreign movement plan token')
+    }
+    if (this._consumedTokens.has(token)) {
+      throw new Error('Movement plan token has already been used')
+    }
+    if (!session.pendingStep || session.pendingStep.token !== token) {
+      throw new Error('Movement plan token does not belong to the current pointer step')
+    }
+  }
+}
+
+/** Возвращает immutable duplicate-step из сохранённого record. */
+function createDuplicateMovementStep({
+  record
+}: {
+  record: MovementRuntimeStepRecord
+}): DuplicateMovementRuntimeStep {
+  return Object.freeze({
+    kind: 'duplicate',
+    phase: record.verification ? 'verified' : 'pending',
+    token: record.token,
+    plan: record.plan,
+    verification: record.verification
+  })
+}
+
+/** Проверяет что один marker не был переиспользован с другим raw intent. */
+function assertSameMovementIntent({
+  first,
+  second
+}: {
+  first: MovementRawIntent
+  second: MovementRawIntent
+}): void {
+  const sameBounds = areMovementBoundsEqual({
+    first: first.bounds,
+    second: second.bounds
+  })
+  const samePosition = first.position.left === second.position.left
+    && first.position.top === second.position.top
+  const sameAxes = first.axes.x === second.axes.x && first.axes.y === second.axes.y
+  const sameModifiers = first.modifiers.ctrlKey === second.modifiers.ctrlKey
+
+  if (!sameBounds || !samePosition || !sameAxes || !sameModifiers) {
+    throw new Error('Native movement pointer marker was reused with a different raw intent')
+  }
+}
+
+/** Сравнивает exact bounds двух raw intent без скрытого допуска. */
+function areMovementBoundsEqual({
+  first,
+  second
+}: {
+  first: MovementRawIntent['bounds']
+  second: MovementRawIntent['bounds']
+}): boolean {
+  return first.left === second.left
+    && first.right === second.right
+    && first.top === second.top
+    && first.bottom === second.bottom
+    && first.centerX === second.centerX
+    && first.centerY === second.centerY
+}

--- a/src/editor/snapping-manager/renderer.ts
+++ b/src/editor/snapping-manager/renderer.ts
@@ -1,6 +1,122 @@
+/* eslint-disable no-use-before-define -- Публичные renderer-функции расположены перед внутренними примитивами. */
+import type { Canvas } from 'fabric'
+
 import { GUIDE_COLOR, GUIDE_WIDTH } from './constants'
-import type { SpacingGuide } from './types'
+import type {
+  GuideBounds,
+  GuideLine,
+  SpacingGuide
+} from './types'
 import { drawGuideLabel } from '../utils/render-utils'
+import { resolveDisplayDistance } from '../utils/distance'
+
+/**
+ * Рисует подтверждённые линейные и spacing-направляющие в верхнем контексте canvas.
+ */
+export function renderSnappingGuides({
+  canvas,
+  guideBounds,
+  guides,
+  spacingGuides
+}: {
+  canvas: Canvas
+  guideBounds: GuideBounds | null
+  guides: readonly GuideLine[]
+  spacingGuides: readonly SpacingGuide[]
+}): void {
+  if (!guides.length && !spacingGuides.length) return
+
+  const context = canvas.getSelectionContext()
+  if (!context) return
+
+  const bounds = guideBounds ?? calculateSnappingViewportBounds({ canvas })
+  const { viewportTransform } = canvas
+  const zoom = canvas.getZoom() || 1
+
+  context.save()
+  try {
+    if (Array.isArray(viewportTransform)) {
+      context.transform(...viewportTransform)
+    }
+    context.lineWidth = GUIDE_WIDTH / zoom
+    context.strokeStyle = GUIDE_COLOR
+    context.setLineDash([4, 4])
+    drawLineGuides({ context, bounds, guides })
+    drawSpacingGuides({ context, zoom, guides: spacingGuides })
+  } finally {
+    context.restore()
+  }
+}
+
+/** Возвращает scene-границы текущего viewport для рисования guide. */
+export function calculateSnappingViewportBounds({
+  canvas
+}: {
+  canvas: Canvas
+}): GuideBounds {
+  const { viewportTransform } = canvas
+  const width = canvas.getWidth()
+  const height = canvas.getHeight()
+  const [
+    scaleX = 1,
+    ,,
+    scaleY = 1,
+    translateX = 0,
+    translateY = 0
+  ] = viewportTransform ?? []
+
+  return {
+    left: (0 - translateX) / scaleX,
+    top: (0 - translateY) / scaleY,
+    right: (width - translateX) / scaleX,
+    bottom: (height - translateY) / scaleY
+  }
+}
+
+/** Рисует обычные guide в заданных scene-границах. */
+function drawLineGuides({
+  context,
+  bounds,
+  guides
+}: {
+  context: CanvasRenderingContext2D
+  bounds: GuideBounds
+  guides: readonly GuideLine[]
+}): void {
+  const { left, right, top, bottom } = bounds
+
+  for (const guide of guides) {
+    context.beginPath()
+    if (guide.type === 'vertical') {
+      context.moveTo(guide.position, top)
+      context.lineTo(guide.position, bottom)
+    } else {
+      context.moveTo(left, guide.position)
+      context.lineTo(right, guide.position)
+    }
+    context.stroke()
+  }
+}
+
+/** Рисует spacing-guide вместе с единообразно округлёнными подписями. */
+function drawSpacingGuides({
+  context,
+  zoom,
+  guides
+}: {
+  context: CanvasRenderingContext2D
+  zoom: number
+  guides: readonly SpacingGuide[]
+}): void {
+  for (const guide of guides) {
+    drawSpacingGuide({
+      context,
+      guide,
+      zoom,
+      distanceLabel: resolveDisplayDistance({ distance: guide.distance }).toString()
+    })
+  }
+}
 
 /**
  * Отрисовывает линии и бейджи для равноудалённых интервалов.

--- a/src/editor/snapping-manager/spacing.ts
+++ b/src/editor/snapping-manager/spacing.ts
@@ -29,6 +29,22 @@ export type SpacingContextByAxis = {
   horizontal: SpacingSelectionContext | null
 }
 
+/** Стабильные соседи и reference pattern одного выбранного spacing-варианта. */
+export type SpacingSelectionIdentity = Readonly<{
+  kind: SpacingSelectionContext['kind']
+  side: SpacingSelectionContext['side']
+  before: Bounds | null
+  after: Bounds | null
+  pattern: SpacingPattern | null
+}>
+
+/** Выбранный spacing-вариант и его роль в опубликованном наборе guide. */
+export type ResolvedSpacingSelection = Readonly<{
+  guide: SpacingGuide
+  identity: SpacingSelectionIdentity
+  isPrimary: boolean
+}>
+
 /** Положение активного интервала относительно выбранного образца расстояния. */
 type SpacingOptionSide = SpacingSelectionContext['side']
 
@@ -43,6 +59,7 @@ type SpacingOption = {
   side: SpacingOptionSide
   kind: SpacingOptionKind
   contextDistance: number
+  identity: SpacingSelectionIdentity
 }
 
 /**
@@ -284,6 +301,7 @@ type SpacingCalculationResult = {
   delta: number
   guides: SpacingGuide[]
   context: SpacingSelectionContext | null
+  selections: ResolvedSpacingSelection[]
 }
 
 /** Кандидат для прилипания к существующему интервалу. */
@@ -308,6 +326,7 @@ type ResolveReferenceSpacingOptionParams = {
 type ReferenceSpacingOptionContext = {
   active: AxisSpacingGeometry
   neighbor: AxisSpacingGeometry
+  neighborBounds: Bounds
   pattern: SpacingPattern
   candidate: ReferenceSpacingCandidate
   axis: SpacingAxis
@@ -623,6 +642,27 @@ const resolvePrimarySpacingOption = ({
 }
 
 /**
+ * Создаёт стабильный ключ полной геометрии spacing guide.
+ */
+export const createSpacingGuideGeometryKey = ({
+  guide
+}: {
+  guide: SpacingGuide
+}): string => {
+  const {
+    type,
+    axis,
+    refStart,
+    refEnd,
+    activeStart,
+    activeEnd,
+    distance
+  } = guide
+
+  return `${type}:${axis}:${refStart}:${refEnd}:${activeStart}:${activeEnd}:${distance}`
+}
+
+/**
  * Добавляет направляющую без дублей по геометрии и расстоянию.
  */
 const pushUniqueSpacingGuide = ({
@@ -634,16 +674,7 @@ const pushUniqueSpacingGuide = ({
   seenGuideKeys: Set<string>
   guide: SpacingGuide
 }): void => {
-  const {
-    type,
-    axis,
-    refStart,
-    refEnd,
-    activeStart,
-    activeEnd,
-    distance
-  } = guide
-  const key = `${type}:${axis}:${refStart}:${refEnd}:${activeStart}:${activeEnd}:${distance}`
+  const key = createSpacingGuideGeometryKey({ guide })
   if (seenGuideKeys.has(key)) return
 
   seenGuideKeys.add(key)
@@ -713,6 +744,21 @@ const createSpacingGuides = ({
   return guides
 }
 
+/** Связывает каждый отображаемый вариант с identity и отмечает primary correction. */
+const createResolvedSpacingSelections = ({
+  selectedOptions,
+  primaryOption
+}: {
+  selectedOptions: SpacingOption[]
+  primaryOption: SpacingOption
+}): ResolvedSpacingSelection[] => {
+  return selectedOptions.map((option) => ({
+    guide: option.guide,
+    identity: option.identity,
+    isPrimary: option === primaryOption
+  }))
+}
+
 /**
  * Формирует направляющие равноудалённости, не смешивая разные расстояния.
  */
@@ -724,12 +770,13 @@ const resolveSpacingResult = ({
   options: SpacingOption[]
   previousContext?: SpacingSelectionContext | null
   switchDistance?: number
-}): { delta: number; guides: SpacingGuide[]; context: SpacingSelectionContext | null } => {
+}): SpacingCalculationResult => {
   if (!options.length) {
     return {
       delta: 0,
       guides: [],
-      context: null
+      context: null,
+      selections: []
     }
   }
 
@@ -761,6 +808,10 @@ const resolveSpacingResult = ({
     guides: createSpacingGuides({ selectedOptions }),
     context: resolveSpacingContextFromOption({
       option: primaryOption
+    }),
+    selections: createResolvedSpacingSelections({
+      selectedOptions,
+      primaryOption
     })
   }
 }
@@ -794,6 +845,27 @@ const resolveAxisSpacingGeometry = ({
   }
 }
 
+/** Копирует стабильную identity соседей и reference pattern выбранного варианта. */
+const createSpacingSelectionIdentity = ({
+  kind,
+  side,
+  before = null,
+  after = null,
+  pattern = null
+}: {
+  kind: SpacingOptionKind
+  side: SpacingOptionSide
+  before?: Bounds | null
+  after?: Bounds | null
+  pattern?: SpacingPattern | null
+}): SpacingSelectionIdentity => ({
+  kind,
+  side,
+  before: before ? { ...before } : null,
+  after: after ? { ...after } : null,
+  pattern: pattern ? { ...pattern } : null
+})
+
 /** Проверяет перекрытие объектов на перпендикулярной оси. */
 const isBoundsAligned = ({
   activeGeometry,
@@ -822,7 +894,7 @@ const resolveSpacingNeighbors = ({
   axis
 }: {
   activeBounds: Bounds
-  candidates: Bounds[]
+  candidates: readonly Bounds[]
   axis: SpacingAxis
 }): SpacingNeighbors | null => {
   const activeGeometry = resolveAxisSpacingGeometry({ bounds: activeBounds, axis })
@@ -848,6 +920,79 @@ const resolveSpacingNeighbors = ({
     before: beforeIndex === null ? null : items[beforeIndex].bounds,
     after: afterIndex === null ? null : items[afterIndex].bounds
   }
+}
+
+/** Сравнивает точные bounds выбранного и текущего nearest neighbor. */
+const areSpacingBoundsEqual = ({
+  first,
+  second
+}: {
+  first: Bounds | null
+  second: Bounds | null
+}): boolean => {
+  if (!first || !second) return first === second
+
+  return first.left === second.left
+    && first.right === second.right
+    && first.top === second.top
+    && first.bottom === second.bottom
+    && first.centerX === second.centerX
+    && first.centerY === second.centerY
+}
+
+/**
+ * Проверяет, что сохранённый spacing-вариант всё ещё использует тех же ближайших соседей.
+ */
+export const isSpacingSelectionApplicable = ({
+  selection,
+  activeBounds,
+  candidates,
+  tolerance
+}: {
+  selection: ResolvedSpacingSelection
+  activeBounds: Bounds
+  candidates: readonly Bounds[]
+  tolerance: number
+}): boolean => {
+  const { identity, guide } = selection
+  const neighbors = resolveSpacingNeighbors({
+    activeBounds,
+    candidates,
+    axis: guide.type
+  })
+  if (!neighbors) return false
+
+  if (identity.kind === 'center') {
+    return identity.side === 'center'
+      && areSpacingBoundsEqual({ first: neighbors.before, second: identity.before })
+      && areSpacingBoundsEqual({ first: neighbors.after, second: identity.after })
+  }
+
+  const expectedNeighbor = identity.side === 'before' ? identity.before : identity.after
+  const currentNeighbor = identity.side === 'before' ? neighbors.before : neighbors.after
+  if (!areSpacingBoundsEqual({ first: currentNeighbor, second: expectedNeighbor })) return false
+
+  const { pattern } = identity
+  if (!pattern || pattern.type !== guide.type || identity.side === 'center') return false
+
+  const active = resolveAxisSpacingGeometry({
+    bounds: activeBounds,
+    axis: guide.type
+  })
+  const side = resolveReferencePatternSide({
+    patternStart: pattern.start,
+    patternEnd: pattern.end,
+    activeStart: active.start,
+    activeEnd: active.end
+  })
+  if (side !== identity.side) return false
+
+  return isPatternAxisAlignedWithActiveRange({
+    patternAxis: pattern.axis,
+    activeRangeStart: active.crossStart,
+    activeRangeEnd: active.crossEnd,
+    tolerance
+  })
 }
 
 /** Подбирает позицию между соседями на сетке с шагом 0,5 px. */
@@ -950,7 +1095,13 @@ const resolveCenteredSpacingOption = ({
     diff: centered.diff,
     side: 'center',
     kind: 'center',
-    contextDistance: 0
+    contextDistance: 0,
+    identity: createSpacingSelectionIdentity({
+      kind: 'center',
+      side: 'center',
+      before,
+      after
+    })
   }
 }
 
@@ -1006,6 +1157,7 @@ const resolveReferenceSpacingCandidate = ({
 const createReferenceSpacingOption = ({
   active,
   neighbor,
+  neighborBounds,
   pattern,
   candidate,
   axis,
@@ -1031,7 +1183,14 @@ const createReferenceSpacingOption = ({
     diff: candidate.diff,
     side,
     kind: 'reference',
-    contextDistance
+    contextDistance,
+    identity: createSpacingSelectionIdentity({
+      kind: 'reference',
+      side,
+      before: side === 'before' ? neighborBounds : null,
+      after: side === 'after' ? neighborBounds : null,
+      pattern
+    })
   }
 }
 
@@ -1083,6 +1242,7 @@ const resolveReferenceSpacingOption = ({
   return createReferenceSpacingOption({
     active,
     neighbor,
+    neighborBounds,
     pattern,
     candidate,
     axis,
@@ -1133,7 +1293,14 @@ const calculateAxisSpacing = ({
   axis
 }: CalculateAxisSpacingParams): SpacingCalculationResult => {
   const neighbors = resolveSpacingNeighbors({ activeBounds, candidates, axis })
-  if (!neighbors) return { delta: 0, guides: [], context: null }
+  if (!neighbors) {
+    return {
+      delta: 0,
+      guides: [],
+      context: null,
+      selections: []
+    }
+  }
 
   const options = resolveAxisSpacingOptions({
     activeBounds,


### PR DESCRIPTION
- Продолжаем перенос snapping на общую логику и подключаем к ней перемещение одиночных объектов изображений.
- Расчёт прилипания от состояния на начало жеста, однократное применение результата и проверка фактической геометрии перед отображением гайдов.
- Стабилизация удержания и отпускания направляющих отдельно по каждой оси, работа Ctrl, пиксельное округление и повторная обработка одного pointer-события.
-  Равноудалённость: теперь учитываются конкретные соседние объекты, совместная коррекция по двум осям и актуальность интервалов после применения результата.
- Исправлено отображение лишних и устаревших гайдов, а также переключение с равноудалённости на обычную направляющую.
- Приведена в порядок очистка snapping-сессии при завершении или прерывании жеста, смене выделения, удалении объекта и потере фокуса.
- Вынесена отрисовка направляющих из SnappingManager в отдельный renderer.
- Добавлены unit- и e2e-покрытие нового movement-пути

Breaking changes нет: публичный API, параметры инициализации, события и формат сериализации не менялись. Изменилось только внутреннее устройство SnappingManager и поведение прилипания одиночных изображений. Остальные типы объектов и скейлинг Image пока продолжают работать через старую логику.