### PR TITLE
SnappingManager. Перемещение отдельного текста переведено на унифицированную логику прилипания

### DIFF
--- a/e2e/fixtures/text-moving-spacing.fixture.ts
+++ b/e2e/fixtures/text-moving-spacing.fixture.ts
@@ -1,0 +1,124 @@
+import { expect } from '@playwright/test'
+import { test as editorTest } from './editor.fixture'
+import { ShapeModel } from '../models/shape/shape.model'
+import { SnappingModel } from '../models/snapping.model'
+import type { SnappingObjectSnapshot } from '../types'
+
+/** Геометрия отдельного текста и опорных объектов для равноудалённого прилипания. */
+export type TextMovingSpacingSetup = Readonly<{
+  activeTextId: string
+  active: SnappingObjectSnapshot
+  bottom: SnappingObjectSnapshot
+  expectedLeft: number
+  expectedTop: number
+  left: SnappingObjectSnapshot
+  right: SnappingObjectSnapshot
+  top: SnappingObjectSnapshot
+}>
+
+/** Дополнительный fixture для горизонтальной и вертикальной равноудалённости текста. */
+interface TextMovingSpacingFixtures {
+  textMovingSpacingSetup: TextMovingSpacingSetup
+}
+
+/** Исходные границы одного опорного шейпа. */
+type TextSpacingReferenceBounds = Readonly<{
+  id: string
+  height: number
+  left: number
+  top: number
+  width: number
+}>
+
+/** Добавляет опорные шейпы и возвращает их точные границы. */
+async function addTextSpacingReferences({
+  bounds,
+  shapes,
+  snapping
+}: {
+  bounds: readonly TextSpacingReferenceBounds[]
+  shapes: ShapeModel
+  snapping: SnappingModel
+}): Promise<readonly SnappingObjectSnapshot[]> {
+  for (const options of bounds) {
+    const shape = await shapes.addAtBounds({
+      presetKey: 'square',
+      options: {
+        ...options,
+        text: ''
+      }
+    })
+
+    shapes.checkCreation({ shape, presetKey: 'square' })
+  }
+
+  const references = await Promise.all(bounds.map(({ id }) => {
+    return snapping.getObjectSnapshot({ id })
+  }))
+
+  expect(references).toHaveLength(bounds.length)
+  expect(references.every(({ boundsWidth, boundsHeight }) => {
+    return boundsWidth > 0 && boundsHeight > 0
+  })).toBe(true)
+
+  return references
+}
+
+/** Editor fixture с отдельным текстом между горизонтальными и вертикальными опорами. */
+export const test = editorTest.extend<TextMovingSpacingFixtures>({
+  textMovingSpacingSetup: async({
+    editorModel,
+    shapes,
+    snapping,
+    text
+  }, use) => {
+    const montage = await editorModel.getMontageAreaBounds()
+    const activeTextId = 'active-text'
+    const activeText = await text.add({
+      id: activeTextId,
+      text: 'Текст',
+      left: montage.left + 240,
+      top: montage.top + 220,
+      originX: 'left',
+      originY: 'top',
+      width: 90,
+      fontSize: 24,
+      autoExpand: false
+    })
+
+    text.checkCreation({ textObject: activeText })
+
+    const references = await addTextSpacingReferences({
+      bounds: [
+        { id: 'left-shape', left: montage.left + 60, top: montage.top + 300, width: 60, height: 100 },
+        { id: 'right-shape', left: montage.left + 240, top: montage.top + 300, width: 60, height: 100 },
+        { id: 'top-shape', left: montage.left + 360, top: montage.top + 60, width: 140, height: 60 },
+        { id: 'bottom-shape', left: montage.left + 360, top: montage.top + 320, width: 140, height: 60 }
+      ],
+      shapes,
+      snapping
+    })
+    const [left, right, top, bottom] = references
+    const active = await snapping.getObjectSnapshot({ id: activeTextId })
+    const expectedLeft = left.boundsRight
+      + ((right.boundsLeft - left.boundsRight - active.boundsWidth) / 2)
+    const expectedTop = top.boundsBottom
+      + ((bottom.boundsTop - top.boundsBottom - active.boundsHeight) / 2)
+
+    expect(expectedLeft).toBeGreaterThan(left.boundsRight)
+    expect(expectedTop).toBeGreaterThan(top.boundsBottom)
+
+    await use({
+      activeTextId,
+      active,
+      bottom,
+      expectedLeft,
+      expectedTop,
+      left,
+      right,
+      top
+    })
+  }
+})
+
+export { expect }

--- a/e2e/tests/snapping-manager/text/moving-geometry.spec.ts
+++ b/e2e/tests/snapping-manager/text/moving-geometry.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '../../../fixtures/editor.fixture'
+import type { SnappingObjectSnapshot } from '../../../types'
+
+/** Повёрнутый отдельный текст и опорный объект для проверки геометрии перемещения. */
+type TextMovementGeometrySetup = {
+  activeTextId: string
+  reference: SnappingObjectSnapshot
+}
+
+let setup: TextMovementGeometrySetup
+
+test.beforeEach(async({
+  editorModel,
+  shapes,
+  snapping,
+  text
+}) => {
+  const montageBounds = await editorModel.getMontageAreaBounds()
+  const activeText = await text.add({
+    id: 'active-text',
+    text: 'Повёрнутый текст',
+    left: montageBounds.left + 280,
+    top: montageBounds.top + 180,
+    originX: 'left',
+    originY: 'top',
+    width: 150,
+    fontSize: 28,
+    autoExpand: false,
+    angle: 30,
+    paddingTop: 6,
+    paddingRight: 10,
+    paddingBottom: 8,
+    paddingLeft: 12,
+    radiusTopLeft: 4,
+    radiusTopRight: 6,
+    radiusBottomRight: 8,
+    radiusBottomLeft: 10
+  })
+  const referenceShape = await shapes.addAtBounds({
+    presetKey: 'square',
+    options: {
+      id: 'reference-shape',
+      left: montageBounds.left + 80,
+      top: montageBounds.top + 100,
+      width: 40,
+      height: 60,
+      text: ''
+    }
+  })
+
+  text.checkCreation({ textObject: activeText })
+  shapes.checkCreation({ shape: referenceShape, presetKey: 'square' })
+
+  setup = {
+    activeTextId: 'active-text',
+    reference: await snapping.getObjectSnapshot({ id: 'reference-shape' })
+  }
+})
+
+test('при перемещении повёрнутого текста его размеры и оформление не меняются', async({
+  snapping,
+  text
+}) => {
+  const initial = text.checkCreation({
+    textObject: await text.getObject({ id: setup.activeTextId })
+  })
+
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const held = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: snapped.boundsLeft + 3,
+    top: snapped.boundsTop + 3
+  })
+  const live = text.checkCreation({
+    textObject: await text.getObject({ id: setup.activeTextId })
+  })
+  const guides = await snapping.getGuideState()
+
+  expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 5)
+  expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 5)
+  expect(live).toEqual({
+    ...initial,
+    left: live.left,
+    top: live.top,
+    selectionStart: live.selectionStart,
+    selectionEnd: live.selectionEnd
+  })
+  expect(guides.guides).toEqual(expect.arrayContaining([
+    { type: 'vertical', position: setup.reference.boundsLeft },
+    { type: 'horizontal', position: setup.reference.boundsTop }
+  ]))
+  expect(guides.guides).toHaveLength(2)
+  expect(guides.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  const committed = text.checkCreation({
+    textObject: await text.getObject({ id: setup.activeTextId })
+  })
+  const committedBounds = await snapping.getObjectSnapshot({ id: setup.activeTextId })
+
+  expect(committed).toEqual(live)
+  expect(committedBounds.boundsLeft).toBeCloseTo(held.boundsLeft, 5)
+  expect(committedBounds.boundsTop).toBeCloseTo(held.boundsTop, 5)
+  expect(committedBounds.boundsWidth).toBeCloseTo(held.boundsWidth, 5)
+  expect(committedBounds.boundsHeight).toBeCloseTo(held.boundsHeight, 5)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('после изменения масштаба и положения области просмотра выравнивает отдельный текст по направляющим', async({
+  editorModel,
+  snapping
+}) => {
+  const viewportBefore = await editorModel.getCanvasViewportTransform()
+
+  await editorModel.zoomInUntilViewportCanMove()
+  await editorModel.dragViewportBySpaceMouse({
+    deltaX: -24,
+    deltaY: -18
+  })
+
+  const viewportAfter = await editorModel.getCanvasViewportTransform()
+
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const live = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const guideState = await snapping.getGuideState()
+
+  expect(viewportAfter.zoom).toBeGreaterThan(viewportBefore.zoom)
+  expect(viewportAfter.x).not.toBeCloseTo(viewportBefore.x, 5)
+  expect(viewportAfter.y).not.toBeCloseTo(viewportBefore.y, 5)
+  expect(live.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(live.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+  expect(guideState.guides).toEqual(expect.arrayContaining([
+    { type: 'vertical', position: setup.reference.boundsLeft },
+    { type: 'horizontal', position: setup.reference.boundsTop }
+  ]))
+  expect(guideState.guides).toHaveLength(2)
+  expect(guideState.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})

--- a/e2e/tests/snapping-manager/text/moving-hold.spec.ts
+++ b/e2e/tests/snapping-manager/text/moving-hold.spec.ts
@@ -1,0 +1,249 @@
+import { test, expect } from '../../../fixtures/editor.fixture'
+import { SNAPPING_TOLERANCE } from '../../../fixtures/data/snapping.data'
+import type { SnappingObjectSnapshot } from '../../../types'
+
+/** Отдельный текст и опорный объект для проверки удержания направляющих. */
+type TextMovementSetup = {
+  activeTextId: string
+  reference: SnappingObjectSnapshot
+}
+
+let setup: TextMovementSetup
+
+test.beforeEach(async({
+  editorModel,
+  shapes,
+  snapping,
+  text
+}) => {
+  const montageBounds = await editorModel.getMontageAreaBounds()
+  const activeText = await text.add({
+    id: 'active-text',
+    text: 'Отдельный текст',
+    left: montageBounds.left + 240,
+    top: montageBounds.top + 120,
+    originX: 'left',
+    originY: 'top',
+    width: 90,
+    fontSize: 24,
+    autoExpand: false
+  })
+  const referenceShape = await shapes.addAtBounds({
+    presetKey: 'square',
+    options: {
+      id: 'reference-shape',
+      left: montageBounds.left + 100,
+      top: montageBounds.top + 120,
+      width: 12,
+      height: 40,
+      text: ''
+    }
+  })
+
+  text.checkCreation({ textObject: activeText })
+  shapes.checkCreation({ shape: referenceShape, presetKey: 'square' })
+
+  setup = {
+    activeTextId: 'active-text',
+    reference: await snapping.getObjectSnapshot({ id: 'reference-shape' })
+  }
+})
+
+test('при микродвижениях отдельный текст сохраняет выбранные направляющие', async({
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+
+  expect(snapped.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(snapped.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+
+  let held = snapped
+  for (const offset of [2, 3, 4]) {
+    held = await snapping.dragObjectBoundsTo({
+      id: setup.activeTextId,
+      left: snapped.boundsLeft + offset,
+      top: snapped.boundsTop + offset
+    })
+    const guideState = await snapping.getGuideState()
+
+    expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 1)
+    expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 1)
+    expect(held.boundsWidth).toBeCloseTo(snapped.boundsWidth, 5)
+    expect(held.boundsHeight).toBeCloseTo(snapped.boundsHeight, 5)
+    expect(guideState.guides).toEqual(expect.arrayContaining([
+      {
+        type: 'vertical',
+        position: setup.reference.boundsLeft
+      },
+      {
+        type: 'horizontal',
+        position: setup.reference.boundsTop
+      }
+    ]))
+    expect(guideState.guides).toHaveLength(2)
+    expect(guideState.spacingGuides).toHaveLength(0)
+  }
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.activeTextId })
+
+  expect(committed.boundsLeft).toBeCloseTo(held.boundsLeft, 5)
+  expect(committed.boundsTop).toBeCloseTo(held.boundsTop, 5)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('при выходе по горизонтали отдельный текст отпускает только вертикальную направляющую', async({
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const acquiredGuides = await snapping.getGuideState()
+
+  expect(snapped.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(snapped.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+  expect(acquiredGuides.guides).toEqual(expect.arrayContaining([
+    { type: 'vertical', position: setup.reference.boundsLeft },
+    { type: 'horizontal', position: setup.reference.boundsTop }
+  ]))
+  expect(acquiredGuides.guides).toHaveLength(2)
+
+  const releasedX = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: snapped.boundsLeft + 40,
+    top: snapped.boundsTop + 4
+  })
+  const guideState = await snapping.getGuideState()
+  const verticalGuides = guideState.guides.filter((guide) => guide.type === 'vertical')
+  const horizontalGuides = guideState.guides.filter((guide) => guide.type === 'horizontal')
+
+  expect(Math.abs(releasedX.boundsLeft - snapped.boundsLeft))
+    .toBeGreaterThan(SNAPPING_TOLERANCE.position)
+  expect(releasedX.boundsTop).toBeCloseTo(snapped.boundsTop, 1)
+  expect(verticalGuides).toHaveLength(0)
+  expect(horizontalGuides).toEqual([{
+    type: 'horizontal',
+    position: setup.reference.boundsTop
+  }])
+  expect(guideState.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('при выходе по вертикали отдельный текст отпускает только горизонтальную направляющую', async({
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const acquiredGuides = await snapping.getGuideState()
+
+  expect(snapped.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(snapped.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+  expect(acquiredGuides.guides).toEqual(expect.arrayContaining([
+    { type: 'vertical', position: setup.reference.boundsLeft },
+    { type: 'horizontal', position: setup.reference.boundsTop }
+  ]))
+  expect(acquiredGuides.guides).toHaveLength(2)
+
+  const releasedY = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: snapped.boundsLeft + 4,
+    top: snapped.boundsTop + 50
+  })
+  const guideState = await snapping.getGuideState()
+  const verticalGuides = guideState.guides.filter((guide) => guide.type === 'vertical')
+  const horizontalGuides = guideState.guides.filter((guide) => guide.type === 'horizontal')
+
+  expect(releasedY.boundsLeft).toBeCloseTo(snapped.boundsLeft, 1)
+  expect(Math.abs(releasedY.boundsTop - snapped.boundsTop))
+    .toBeGreaterThan(SNAPPING_TOLERANCE.position)
+  expect(verticalGuides).toEqual([{
+    type: 'vertical',
+    position: setup.reference.boundsLeft
+  }])
+  expect(horizontalGuides).toHaveLength(0)
+  expect(guideState.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('при нажатии Ctrl отдельный текст снимает удержание и после отпускания прилипает заново', async({
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const acquiredGuides = await snapping.getGuideState()
+
+  expect(snapped.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(snapped.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+  expect(acquiredGuides.guides).toEqual(expect.arrayContaining([
+    { type: 'vertical', position: setup.reference.boundsLeft },
+    { type: 'horizontal', position: setup.reference.boundsTop }
+  ]))
+  expect(acquiredGuides.guides).toHaveLength(2)
+
+  const withoutSnap = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: snapped.boundsLeft + 4,
+    top: snapped.boundsTop + 4,
+    ctrlKey: true
+  })
+  const disabledGuides = await snapping.getGuideState()
+
+  expect(Math.abs(withoutSnap.boundsLeft - (snapped.boundsLeft + 4)))
+    .toBeLessThanOrEqual(SNAPPING_TOLERANCE.position)
+  expect(Math.abs(withoutSnap.boundsTop - (snapped.boundsTop + 4)))
+    .toBeLessThanOrEqual(SNAPPING_TOLERANCE.position)
+  expect(disabledGuides.guides).toHaveLength(0)
+  expect(disabledGuides.spacingGuides).toHaveLength(0)
+
+  const reacquired = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.centerX + 1,
+    top: setup.reference.centerY + 1
+  })
+  const enabledGuides = await snapping.getGuideState()
+
+  expect(reacquired.boundsLeft).toBeCloseTo(setup.reference.centerX, 1)
+  expect(reacquired.boundsTop).toBeCloseTo(setup.reference.centerY, 1)
+  expect(reacquired.boundsLeft).not.toBeCloseTo(snapped.boundsLeft, 1)
+  expect(reacquired.boundsTop).not.toBeCloseTo(snapped.boundsTop, 1)
+  expect(enabledGuides.guides).toContainEqual({
+    type: 'vertical',
+    position: setup.reference.centerX
+  })
+  expect(enabledGuides.guides).toContainEqual({
+    type: 'horizontal',
+    position: setup.reference.centerY
+  })
+  expect(enabledGuides.guides).toHaveLength(2)
+  expect(enabledGuides.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})

--- a/e2e/tests/snapping-manager/text/moving-lifecycle.spec.ts
+++ b/e2e/tests/snapping-manager/text/moving-lifecycle.spec.ts
@@ -1,0 +1,282 @@
+import { test, expect } from '../../../fixtures/editor.fixture'
+import { SNAPPING_TOLERANCE } from '../../../fixtures/data/snapping.data'
+import type { SnappingObjectSnapshot } from '../../../types'
+
+/** Исходное состояние отдельного сценария перемещения текста. */
+type TextMovementLifecycleSetup = {
+  activeTextId: string
+  baseline: SnappingObjectSnapshot
+  reference: SnappingObjectSnapshot
+}
+
+let setup: TextMovementLifecycleSetup
+
+test.beforeEach(async({
+  editorModel,
+  history,
+  shapes,
+  snapping,
+  text
+}) => {
+  const montageBounds = await editorModel.getMontageAreaBounds()
+  const referenceShape = await shapes.addAtBounds({
+    presetKey: 'square',
+    options: {
+      id: 'reference-shape',
+      left: montageBounds.left + 80,
+      top: montageBounds.top + 120,
+      width: 12,
+      height: 40,
+      text: ''
+    }
+  })
+  const activeText = await text.add({
+    id: 'active-text',
+    text: 'Отдельный текст',
+    left: montageBounds.left + 260,
+    top: montageBounds.top + 120,
+    originX: 'left',
+    originY: 'top',
+    width: 90,
+    fontSize: 24,
+    autoExpand: false
+  })
+
+  text.checkCreation({ textObject: activeText })
+  shapes.checkCreation({ shape: referenceShape, presetKey: 'square' })
+
+  const pendingSaveFlushed = await history.flushPendingSave()
+
+  expect(pendingSaveFlushed, 'подготовка не должна оставлять отложенное сохранение').toBe(false)
+  expect(activeText?.id).toBe('active-text')
+
+  setup = {
+    activeTextId: 'active-text',
+    baseline: await snapping.getObjectSnapshot({ id: 'active-text' }),
+    reference: await snapping.getObjectSnapshot({ id: 'reference-shape' })
+  }
+})
+
+test('одно перемещение текста создаёт одну запись в истории и восстанавливается через undo/redo', async({
+  history,
+  snapping
+}) => {
+  const historyBefore = await history.getPosition()
+
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const live = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+
+  expect(live.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(live.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.activeTextId })
+  const historySaved = await history.flushPendingSave()
+  const historyAfter = await history.getPosition()
+
+  expect(historySaved, 'object:modified должен сохранить завершённое перемещение').toBe(true)
+  expect(committed).toEqual(live)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+  expect(historyAfter.patchCount).toBe(historyBefore.patchCount + 1)
+  expect(historyAfter.currentIndex).toBe(historyBefore.currentIndex + 1)
+
+  await history.undo()
+  const restored = await snapping.getObjectSnapshot({ id: setup.activeTextId })
+
+  expect(restored.boundsLeft).toBeCloseTo(setup.baseline.boundsLeft, 5)
+  expect(restored.boundsTop).toBeCloseTo(setup.baseline.boundsTop, 5)
+  expect(restored.boundsWidth).toBeCloseTo(setup.baseline.boundsWidth, 5)
+  expect(restored.boundsHeight).toBeCloseTo(setup.baseline.boundsHeight, 5)
+
+  await history.redo()
+  const redone = await snapping.getObjectSnapshot({ id: setup.activeTextId })
+
+  expect(redone.boundsLeft).toBeCloseTo(committed.boundsLeft, 2)
+  expect(redone.boundsTop).toBeCloseTo(committed.boundsTop, 2)
+  expect(redone.boundsWidth).toBeCloseTo(committed.boundsWidth, 5)
+  expect(redone.boundsHeight).toBeCloseTo(committed.boundsHeight, 5)
+})
+
+test('новое перетаскивание текста не наследует удержание предыдущего жеста', async({
+  shapes,
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const firstSnap = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+
+  expect(firstSnap.boundsLeft).toBeCloseTo(setup.reference.boundsLeft, 1)
+  expect(firstSnap.boundsTop).toBeCloseTo(setup.reference.boundsTop, 1)
+
+  await snapping.finishPointerInteraction()
+  const referenceRemoved = await shapes.remove({ id: 'reference-shape' })
+
+  expect(referenceRemoved).toBe(true)
+  expect((await snapping.getGuideState()).guides).toHaveLength(0)
+
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const freshGesture = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: firstSnap.boundsLeft + 3,
+    top: firstSnap.boundsTop + 3
+  })
+  const guideState = await snapping.getGuideState()
+
+  expect(Math.abs(freshGesture.boundsLeft - (firstSnap.boundsLeft + 3)))
+    .toBeLessThanOrEqual(SNAPPING_TOLERANCE.position)
+  expect(Math.abs(freshGesture.boundsTop - (firstSnap.boundsTop + 3)))
+    .toBeLessThanOrEqual(SNAPPING_TOLERANCE.position)
+  expect(Math.abs(freshGesture.boundsLeft - firstSnap.boundsLeft))
+    .toBeGreaterThan(SNAPPING_TOLERANCE.position)
+  expect(Math.abs(freshGesture.boundsTop - firstSnap.boundsTop))
+    .toBeGreaterThan(SNAPPING_TOLERANCE.position)
+  expect(guideState.guides).toHaveLength(0)
+  expect(guideState.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('восстановленный через undo/redo текст сохраняет направляющие при микродвижении', async({
+  history,
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  await snapping.finishPointerInteraction()
+
+  expect(await history.flushPendingSave()).toBe(true)
+  expect((await history.getPosition()).currentIndex).toBeGreaterThan(0)
+
+  await history.undo()
+  await history.redo()
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.reference.centerX + 1,
+    top: setup.reference.centerY + 1
+  })
+  const snappedGuides = await snapping.getGuideState()
+  const held = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: snapped.boundsLeft + 3,
+    top: snapped.boundsTop + 3
+  })
+  const guideState = await snapping.getGuideState()
+
+  expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 1)
+  expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 1)
+  expect(snappedGuides.guides).toHaveLength(2)
+  expect(guideState.guides).toEqual(snappedGuides.guides)
+  expect(guideState.guides).toHaveLength(2)
+  expect(guideState.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('текст из шаблона сохраняет направляющие при микродвижении', async({
+  snapping,
+  text
+}) => {
+  const templateText = text.checkCreation({ textObject: await text.applyRegressionTemplate() })
+
+  if (typeof templateText.id !== 'string') {
+    throw new Error('текст из шаблона должен иметь id')
+  }
+
+  await snapping.startObjectDrag({ id: templateText.id })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: templateText.id,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const snappedGuides = await snapping.getGuideState()
+  const held = await snapping.dragObjectBoundsTo({
+    id: templateText.id,
+    left: snapped.boundsLeft + 4,
+    top: snapped.boundsTop + 4
+  })
+  const guideState = await snapping.getGuideState()
+
+  expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 1)
+  expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 1)
+  expect(snappedGuides.guides).toHaveLength(2)
+  expect(guideState.guides).toEqual(snappedGuides.guides)
+  expect(guideState.guides).toHaveLength(2)
+  expect(guideState.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('вставленный из буфера текст сохраняет направляющие при микродвижении', async({
+  clipboard,
+  editorModel,
+  snapping,
+  text
+}) => {
+  const selected = await text.select({ id: setup.activeTextId })
+
+  expect(selected?.id).toBe(setup.activeTextId)
+  expect(selected?.type).toBe('background-textbox')
+
+  await clipboard.copy()
+  await clipboard.waitForClipboardReady()
+  const pasted = await clipboard.paste()
+  const copiedText = await editorModel.getActiveObject()
+
+  expect(pasted).toBe(true)
+  expect(copiedText?.type).toBe('background-textbox')
+  expect(typeof copiedText?.id).toBe('string')
+
+  if (typeof copiedText?.id !== 'string') {
+    throw new Error('после вставки скопированный текст должен быть активен')
+  }
+
+  expect(copiedText.id).not.toBe(setup.activeTextId)
+
+  await snapping.startObjectDrag({ id: copiedText.id })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: copiedText.id,
+    left: setup.reference.boundsLeft + 1,
+    top: setup.reference.boundsTop + 1
+  })
+  const snappedGuides = await snapping.getGuideState()
+  const held = await snapping.dragObjectBoundsTo({
+    id: copiedText.id,
+    left: snapped.boundsLeft + 4,
+    top: snapped.boundsTop + 4
+  })
+  const guideState = await snapping.getGuideState()
+
+  expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 1)
+  expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 1)
+  expect(snappedGuides.guides).toHaveLength(2)
+  expect(guideState.guides).toEqual(snappedGuides.guides)
+  expect(guideState.guides).toHaveLength(2)
+  expect(guideState.spacingGuides).toHaveLength(0)
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})

--- a/e2e/tests/snapping-manager/text/moving-spacing.spec.ts
+++ b/e2e/tests/snapping-manager/text/moving-spacing.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '../../../fixtures/text-moving-spacing.fixture'
+
+test('при микродвижениях отдельный текст сохраняет равноудалённость по горизонтали', async({
+  textMovingSpacingSetup: setup,
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.expectedLeft + 3,
+    top: setup.left.boundsTop + 25
+  })
+  const initialGuides = await snapping.getGuideState()
+  const leftGap = snapped.boundsLeft - setup.left.boundsRight
+  const rightGap = setup.right.boundsLeft - snapped.boundsRight
+
+  expect(snapped.boundsLeft).toBeCloseTo(setup.expectedLeft, 5)
+  expect(leftGap).toBeCloseTo(rightGap, 5)
+  expect(initialGuides.spacingGuides).toEqual([{
+    type: 'horizontal',
+    axis: snapped.centerY,
+    refStart: setup.left.boundsRight,
+    refEnd: snapped.boundsLeft,
+    activeStart: snapped.boundsRight,
+    activeEnd: setup.right.boundsLeft,
+    distance: Math.round(leftGap)
+  }])
+
+  for (const offset of [2, 3, 4]) {
+    const held = await snapping.dragObjectBoundsTo({
+      id: setup.activeTextId,
+      left: snapped.boundsLeft + offset,
+      top: snapped.boundsTop
+    })
+    const guideState = await snapping.getGuideState()
+
+    expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 5)
+    expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 5)
+    expect(held.boundsWidth).toBeCloseTo(snapped.boundsWidth, 5)
+    expect(held.boundsHeight).toBeCloseTo(snapped.boundsHeight, 5)
+    expect(guideState).toEqual(initialGuides)
+  }
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.activeTextId })
+
+  expect(committed.boundsLeft).toBeCloseTo(snapped.boundsLeft, 5)
+  expect(committed.boundsTop).toBeCloseTo(snapped.boundsTop, 5)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})
+
+test('при микродвижениях отдельный текст сохраняет равноудалённость по вертикали', async({
+  textMovingSpacingSetup: setup,
+  snapping
+}) => {
+  await snapping.startObjectDrag({ id: setup.activeTextId })
+  const snapped = await snapping.dragObjectBoundsTo({
+    id: setup.activeTextId,
+    left: setup.top.boundsLeft + 40,
+    top: setup.expectedTop + 3
+  })
+  const initialGuides = await snapping.getGuideState()
+  const topGap = snapped.boundsTop - setup.top.boundsBottom
+  const bottomGap = setup.bottom.boundsTop - snapped.boundsBottom
+
+  expect(snapped.boundsTop).toBeCloseTo(setup.expectedTop, 5)
+  expect(topGap).toBeCloseTo(bottomGap, 5)
+  expect(initialGuides.spacingGuides).toEqual([{
+    type: 'vertical',
+    axis: snapped.centerX,
+    refStart: setup.top.boundsBottom,
+    refEnd: snapped.boundsTop,
+    activeStart: snapped.boundsBottom,
+    activeEnd: setup.bottom.boundsTop,
+    distance: Math.round(topGap)
+  }])
+
+  for (const offset of [2, 3, 4]) {
+    const held = await snapping.dragObjectBoundsTo({
+      id: setup.activeTextId,
+      left: snapped.boundsLeft,
+      top: snapped.boundsTop + offset
+    })
+    const guideState = await snapping.getGuideState()
+
+    expect(held.boundsLeft).toBeCloseTo(snapped.boundsLeft, 5)
+    expect(held.boundsTop).toBeCloseTo(snapped.boundsTop, 5)
+    expect(held.boundsWidth).toBeCloseTo(snapped.boundsWidth, 5)
+    expect(held.boundsHeight).toBeCloseTo(snapped.boundsHeight, 5)
+    expect(guideState).toEqual(initialGuides)
+  }
+
+  const clearedGuides = await snapping.finishPointerInteraction()
+  const committed = await snapping.getObjectSnapshot({ id: setup.activeTextId })
+
+  expect(committed.boundsLeft).toBeCloseTo(snapped.boundsLeft, 5)
+  expect(committed.boundsTop).toBeCloseTo(snapped.boundsTop, 5)
+  expect(clearedGuides.guides).toHaveLength(0)
+  expect(clearedGuides.spacingGuides).toHaveLength(0)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anu3ev/fabric-image-editor",
-      "version": "0.10.14",
+      "version": "0.10.15",
       "license": "MIT",
       "dependencies": {
         "fabric": "^7.2.0",
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -911,9 +911,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1101,9 +1101,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3521,16 +3521,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -4191,9 +4191,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -4625,9 +4625,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4884,9 +4884,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5511,9 +5511,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6737,9 +6737,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7269,9 +7269,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7596,9 +7596,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -8227,9 +8227,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -8914,9 +8914,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -8934,7 +8934,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8957,9 +8957,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -10153,9 +10153,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anu3ev/fabric-image-editor",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "TypeScript image editor library built on FabricJS, allowing you to create instances with an integrated montage area and providing an API to modify and manage state.",
   "module": "dist/main.js",
   "files": [

--- a/specs/src/editor/snapping-manager/movement/movement-snapping-routing.spec.ts
+++ b/specs/src/editor/snapping-manager/movement/movement-snapping-routing.spec.ts
@@ -9,7 +9,8 @@ import {
 /** Типы объектов, для которых уже используется унифицированный расчёт перемещения. */
 const UNIFIED_MOVEMENT_TARGETS = [
   { kind: 'image', label: 'изображения' },
-  { kind: 'shape', label: 'шейпа' }
+  { kind: 'shape', label: 'шейпа' },
+  { kind: 'text', label: 'отдельного текста' }
 ] satisfies ReadonlyArray<{
   kind: MovementRoutingTargetKind
   label: string
@@ -22,7 +23,7 @@ const LEGACY_MOVEMENT_TARGETS = [
   { kind: 'group', label: 'обычной группы объектов' },
   { kind: 'nested-image', label: 'вложенного изображения' },
   { kind: 'nested-shape', label: 'вложенного шейпа' },
-  { kind: 'text', label: 'отдельного текста' }
+  { kind: 'nested-text', label: 'вложенного текста' }
 ] satisfies ReadonlyArray<{
   kind: MovementRoutingTargetKind
   label: string

--- a/specs/test-utils/snapping/movement-snapping-routing.ts
+++ b/specs/test-utils/snapping/movement-snapping-routing.ts
@@ -21,6 +21,7 @@ export type MovementRoutingTargetKind =
   | 'image'
   | 'nested-image'
   | 'nested-shape'
+  | 'nested-text'
   | 'shape'
   | 'text'
 
@@ -119,8 +120,11 @@ export function createMovementRoutingTarget({
     return applyMovementGeometry({ target: new ActiveSelection([], {}), id: kind })
   }
 
-  if (kind === 'text') {
-    return applyMovementGeometry({ target: new Textbox('Text', {}), id: kind })
+  if (kind === 'text' || kind === 'nested-text') {
+    const textbox = applyMovementGeometry({ target: new Textbox('Text', {}), id: kind })
+    if (kind === 'nested-text') textbox.group = new Group([], {})
+
+    return textbox
   }
 
   const cropFrame = applyMovementGeometry({ target: new Rect({}), id: kind })

--- a/src/editor/snapping-manager/README.md
+++ b/src/editor/snapping-manager/README.md
@@ -2,7 +2,7 @@
 
 `SnappingManager` finds guides and coordinates both verified and legacy snapping paths. Migrated interactions publish guides only after the object reaches them, while legacy interactions keep their existing calculated-guide contract. Canonical dimensions of composite objects remain the responsibility of the manager that owns the corresponding object type.
 
-The two-phase contract is currently used when scaling a regular top-level shape, when moving a standalone top-level `FabricImage` or top-level shape, and when scaling a supported top-level `FabricImage` through any of the eight standard Fabric controls. Movement of standalone text, `ActiveSelection`, `Group`, and `CropFrame` still uses the legacy path. Nested images and shapes also remain on that path. Unsupported image scale geometries and controls with custom scale behaviour or geometry are not routed through the migrated scale owner. The exact migration boundary and the recommended order for continuing the work are documented in [`technical-specifications/unified-scale-snapping-current-state.md`](../../../technical-specifications/unified-scale-snapping-current-state.md).
+The two-phase contract is currently used when scaling a regular top-level shape, when moving a standalone top-level `FabricImage`, top-level shape, or standalone top-level `Textbox`, and when scaling a supported top-level `FabricImage` through any of the eight standard Fabric controls. Movement of nested text, `ActiveSelection`, `Group`, and `CropFrame` still uses the legacy path. Nested images and shapes also remain on that path. Unsupported image scale geometries and controls with custom scale behaviour or geometry are not routed through the migrated scale owner. The exact migration boundary and the recommended order for continuing the work are documented in [`technical-specifications/unified-scale-snapping-current-state.md`](../../../technical-specifications/unified-scale-snapping-current-state.md).
 
 ## Responsibilities
 
@@ -18,7 +18,7 @@ The two-phase contract is currently used when scaling a regular top-level shape,
 - [`movement/movement-spacing-correction.ts`](./movement/movement-spacing-correction.ts) keeps exact correction separate from display rounding. An object that already belonged to a logical chain at `mousedown` returns to its initial position on the constrained axis, while a new isolated interval continues to use the selected exact neighbours or reference interval.
 - [`movement/movement-spacing-verification.ts`](./movement/movement-spacing-verification.ts) verifies the selected intervals against the final bounds and builds guides for every interval of a confirmed logical chain.
 - [`movement/movement-snapping-runtime.ts`](./movement/movement-snapping-runtime.ts) gives one movement plan to each native pointer marker and updates line and spacing hold state only after verification.
-- [`movement/movement-snapping-controller.ts`](./movement/movement-snapping-controller.ts) captures an immutable movement session and applies one final Fabric translation for standalone top-level images and top-level shapes. Other object types are deliberately routed to the existing owner.
+- [`movement/movement-snapping-controller.ts`](./movement/movement-snapping-controller.ts) captures an immutable movement session and applies one final Fabric translation for standalone top-level images, top-level shapes, and standalone top-level `Textbox` objects. Other object types are deliberately routed to the existing owner.
 - [`scaling/image-scale-snapping-controller.ts`](./scaling/image-scale-snapping-controller.ts) owns supported scale sessions for a top-level `FabricImage`, applies both resolved scale factors once around the fixed scene point, and returns only guides verified against the exact final bounds.
 - [`movement/line-snapping.ts`](./movement/line-snapping.ts) resolves ordinary line snapping for movement targets that have not yet been migrated.
 - [`movement/spacing.ts`](./movement/spacing.ts) resolves equal spacing and returns every selected interval with its exact nearest-neighbour or reference-pattern identity, whether it is primary or related, and the segment to render.
@@ -58,9 +58,9 @@ The new path supports side and corner controls, rotation, centred scaling, free 
 
 Gesture state is cleared on `mouseup`, selection changes, object removal, `pointercancel`, `touchcancel`, window blur, and manager destruction.
 
-## Image and shape movement integration
+## Image, shape, and standalone text movement integration
 
-For a standalone top-level image or top-level shape, `mousedown` captures exact initial bounds, Fabric `left/top`, zoom, named line candidates, and a full equal-spacing snapshot that includes the active object. Every `object:moving` step reads the raw Fabric result, resolves line and equal-spacing hold state independently by axis, includes pixel rounding in the same final position, applies at most one post-Fabric translation, and verifies the resulting exact bounds before publishing guides.
+For a standalone top-level image, top-level shape, or standalone top-level `Textbox`, `mousedown` captures exact initial bounds, Fabric `left/top`, zoom, named line candidates, and a full equal-spacing snapshot that includes the active object. Every `object:moving` step reads the raw Fabric result, resolves line and equal-spacing hold state independently by axis, includes pixel rounding in the same final position, applies at most one post-Fabric translation, and verifies the resulting exact bounds before publishing guides.
 
 Exact correction and the displayed distance are deliberately separate. Centred placement and a newly acquired reference interval use exact scene bounds without quantizing the correction to a half-pixel step. An existing chain is accepted only when the spread between its minimum and maximum exact intervals is at most `0.001` scene pixels, every interval resolves to the same display value, and every object intersects one shared perpendicular corridor. The representative distance is then calculated from the complete chain, and every guide uses the shared display value and the centre of the common corridor. These rules are identical for horizontal and vertical chains.
 
@@ -70,9 +70,9 @@ When the active object already belongs to a confirmed chain at `mousedown`, snap
 
 Ctrl returns the unrounded raw Fabric position and clears both line and spacing hold state. A repeated native marker reuses its verified result without reading or changing the target again. A new `mousedown` first ends the previous movement session and clears visible guides and legacy anchor caches before the new snapshot and anchors are captured. The movement session and visible guides are also cleared on `mouseup`, selection changes, removal of the active target, `pointercancel`, `touchcancel`, window blur, and manager destruction.
 
-Shape movement remains a plain Fabric translation: it does not run shape layout, change canonical dimensions, or alter the embedded text. On a drag `object:modified` event, ShapeManager still performs its normal interaction cleanup but skips scale materialization because a move must not reinterpret pre-existing `scaleX/scaleY` as a resize. The regular Fabric history lifecycle still commits the completed drag.
+Shape movement remains a plain Fabric translation: it does not run shape layout, change canonical dimensions, or alter the embedded text. On a drag `object:modified` event, ShapeManager still performs its normal interaction cleanup but skips scale materialization because a move must not reinterpret pre-existing `scaleX/scaleY` as a resize. Standalone text movement is also a plain Fabric translation and does not change its text, dimensions, font size, padding, corner radii, angle, or scale factors. The regular Fabric history lifecycle commits both completed drag types without an additional save from their domain managers.
 
-This phase intentionally handles only an active browser drag of a top-level `FabricImage` or top-level shape. Movement without an active browser gesture, nested images and shapes, standalone text, `ActiveSelection`, `Group`, and `CropFrame` continue through the legacy path.
+This phase intentionally handles only an active browser drag of a top-level `FabricImage`, top-level shape, or standalone top-level `Textbox`. Movement without an active browser gesture, nested images, nested shapes, nested text, `ActiveSelection`, `Group`, and `CropFrame` continue through the legacy path.
 
 ## Image scale integration
 
@@ -110,6 +110,7 @@ These formulas must not be moved into the shared resolver. `CropManager` must ap
 
 - First identify where the defect lives: target selection, guide holding, domain application, result verification, or rendering.
 - For a new object type, start with one real browser regression and then connect its owner to the shared runtime.
-- Do not consider an object type migrated because one test is green. Cover side and corner controls, rotation, Ctrl and Shift, repeated pointer positions, `mouseup`, history, and gesture interruption paths.
-- Image scale is complete for the supported top-level `FabricImage` boundary, and movement is complete for top-level images and shapes. The next movement slice is standalone text, followed by `ActiveSelection` and `Group` after their own capability audits.
+- Do not consider movement migrated because one test is green. Cover line and equal-spacing hold, independent axis release, Ctrl, rotation, zoom and pan, `mouseup`, history, and gesture interruption paths.
+- Do not consider scaling migrated because one control is green. Cover every supported side and corner control, rotation, Ctrl and Shift, repeated pointer positions, `mouseup`, history, and gesture interruption paths.
+- Image scale is complete for the supported top-level `FabricImage` boundary, and movement is complete for top-level images, shapes, and standalone `Textbox` objects. The next movement slices are `ActiveSelection` and then `Group`, each after its own capability audit.
 - Before changing `CropFrame`, reread [`../crop-manager/README.md`](../crop-manager/README.md), [`scaling/legacy-scale-snapping.ts`](./scaling/legacy-scale-snapping.ts), [`pixel-grid.ts`](./pixel-grid.ts), and [`../crop-manager/domain/crop-frame.ts`](../crop-manager/domain/crop-frame.ts).

--- a/src/editor/snapping-manager/index.ts
+++ b/src/editor/snapping-manager/index.ts
@@ -224,7 +224,7 @@ export default class SnappingManager {
   /** События указателя, уже обработанные менеджером конкретного типа объекта. */
   private readonly handledScaleStepEvents = new WeakSet<object>()
 
-  /** Управляет унифицированным прилипанием при перемещении изображений и шейпов. */
+  /** Управляет унифицированным прилипанием при перемещении изображений, шейпов и отдельного текста. */
   private readonly movementSnappingController: MovementSnappingController
 
   /** Управляет общей сессией прилипания при скейлинге изображений. */

--- a/src/editor/snapping-manager/movement/movement-snapping-controller.ts
+++ b/src/editor/snapping-manager/movement/movement-snapping-controller.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define -- Публичный контроллер расположен перед внутренними преобразованиями результата. */
 import {
   FabricImage,
+  Textbox,
   type BasicTransformEvent,
   type FabricObject,
   type TPointerEvent
@@ -38,7 +39,7 @@ import { isShapeGroup } from '../../shape-manager/domain/shape-reference'
 import type { ShapeGroup } from '../../shape-manager/types'
 
 /** Верхнеуровневые объекты, уже переведённые на общую логику перемещения. */
-type SupportedMovementTarget = FabricImage | ShapeGroup
+type SupportedMovementTarget = FabricImage | ShapeGroup | Textbox
 
 /** Событие canvas для одного шага перемещения. */
 type ObjectMovementTransformEvent = BasicTransformEvent<TPointerEvent> & {
@@ -67,7 +68,7 @@ const UNHANDLED_OBJECT_MOVEMENT_STEP: UnhandledObjectMovementStep = Object.freez
 })
 
 /**
- * Управляет общей сессией прилипания при перемещении изображения или шейпа.
+ * Управляет общей сессией прилипания при перемещении изображения, шейпа или отдельного текста.
  * Остальные типы объектов продолжают использовать прежний путь обработки.
  */
 export class MovementSnappingController {
@@ -158,13 +159,13 @@ export class MovementSnappingController {
     return true
   }
 
-  /** Разрешает обычное перемещение одиночного изображения или шейпа. */
+  /** Разрешает обычное перемещение одиночного изображения, шейпа или отдельного текста. */
   private _isSupportedTarget(
     target?: FabricObject | null
   ): target is SupportedMovementTarget {
     if (!target || target.group) return false
 
-    return target instanceof FabricImage || isShapeGroup(target)
+    return target instanceof FabricImage || target instanceof Textbox || isShapeGroup(target)
   }
 
   /** Фиксирует положение объекта после перемещения Fabric, но до применения прилипания. */


### PR DESCRIPTION
## Что сделано

- Перемещение отдельного верхнеуровневого `Textbox` переведено в общий `MovementSnappingController`.
- Исправлено переключение на соседнюю направляющую при микродвижениях внутри удержания.
- Добавлены unit-тесты маршрутизации и 13 браузерных сценариев: удержание, отпускание осей, Ctrl, равноудалённость по горизонтали и вертикали, поворот, изменение области просмотра, история, undo/redo, шаблоны и вставка из буфера.